### PR TITLE
fix: update meta description

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <title>Canonical - Investing in a post AGI future</title>
-    <meta name="description" content="Canonical leads early-stage investments in technical founding teams. We invest early in the picks-and-shovels of the post-AGI future." />
+    <title>Investing in a post AGI future</title>
+    <meta name="description" content="Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed." />
     <meta name="keywords" content="venture capital, AI infrastructure, decentralized AI, post-AGI, blockchain, AI investment, technology fund, startup funding, robotics, quantum"/>
     <meta name="author" content="Canonical" />
     <meta name="robots" content="index, follow" />
@@ -13,8 +13,8 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://canonical.cc" />
-    <meta property="og:title" content="Canonical - Investing in a post AGI future" />
-    <meta property="og:description" content="Canonical backs technical founders building decentralized AI infrastructure. We invest early in the picks-and-shovels of the post-AGI future." />
+    <meta property="og:title" content="Investing in a post AGI future" />
+    <meta property="og:description" content="Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed." />
     <meta property="og:image" content="https://canonical.cc/images/site-logo.png" />
     <meta property="og:site_name" content="Canonical" />
     <meta property="og:locale" content="en_US" />
@@ -22,8 +22,8 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://canonical.cc" />
-    <meta property="twitter:title" content="Canonical - Investing in a post AGI future" />
-    <meta property="twitter:description" content="Canonical backs technical founders building decentralized AI infrastructure. We invest early in the picks-and-shovels of the post-AGI future." />
+    <meta property="twitter:title" content="Investing in a post AGI future" />
+    <meta property="twitter:description" content="Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed." />
     <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
     <meta property="twitter:creator" content="@canonicalcrypto" />
     <meta property="twitter:site" content="@canonicalcrypto" />
@@ -40,7 +40,7 @@
       "@context": "https://schema.org",
       "@type": "Organization",
       "name": "Canonical",
-      "description": "Canonical leads early-stage investments in technical founding teams. We invest early in the picks-and-shovels of the post-AGI future.",
+      "description": "Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed.",
       "url": "https://canonical.cc",
       "logo": "https://canonical.cc/images/site-logo.png",
       "sameAs": [


### PR DESCRIPTION
Changed
- title to: "Investing in a post AGI future" 
- description to: "Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed."