### PR TITLE
Update Substack URL from canonicalcrypto to canonicalcc

### DIFF
--- a/companies/exo-labs.html
+++ b/companies/exo-labs.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/gensyn.html
+++ b/companies/gensyn.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/glide.html
+++ b/companies/glide.html
@@ -145,7 +145,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/haptic.html
+++ b/companies/haptic.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/kocree.html
+++ b/companies/kocree.html
@@ -123,7 +123,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/mesta.html
+++ b/companies/mesta.html
@@ -145,7 +145,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/nirvana-ai.html
+++ b/companies/nirvana-ai.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/opengradient.html
+++ b/companies/opengradient.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/rain.html
+++ b/companies/rain.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/ritual.html
+++ b/companies/ritual.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/robo.html
+++ b/companies/robo.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/sahara.html
+++ b/companies/sahara.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/sentient.html
+++ b/companies/sentient.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/synthefy.html
+++ b/companies/synthefy.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/companies/virtuals.html
+++ b/companies/virtuals.html
@@ -134,7 +134,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/index.html
+++ b/index.html
@@ -234,7 +234,7 @@
 
                     <div class="substack-footer">
                         <a 
-                            href="https://canonicalcrypto.substack.com" 
+                            href="https://canonicalcc.substack.com" 
                             target="_blank" 
                             rel="noopener noreferrer" 
                             class="substack-view-all-link"
@@ -370,7 +370,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -270,7 +270,7 @@ function openSubstackPost(url) {
 }
 
 async function loadSubstackPosts() {
-    const rssUrl = "https://canonicalcrypto.substack.com/feed";
+    const rssUrl = "https://canonicalcc.substack.com/feed";
 
     try {
         // Use a public RSS-to-JSON proxy because RSS XML can't be fetched directly

--- a/portfolio.html
+++ b/portfolio.html
@@ -85,7 +85,7 @@
                         <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on X
                         </a>
-                        <a href="https://canonicalcrypto.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
                             Canonical on Substack
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
Updated all Substack publication URLs across the website from `canonicalcrypto.substack.com` to `canonicalcc.substack.com` to reflect the new Substack handle.

## Changes Made
- Updated Substack link in the main "Canonical on Substack" section (index.html)
- Updated Substack footer links across all 16 company pages (exo-labs, gensyn, glide, haptic, kocree, mesta, nirvana-ai, opengradient, rain, ritual, robo, sahara, sentient, synthefy, virtuals)
- Updated Substack footer link in portfolio.html
- Updated RSS feed URL in JavaScript from `canonicalcrypto.substack.com/feed` to `canonicalcc.substack.com/feed` to ensure Substack posts continue to load correctly

## Implementation Details
- All changes are URL updates only, no functional logic modifications
- The RSS feed URL update in `js/script.js` ensures the Substack posts widget continues to fetch content from the correct publication
- Changes are consistent across all pages to maintain uniform branding

https://claude.ai/code/session_01NoXgSGKeBtmEjMgHvVZVah