### PR TITLE
Tighten vertical whitespace across header, hero, and sections

### DIFF
--- a/companies/exo-labs.html
+++ b/companies/exo-labs.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/gensyn.html
+++ b/companies/gensyn.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/glide.html
+++ b/companies/glide.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/haptic.html
+++ b/companies/haptic.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/kocree.html
+++ b/companies/kocree.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/mesta.html
+++ b/companies/mesta.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/nirvana-ai.html
+++ b/companies/nirvana-ai.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/opengradient.html
+++ b/companies/opengradient.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/rain.html
+++ b/companies/rain.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/ritual.html
+++ b/companies/ritual.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/robo.html
+++ b/companies/robo.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/sahara.html
+++ b/companies/sahara.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/sentient.html
+++ b/companies/sentient.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/synthefy.html
+++ b/companies/synthefy.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/companies/virtuals.html
+++ b/companies/virtuals.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="../css/style.css?v=20260514">
+    <link rel="stylesheet" href="../css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/css/style.css
+++ b/css/style.css
@@ -50,6 +50,11 @@ html {
     transition: all 0.3s ease;
 }
 
+#header .container {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
 #header.scrolled {
     background-color: rgba(30, 58, 138, 0.95);
     backdrop-filter: blur(10px);
@@ -87,12 +92,8 @@ html {
 
 /* Hero Section */
 .hero-section {
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     text-align: center;
-    padding: 0 2rem;
+    padding: 10rem 2rem 6rem;
 }
 
 .hero-content {
@@ -121,12 +122,12 @@ html {
 
 /* Section Spacing */
 .section-padding {
-    padding: 6rem 0;
+    padding: 3rem 0;
 }
 
 @media (min-width: 768px) {
     .section-padding {
-        padding: 8rem 0;
+        padding: 5rem 0;
     }
 }
 
@@ -195,7 +196,7 @@ html {
     font-size: 1.25rem;
     color: rgba(255, 255, 255, 0.8);
     text-align: center;
-    margin-bottom: 4rem;
+    margin-bottom: 2.5rem;
     font-family: 'Aeonik Regular', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
@@ -726,8 +727,8 @@ html {
 /* Portfolio Page */
 
 .portfolio-page-hero {
-    padding-top: 10rem;
-    padding-bottom: 3rem;
+    padding-top: 6rem;
+    padding-bottom: 2rem;
 }
 
 .portfolio-grid {
@@ -834,8 +835,8 @@ html {
 /* Company Page */
 
 .company-hero {
-    padding-top: 9rem;
-    padding-bottom: 2rem;
+    padding-top: 5.5rem;
+    padding-bottom: 1.5rem;
 }
 
 .company-back-link {

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css?v=20260514">
+    <link rel="stylesheet" href="css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">

--- a/portfolio.html
+++ b/portfolio.html
@@ -30,7 +30,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link rel="stylesheet" href="css/style.css?v=20260514">
+    <link rel="stylesheet" href="css/style.css?v=20260514f">
 </head>
 <body>
     <div class="min-h-screen">


### PR DESCRIPTION
## Summary
Condenses excessive vertical whitespace site-wide. Hero no longer fills 100vh, section gaps cut ~40%, header bar slimmer.

## Changes
| Element | Before | After |
|---|---|---|
| Header inner padding | 2rem top + 2rem bottom | 1rem + 1rem |
| Hero | `min-height: 100vh` + flex-center | `padding: 10rem 2rem 6rem` |
| Section padding (desktop) | 8rem | 5rem |
| Section padding (mobile) | 6rem | 3rem |
| Section subtitle margin-bottom | 4rem | 2.5rem |
| Portfolio hero top padding | 10rem | 6rem |
| Company hero top padding | 9rem | 5.5rem |

Also bumps `style.css?v=` to `20260514f` so deployed visitors fetch the new CSS without a hard refresh.

## Test plan
- [ ] Home: hero sits naturally below the fixed header, no empty centered viewport. About/Thesis/Portfolio/Substack/Team flow closer together.
- [ ] /portfolio: title closer to header.
- [ ] /companies/*: company hero closer to header.
- [ ] Mobile: still readable, not cramped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)