### PR TITLE
Add HACKS dropdown to nav (Dilution Lab, Fund Modeler)

### DIFF
--- a/companies/exo-labs.html
+++ b/companies/exo-labs.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/gensyn.html
+++ b/companies/gensyn.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/glide.html
+++ b/companies/glide.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/haptic.html
+++ b/companies/haptic.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/kocree.html
+++ b/companies/kocree.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/mesta.html
+++ b/companies/mesta.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/nirvana-ai.html
+++ b/companies/nirvana-ai.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/opengradient.html
+++ b/companies/opengradient.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/rain.html
+++ b/companies/rain.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/ritual.html
+++ b/companies/ritual.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/robo.html
+++ b/companies/robo.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/sahara.html
+++ b/companies/sahara.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/sentient.html
+++ b/companies/sentient.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/synthefy.html
+++ b/companies/synthefy.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/companies/virtuals.html
+++ b/companies/virtuals.html
@@ -36,6 +36,13 @@
                         <a href="../#about" class="nav-link">ABOUT</a>
                         <a href="../#thesis" class="nav-link">THESIS</a>
                         <a href="../portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="../#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>

--- a/css/style.css
+++ b/css/style.css
@@ -750,6 +750,69 @@ html {
     padding-bottom: 2px;
 }
 
+/* Nav dropdown */
+.nav-dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.nav-dropdown-toggle {
+    display: inline-flex;
+    align-items: center;
+}
+
+.nav-dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(0.5rem);
+    min-width: 12rem;
+    background-color: rgba(30, 58, 138, 0.95);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+    z-index: 60;
+}
+
+.nav-dropdown::before {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    height: 0.75rem;
+}
+
+.nav-dropdown:hover .nav-dropdown-menu,
+.nav-dropdown:focus-within .nav-dropdown-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0.75rem);
+}
+
+.nav-dropdown-item {
+    display: block;
+    padding: 0.6rem 1.25rem;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    text-decoration: none;
+    white-space: nowrap;
+    font-family: 'Aeonik Regular', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.nav-dropdown-item:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+}
+
 /* View all portfolio link (homepage) */
 .portfolio-footer {
     text-align: right;

--- a/index.html
+++ b/index.html
@@ -91,6 +91,15 @@
                         <a href="/portfolio" class="nav-link">
                             PORTFOLIO
                         </a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">
+                                HACKS
+                            </button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <button onclick="scrollToSection('team')" class="nav-link">
                             TEAM
                         </button>

--- a/portfolio.html
+++ b/portfolio.html
@@ -45,6 +45,13 @@
                         <a href="/#about" class="nav-link">ABOUT</a>
                         <a href="/#thesis" class="nav-link">THESIS</a>
                         <a href="/portfolio" class="nav-link nav-link-active">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                            </div>
+                        </div>
                         <a href="/#team" class="nav-link">TEAM</a>
                     </nav>
                 </div>


### PR DESCRIPTION
## Summary
- New HACKS dropdown menu between PORTFOLIO and TEAM, linking to dilutionlab.canonical.cc and fundmodeler.canonical.cc.
- Dropdown shows on hover with the same translucent dark-blue + backdrop-blur styling as the scrolled header. No chevron — plain text, matches surrounding nav items.
- Applied across index.html, portfolio.html, and all 15 company pages.

## Test plan
- [ ] Home: hover HACKS → dropdown shows Dilution Lab + Fund Modeler
- [ ] Portfolio: same hover behavior, PORTFOLIO stays active-underlined
- [ ] Company page (e.g. /companies/virtuals): same hover behavior
- [ ] Links navigate to dilutionlab.canonical.cc and fundmodeler.canonical.cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)