### PR TITLE
Add Power Law Outlier Lab

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@
                             <div class="nav-dropdown-menu" role="menu">
                                 <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
                                 <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                                <a href="/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
                             </div>
                         </div>
                         <button onclick="scrollToSection('team')" class="nav-link">

--- a/labs/power-law/index.html
+++ b/labs/power-law/index.html
@@ -1,0 +1,653 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <title>Power Law Outlier Lab | Canonical</title>
+    <meta name="description" content="An interactive lab for LPs. Manipulate the shape of a venture fund's outcome distribution and see what actually drives fund returns." />
+    <meta name="author" content="Canonical" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://canonical.cc/labs/power-law" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://canonical.cc/labs/power-law" />
+    <meta property="og:title" content="Power Law Outlier Lab | Canonical" />
+    <meta property="og:description" content="An interactive lab for LPs. Manipulate the shape of a venture fund's outcome distribution and see what actually drives fund returns." />
+    <meta property="og:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="og:site_name" content="Canonical" />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://canonical.cc/labs/power-law" />
+    <meta property="twitter:title" content="Power Law Outlier Lab | Canonical" />
+    <meta property="twitter:description" content="An interactive lab for LPs. Manipulate the shape of a venture fund's outcome distribution and see what actually drives fund returns." />
+    <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="twitter:creator" content="@canonicalcrypto" />
+    <meta property="twitter:site" content="@canonicalcrypto" />
+
+    <meta name="theme-color" content="#1e3a8a" />
+    <link rel="icon" type="image/x-icon" href="https://www.canonical.cc/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
+    <link rel="stylesheet" href="../../css/style.css?v=20260514f">
+    <link rel="stylesheet" href="lab.css?v=1">
+</head>
+<body>
+    <div class="min-h-screen">
+        <!-- Header (identical to canonical.cc) -->
+        <header id="header" class="fixed top-0 w-full bg-transparent z-50 transition-all duration-200">
+            <div class="container mx-auto px-8 py-8">
+                <div class="flex items-center justify-between">
+                    <a href="/" class="logo-link">
+                        <img src="https://canonical.cc/images/logo-rectangle-trans-short.svg" alt="Canonical" class="h-8 w-auto" />
+                    </a>
+                    <nav class="hidden md:flex items-center space-x-10">
+                        <a href="/#about" class="nav-link">ABOUT</a>
+                        <a href="/#thesis" class="nav-link">THESIS</a>
+                        <a href="/portfolio" class="nav-link">PORTFOLIO</a>
+                        <div class="nav-dropdown">
+                            <button class="nav-link nav-dropdown-toggle nav-link-active" type="button" aria-haspopup="true" aria-expanded="false">HACKS</button>
+                            <div class="nav-dropdown-menu" role="menu">
+                                <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                                <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                                <a href="/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
+                            </div>
+                        </div>
+                        <a href="/#team" class="nav-link">TEAM</a>
+                    </nav>
+                </div>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero -->
+            <section class="lab-hero">
+                <div class="container mx-auto px-8">
+                    <div class="lab-hero-content">
+                        <span class="lab-eyebrow">CANONICAL LABS · POWER LAW OUTLIER LAB</span>
+                        <h1 class="lab-title">A venture fund simulator.</h1>
+                        <p class="lab-subtitle">
+                            Describe a fund — its size, the number of investments, the failure rate, the shape of the right tail — and we run <strong>10,000 simulated versions</strong> of that fund.
+                            The histogram shows the full distribution of plausible outcomes, not just the headline number on a pitch deck.
+                        </p>
+                        <div class="use-cases">
+                            <div class="use-case">
+                                <span class="use-case-tag">If you're an LP</span>
+                                <span class="use-case-body">Plug in a manager's stated strategy (N, ownership, reserves). Is their projected 3x in the top decile of plausible outcomes, or the median? Use this <em>before</em> the IC meeting.</span>
+                            </div>
+                            <div class="use-case">
+                                <span class="use-case-tag">If you're a GP</span>
+                                <span class="use-case-body">Show your LPs why your N matters, why concentration discipline matters, and why the right tail is your real thesis. Drop a screenshot in your deck.</span>
+                            </div>
+                            <div class="use-case">
+                                <span class="use-case-tag">If you're curious</span>
+                                <span class="use-case-body">Click any scenario below. Each one isolates a single counter-intuitive thing the math does that most fund pitches gloss over.</span>
+                            </div>
+                        </div>
+                        <div class="preset-chips" id="preset-chips" role="group" aria-label="Fund presets">
+                            <span class="preset-chips-label">Start with a preset:</span>
+                            <button class="preset-chip active tip-wrap" data-preset="seed" tabindex="0">
+                                Seed
+                                <span class="tip-content tip-content--below">
+                                    <strong>Seed preset.</strong> $50M fund, 25 investments, 50% loss rate, fat right tail (α=1.2, cap 500x). Models a concentrated seed strategy in the style of public empirical work (Correlation Ventures, Kauffman).
+                                </span>
+                            </button>
+                            <button class="preset-chip tip-wrap" data-preset="seriesA" tabindex="0">
+                                Series A
+                                <span class="tip-content tip-content--below">
+                                    <strong>Series A preset.</strong> $150M fund, 18 investments, 35% loss rate, moderate tail (α=1.5, cap 120x). Tighter than seed, less upside per company, but fewer total losses.
+                                </span>
+                            </button>
+                            <button class="preset-chip tip-wrap" data-preset="growth" tabindex="0">
+                                Growth
+                                <span class="tip-content tip-content--below">
+                                    <strong>Growth preset.</strong> $400M fund, 12 investments, 15% loss rate, thin tail (α=1.8, cap 30x). The distribution looks almost normal — growth math is not power-law dominated.
+                                </span>
+                            </button>
+                            <button class="preset-chip tip-wrap" data-preset="custom" tabindex="0">
+                                Custom
+                                <span class="tip-content tip-content--below">
+                                    <strong>Custom.</strong> Your current settings don't match any built-in preset. Tweak any slider and this label appears.
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Scenario callout (hidden by default; populated by scenarios) -->
+            <section id="scenario-callout" class="scenario-callout hidden">
+                <div class="container mx-auto px-8">
+                    <div class="scenario-callout-inner">
+                        <div class="scenario-callout-header">
+                            <span class="scenario-callout-label">SCENARIO</span>
+                            <button class="scenario-callout-dismiss" id="scenario-dismiss" aria-label="Dismiss scenario">×</button>
+                        </div>
+                        <h3 class="scenario-callout-title" id="scenario-title"></h3>
+                        <div class="scenario-callout-body" id="scenario-body"></div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Main lab area -->
+            <section class="lab-main">
+                <div class="container mx-auto px-8">
+                    <div class="lab-grid">
+
+                        <!-- Controls -->
+                        <aside class="lab-controls">
+                            <div class="control-section">
+                                <h4 class="control-section-title">Fund</h4>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-fundSize">
+                                        <span class="control-label-text">
+                                            Fund size
+                                            <span class="tip-wrap" tabindex="0" aria-label="More about fund size">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Fund size.</strong> Total dollars committed by LPs.
+                                                    Drives every dollar-denominated number downstream — at the same N and reserves, a bigger fund means bigger checks.
+                                                    Typical seed funds: $30–100M; Series A: $150–400M; growth: $500M+.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-fundSize">$50M</span>
+                                    </label>
+                                    <input type="range" id="ctl-fundSize" min="10" max="500" step="5" value="50" title="Total committed capital, in $M" />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-N">
+                                        <span class="control-label-text">
+                                            Initial investments (N)
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Number of first checks.</strong> How many companies you initially invest in.
+                                                    More names = lower variance and a thinner right tail (you'll probably miss the outlier).
+                                                    Concentrated seed funds: 15–30. Index-style funds: 50+.
+                                                    <em>This is the single most consequential portfolio-construction choice.</em>
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-N">25</span>
+                                    </label>
+                                    <input type="range" id="ctl-N" min="5" max="100" step="1" value="25" title="Number of initial investments" />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-reserves">
+                                        <span class="control-label-text">
+                                            Reserves %
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Reserves.</strong> Share of the fund held back to follow on in later rounds.
+                                                    Higher reserves = smaller initial checks but more ammunition to defend ownership in winners.
+                                                    Industry default is 30–50%.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-reserves">40%</span>
+                                    </label>
+                                    <input type="range" id="ctl-reserves" min="0" max="70" step="1" value="40" title="% of fund reserved for follow-on rounds" />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-ownership">
+                                        <span class="control-label-text">
+                                            Ownership multiplier
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Ownership multiplier.</strong> Scales every company's outcome multiple by this factor.
+                                                    2.0x = you owned twice as much of every company at exit — what you get from bigger initial checks, lower dilution, or smarter pro-rata defense.
+                                                    Linear effect on fund TVPI.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-ownership">1.0x</span>
+                                    </label>
+                                    <input type="range" id="ctl-ownership" min="0.5" max="2.5" step="0.05" value="1.0" title="Scales per-company outcome multiple" />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-followon">
+                                        <span class="control-label-text">
+                                            Follow-on strategy
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Where reserve dollars go.</strong>
+                                                    <p><em>Pro-rata:</em> reserves split evenly across the portfolio.</p>
+                                                    <p><em>Super pro-rata:</em> reserves loaded into your realized winners (top 30% by multiple).</p>
+                                                    <p><em>None:</em> reserves returned to LPs at 1.0x, no follow-on.</p>
+                                                    The concentration choice has a bigger impact on fund TVPI than most LPs realize.
+                                                </span>
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <select id="ctl-followon" class="control-select" title="How reserve capital is deployed">
+                                        <option value="prorata" selected>Pro-rata (split equally)</option>
+                                        <option value="superprorata">Super pro-rata (winners)</option>
+                                        <option value="none">None (return reserves)</option>
+                                    </select>
+                                </div>
+                                <div class="control-row derived">
+                                    <span class="control-derived">Initial check ≈ <strong id="val-checkSize">$1.2M</strong></span>
+                                </div>
+                            </div>
+
+                            <div class="control-section">
+                                <h4 class="control-section-title">Outcome shape</h4>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-lossRate">
+                                        <span class="control-label-text">
+                                            Loss rate
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Loss rate.</strong> Share of companies that return $0 (total loss).
+                                                    Real empirical ranges: seed 45–65%, Series A 25–40%, growth 10–20%.
+                                                    Higher loss rate doesn't move expected TVPI linearly — the lost dollars come out of the bottom of the distribution, not the top.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-lossRate">65%</span>
+                                    </label>
+                                    <input type="range" id="ctl-lossRate" min="0" max="90" step="1" value="65" title="% of investments that go to zero" />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-alpha">
+                                        <span class="control-label-text">
+                                            Tail thickness (α)
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Tail thickness.</strong> The shape parameter of the Pareto distribution.
+                                                    <strong>Lower α = fatter tail</strong> = the rare 100x outlier matters much more.
+                                                    1.1–1.3 = seed-style fat tail; 1.5–1.8 = Series A; 2.0+ = growth.
+                                                    <em>The most consequential slider in this lab — try moving it just 0.2 and watch the histogram redraw.</em>
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-alpha">1.50</span>
+                                    </label>
+                                    <input type="range" id="ctl-alpha" min="1.05" max="3.0" step="0.05" value="1.5" title="Pareto shape α. Lower = fatter right tail." />
+                                </div>
+                                <div class="control-row">
+                                    <label class="control-label" for="ctl-tailCap">
+                                        <span class="control-label-text">
+                                            Tail cap
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Tail cap.</strong> Hard maximum outcome multiple for any single company.
+                                                    Sets a ceiling on the right tail to keep the math finite.
+                                                    100–500x is reasonable for seed; 30x for growth.
+                                                    Real outliers like early Uber or Coinbase landed well past 1000x — bump this up to see what that does.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-tailCap">100x</span>
+                                    </label>
+                                    <input type="range" id="ctl-tailCap" min="10" max="1000" step="5" value="100" title="Maximum possible outcome multiple" />
+                                </div>
+                                <div class="control-row derived">
+                                    <span class="control-derived">E[per-co multiple] = <strong id="val-evMultiple">3.1x</strong></span>
+                                </div>
+                            </div>
+
+                            <div class="control-section">
+                                <h4 class="control-section-title">Fund economics</h4>
+                                <div class="control-row inline">
+                                    <label class="control-label" for="ctl-mgmtFee">
+                                        <span class="control-label-text">
+                                            Mgmt fee
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Management fee.</strong> Annual fee as % of committed capital, charged for the fund life.
+                                                    Standard 2% × 10 years = 20% drag on gross returns.
+                                                    Lower fees pass through directly to LP net TVPI.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-mgmtFee">2.0%</span>
+                                    </label>
+                                    <input type="range" id="ctl-mgmtFee" min="0" max="3" step="0.1" value="2.0" title="Annual management fee %" />
+                                </div>
+                                <div class="control-row inline">
+                                    <label class="control-label" for="ctl-carry">
+                                        <span class="control-label-text">
+                                            Carry
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Carried interest.</strong> GP's share of profits above 1.0x of committed capital.
+                                                    Standard is 20%. European waterfall is assumed — carry is only paid after LPs receive their full commitment back.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-carry">20%</span>
+                                    </label>
+                                    <input type="range" id="ctl-carry" min="0" max="30" step="1" value="20" title="GP carry %" />
+                                </div>
+                                <div class="control-row inline">
+                                    <label class="control-label" for="ctl-life">
+                                        <span class="control-label-text">
+                                            Fund life (yrs)
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Fund life.</strong> Years over which management fees accrue.
+                                                    Doesn't model exit timing — TVPI is reported as a horizon-free multiple.
+                                                    A 12-year fund pays 24% in fees at 2%; an 8-year fund pays 16%.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-life">10</span>
+                                    </label>
+                                    <input type="range" id="ctl-life" min="5" max="15" step="1" value="10" title="Years over which fees accrue" />
+                                </div>
+                            </div>
+
+                            <div class="control-section">
+                                <h4 class="control-section-title">Simulation</h4>
+                                <div class="control-row inline">
+                                    <label class="control-label" for="ctl-trials">
+                                        <span class="control-label-text">
+                                            Trials
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Monte Carlo trials.</strong> Number of simulated funds.
+                                                    10,000 is enough for stable median/quantile estimates; crank to 100,000 for sharper p99.
+                                                    More trials = more confidence, slower simulation.
+                                                </span>
+                                            </span>
+                                        </span>
+                                        <span class="control-value" id="val-trials">10,000</span>
+                                    </label>
+                                    <input type="range" id="ctl-trials" min="1000" max="100000" step="1000" value="10000" title="Number of Monte Carlo trials" />
+                                </div>
+                                <div class="control-buttons">
+                                    <button class="control-btn tip-wrap" id="btn-rerun" type="button" tabindex="0">
+                                        Rerun
+                                        <span class="tip-content tip-content--below">
+                                            Re-runs the Monte Carlo simulation with the current parameters. Useful after changing trials, or to refresh the random draws and see how stable the result is.
+                                        </span>
+                                    </button>
+                                    <button class="control-btn tip-wrap" id="btn-reset" type="button" tabindex="0">
+                                        Reset
+                                        <span class="tip-content tip-content--below">
+                                            Returns all controls to the default Seed preset.
+                                        </span>
+                                    </button>
+                                    <button class="control-btn primary tip-wrap" id="btn-share" type="button" tabindex="0">
+                                        Copy share link
+                                        <span class="tip-content tip-content--below">
+                                            Copies a URL with the current settings encoded in the hash. Send to share an exact fund configuration — the recipient lands on the same simulation.
+                                        </span>
+                                    </button>
+                                </div>
+                            </div>
+                        </aside>
+
+                        <!-- Output -->
+                        <section class="lab-output">
+
+                            <!-- KPI Ribbon -->
+                            <div class="kpi-ribbon">
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        E[TVPI]
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Expected TVPI.</strong> The mean fund TVPI across all 10,000 simulated runs.
+                                                Dragged upward by right-tail outliers — the rare 20x outcomes inflate the average even though most funds don't hit them.
+                                                <em>If a pitch deck quotes one number, it's usually this. It's the most flattering one.</em>
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-mean">—</div>
+                                </div>
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        p50 TVPI
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Median TVPI.</strong> Half of the 10,000 simulated funds returned more, half returned less.
+                                                The "typical" outcome.
+                                                The gap between p50 and E[TVPI] is the power law working — in a normal distribution they'd be close.
+                                                Watch them drift apart as you fatten the tail.
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-p50">—</div>
+                                </div>
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        P(&gt;3x)
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Probability of returning 3x+.</strong> The fraction of simulated funds that returned 3.0x net to LPs or more.
+                                                The "good fund" threshold.
+                                                For seed-style strategies this lands around 10–20%; for growth it's typically &lt;5%.
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-p3x">—</div>
+                                </div>
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        P(&gt;5x)
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Probability of returning 5x+.</strong> The "outlier fund" threshold.
+                                                Single-digit-percent territory even for great strategies — these are the funds that build a firm's reputation.
+                                                A strategy that can't produce a meaningfully positive P(&gt;5x) is not selling venture risk.
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-p5x">—</div>
+                                </div>
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        P(loss)
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Probability of losing capital.</strong> Fraction of simulated funds that returned less than 1.0x to LPs (failed to return committed capital).
+                                                Always non-trivial in venture — 25–35% is typical for a seed fund.
+                                                Don't pretend this number is zero.
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-ploss">—</div>
+                                </div>
+                                <div class="kpi">
+                                    <div class="kpi-label">
+                                        Sim time
+                                        <span class="tip-wrap" tabindex="0">
+                                            <span class="tip-icon">i</span>
+                                            <span class="tip-content">
+                                                <strong>Simulation time.</strong> How long the Monte Carlo run took, in milliseconds.
+                                                Mostly a debug indicator — if it climbs past a second, lower the trials slider.
+                                            </span>
+                                        </span>
+                                    </div>
+                                    <div class="kpi-value" id="kpi-time">—</div>
+                                </div>
+                            </div>
+
+                            <!-- Histogram (hero) -->
+                            <div class="hist-card">
+                                <div class="hist-card-header">
+                                    <h3 class="hist-card-title">Fund TVPI — distribution across <span id="hist-trial-count">10,000</span> simulated funds</h3>
+                                    <p class="hist-card-sub">Each bar = the % of simulated funds that landed in that TVPI bucket. Quantile markers (p10–p90) overlaid in white.</p>
+                                </div>
+                                <div id="histogram" class="histogram"></div>
+                                <div class="hist-legend">
+                                    <span class="legend-swatch loss"></span> &lt;1x (loss)
+                                    <span class="legend-swatch mediocre"></span> 1–3x
+                                    <span class="legend-swatch winner"></span> 3–10x
+                                    <span class="legend-swatch outlier"></span> 10x+
+                                </div>
+                            </div>
+
+                            <!-- Sources of return -->
+                            <div class="sources-card">
+                                <h3 class="sources-title">Where the return came from</h3>
+                                <p class="sources-sub">Averaged across all simulated funds. The fewer winners drive the return, the more the math is power-law shaped.</p>
+                                <div class="sources-grid">
+                                    <div class="source-item">
+                                        <div class="source-num" id="src-top1">—</div>
+                                        <div class="source-cap">
+                                            Top 1 company
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Top 1 contribution.</strong> Across all simulations, on average, what % of the fund's total dollar return came from the single largest winner.
+                                                    The signature power-law number.
+                                                    In seed strategies it's often 40–60%; in growth it's closer to 20–30%.
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <div class="source-hint">share of total fund return</div>
+                                    </div>
+                                    <div class="source-item">
+                                        <div class="source-num" id="src-top3">—</div>
+                                        <div class="source-cap">
+                                            Top 3
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Top 3 contribution.</strong> Same idea as Top 1, but for the three largest winners combined.
+                                                    If this exceeds 80%, the fund is fundamentally power-law dominated — most of your TVPI comes from three calls.
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <div class="source-hint">share of total fund return</div>
+                                    </div>
+                                    <div class="source-item">
+                                        <div class="source-num" id="src-top10">—</div>
+                                        <div class="source-cap">
+                                            Top 10
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>Top 10 contribution.</strong> Share of fund return from the top 10 winners combined.
+                                                    For most seed strategies this is north of 90% — meaning the bottom 15+ investments contribute almost nothing.
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <div class="source-hint">share of total fund return</div>
+                                    </div>
+                                    <div class="source-item highlight">
+                                        <div class="source-num" id="src-notop">—</div>
+                                        <div class="source-cap">
+                                            TVPI without your top winner
+                                            <span class="tip-wrap" tabindex="0">
+                                                <span class="tip-icon">i</span>
+                                                <span class="tip-content">
+                                                    <strong>TVPI minus the top hit.</strong> What the fund's net TVPI would have been if the single largest winner had returned $0 instead.
+                                                    The most underappreciated number in venture — most "good" funds become 1.0x funds once you remove their best deal.
+                                                    <em>This is the LP question a GP can't dodge.</em>
+                                                </span>
+                                            </span>
+                                        </div>
+                                        <div class="source-hint">delete the biggest hit — what's left?</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Scripted scenarios -->
+            <section class="scenarios-section">
+                <div class="container mx-auto px-8">
+                    <h2 class="section-title">Explore</h2>
+                    <p class="section-subtitle">Six scenarios. Each loads a preset and a short argument. Disagree freely.</p>
+                    <div class="scenarios-grid" id="scenarios-grid">
+                        <!-- Populated by JS -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Methodology -->
+            <section class="methodology-section">
+                <div class="container mx-auto px-8">
+                    <details class="methodology">
+                        <summary class="methodology-summary">
+                            <span>Methodology — what's actually being simulated</span>
+                            <span class="methodology-chevron">+</span>
+                        </summary>
+                        <div class="methodology-body">
+                            <h4>The model</h4>
+                            <p>
+                                Each company independently draws an outcome multiple from a <strong>mixture distribution</strong>: with probability <em>loss rate</em> it returns 0; otherwise it draws from a Pareto distribution with shape <em>α</em>, lower bound 1, truncated at <em>tail cap</em>. Pareto is the standard parametric form for venture outcomes — it produces the long tail empirical fund data shows.
+                            </p>
+                            <h4>Sampling</h4>
+                            <p>
+                                Survivor sampling: <code>u ~ Uniform(0, U_max)</code> where <code>U_max = 1 − (1 / tailCap)^α</code>, then <code>x = 1 / (1 − u)^(1/α)</code>. Truncating at <em>tail cap</em> bounds the largest possible outcome. With α near 1 the tail is fat and a single 100x outcome dominates; with α near 3 the tail collapses and the distribution looks almost normal.
+                            </p>
+                            <h4>Fund economics</h4>
+                            <p>
+                                Initial check = (1 − reserves) × fundSize / N. Follow-on capital is split across the portfolio according to your selected strategy (pro-rata = equal split; super pro-rata = top 30% of winners by realized multiple; none = reserves returned to LPs at 1.0x). Gross return is summed across all positions and scaled by the ownership multiplier. We subtract management fees over the fund life and apply carry on profits above 1.0x of committed capital. The reported TVPI is net to LP.
+                            </p>
+                            <h4>Calibration</h4>
+                            <p>
+                                Seed preset (α=1.5, loss rate 65%, cap 100x) is consistent with public empirical work — Correlation Ventures, Kauffman, AngelList. Series A and Growth presets shift loss rate down and tail thickness up, matching the conventional view that later stages have lower variance.
+                            </p>
+                            <h4>Limitations (read these)</h4>
+                            <ul>
+                                <li><strong>Company outcomes are assumed independent.</strong> They aren't — vintage years, sector concentration, and macro shocks correlate failures. Real fund TVPI variance is wider than this model shows.</li>
+                                <li><strong>Outcomes are net of dilution.</strong> The Pareto sample represents what your initial check became at exit. Cap-table mechanics are folded into the distribution, not modeled separately.</li>
+                                <li><strong>Time is collapsed.</strong> The simulation reports TVPI, not DPI, and treats the fund life as a single horizon. Time-value-of-money matters for IRR but not for the visceral point this lab is making.</li>
+                                <li><strong>This is a teaching tool.</strong> Don't use it to underwrite a manager. Use it to argue with their pitch deck.</li>
+                            </ul>
+                        </div>
+                    </details>
+                </div>
+            </section>
+        </main>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <div class="container mx-auto px-8">
+                <div class="flex flex-col md:flex-row justify-between items-center">
+                    <p class="footer-text">
+                        © 2025 Canonical Crypto. All rights reserved.
+                    </p>
+                    <div class="flex items-center space-x-6 mt-4 md:mt-0">
+                        <a href="https://x.com/canonicalcrypto" target="_blank" rel="noopener noreferrer" class="footer-link">
+                            Canonical on X
+                        </a>
+                        <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="footer-link">
+                            Canonical on Substack
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="lab.js?v=1"></script>
+    <!-- Header scroll behavior, lifted from main script.js -->
+    <script>
+        function handleHeaderScroll() {
+            const header = document.getElementById('header');
+            if (window.scrollY > 50) header.classList.add('scrolled');
+            else header.classList.remove('scrolled');
+        }
+        window.addEventListener('scroll', handleHeaderScroll);
+        handleHeaderScroll();
+    </script>
+</body>
+</html>

--- a/labs/power-law/lab.css
+++ b/labs/power-law/lab.css
@@ -1,0 +1,876 @@
+/* Power Law Outlier Lab — lab-specific styles
+   Inherits from /css/style.css (body gradient, header, nav, footer) */
+
+/* Tooltip system — used across all inputs and chips */
+.tip-wrap {
+    position: relative;
+}
+.tip-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    color: rgba(255, 255, 255, 0.75);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10px;
+    font-weight: 700;
+    line-height: 1;
+    margin-left: 0.35rem;
+    cursor: help;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    user-select: none;
+    vertical-align: middle;
+}
+.tip-icon:hover,
+.tip-wrap:hover .tip-icon,
+.tip-wrap:focus-within .tip-icon {
+    background: rgba(250, 204, 21, 0.35);
+    color: #facc15;
+}
+
+.tip-content {
+    /* Default position is off-screen viewport-fixed; JS sets real coords on hover.
+       Critical: this keeps the tooltip from contributing to its ancestors' scrollWidth,
+       which was making the controls column overflow even when hidden. */
+    position: fixed;
+    left: -9999px;
+    top: 0;
+    width: 280px;
+    max-width: calc(100vw - 2rem);
+    background: rgba(15, 23, 42, 0.97);
+    border: 1px solid rgba(250, 204, 21, 0.4);
+    border-radius: 0.5rem;
+    padding: 0.75rem 0.875rem;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    color: rgba(255, 255, 255, 0.92);
+    z-index: 200;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(4px);
+    transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    font-weight: 400;
+    letter-spacing: normal;
+    text-transform: none;
+    white-space: normal;
+    text-align: left;
+}
+
+/* .tip-content--below is a flag read by JS to decide above-vs-below positioning.
+   No CSS positioning rules here — JS handles it. */
+
+.tip-content strong {
+    color: #facc15;
+    font-weight: 600;
+}
+.tip-content em {
+    color: rgba(255, 255, 255, 0.7);
+    font-style: italic;
+}
+.tip-content code {
+    background: rgba(0, 0, 0, 0.4);
+    padding: 0.05rem 0.3rem;
+    border-radius: 0.2rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.72rem;
+    color: #93c5fd;
+}
+.tip-content p {
+    margin-bottom: 0.4rem;
+}
+.tip-content p:last-child { margin-bottom: 0; }
+
+.tip-wrap:hover > .tip-content,
+.tip-wrap:focus-within > .tip-content {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+/* When tooltip would clip off the right edge of the controls panel,
+   anchor it to the right instead. */
+.tip-content--right {
+    left: auto;
+    right: 0;
+}
+
+/* Hero */
+.lab-hero {
+    padding: 8rem 0 2rem;
+    text-align: center;
+}
+
+.lab-hero-content {
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.lab-eyebrow {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    color: rgba(255, 255, 255, 0.6);
+    margin-bottom: 1.5rem;
+}
+
+.lab-title {
+    font-size: clamp(2.5rem, 6vw, 4.5rem);
+    font-weight: 300;
+    line-height: 1.1;
+    margin-bottom: 1.25rem;
+    color: #ffffff;
+}
+
+.lab-subtitle {
+    font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+    font-weight: 400;
+    line-height: 1.6;
+    color: rgba(255, 255, 255, 0.8);
+    max-width: 720px;
+    margin: 0 auto 2rem;
+}
+
+.use-cases {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    max-width: 1000px;
+    margin: 2.5rem auto 2.5rem;
+    text-align: left;
+}
+
+.use-case {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0.75rem;
+    padding: 1rem 1.125rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.use-case-tag {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: #facc15;
+}
+
+.use-case-body {
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: rgba(255, 255, 255, 0.82);
+    font-weight: 400;
+}
+
+.use-case-body em {
+    color: rgba(255, 255, 255, 0.95);
+    font-style: italic;
+}
+
+.preset-chips {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 0.375rem 0.875rem 0.375rem 1rem;
+    border-radius: 999px;
+}
+
+.preset-chips-label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.6);
+    letter-spacing: 0.05em;
+    padding-right: 0.25rem;
+}
+
+.preset-chip {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.preset-chip:hover {
+    color: #ffffff;
+}
+
+.preset-chip.active {
+    background-color: rgba(255, 255, 255, 0.95);
+    color: #1e3a8a;
+}
+
+/* Scenario callout */
+.scenario-callout {
+    padding: 0 0 1.5rem;
+}
+
+.scenario-callout.hidden { display: none; }
+
+.scenario-callout-inner {
+    background: linear-gradient(135deg, rgba(250, 204, 21, 0.12), rgba(251, 191, 36, 0.06));
+    border: 1px solid rgba(250, 204, 21, 0.35);
+    border-radius: 1rem;
+    padding: 1.5rem 2rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.scenario-callout-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.scenario-callout-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    color: #facc15;
+}
+
+.scenario-callout-dismiss {
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.6);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.5rem;
+    font-family: inherit;
+}
+
+.scenario-callout-dismiss:hover {
+    color: #ffffff;
+}
+
+.scenario-callout-title {
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: #ffffff;
+    margin-bottom: 0.75rem;
+}
+
+.scenario-callout-body p {
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1rem;
+    line-height: 1.65;
+    margin-bottom: 0.75rem;
+}
+
+.scenario-callout-body p:last-child { margin-bottom: 0; }
+
+/* Lab main */
+.lab-main {
+    padding: 1rem 0 4rem;
+}
+
+.lab-grid {
+    display: grid;
+    grid-template-columns: 360px 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+/* Controls */
+.lab-controls {
+    position: sticky;
+    top: 100px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    max-height: calc(100vh - 120px);
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* .tip-content.floating is a marker class JS adds to coordinate state.
+   The actual top/left are set as inline styles. No CSS needed here. */
+
+.control-section {
+    margin-bottom: 1.75rem;
+}
+
+.control-section:last-child {
+    margin-bottom: 0;
+}
+
+.control-section-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    color: rgba(255, 255, 255, 0.5);
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.control-row {
+    margin-bottom: 1rem;
+}
+
+.control-row.inline { margin-bottom: 0.75rem; }
+.control-row.derived { margin-bottom: 0; padding-top: 0.25rem; }
+
+.control-label {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.825rem;
+    color: rgba(255, 255, 255, 0.9);
+    margin-bottom: 0.5rem;
+    letter-spacing: 0.02em;
+    gap: 0.5rem;
+}
+
+.control-label-text {
+    display: inline-flex;
+    align-items: center;
+    flex: 1;
+}
+
+.control-value {
+    color: #facc15;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.875rem;
+}
+
+.control-derived {
+    display: block;
+    font-size: 0.825rem;
+    color: rgba(255, 255, 255, 0.65);
+    padding: 0.5rem 0.75rem;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 0.375rem;
+}
+
+.control-derived strong {
+    color: #93c5fd;
+    font-weight: 500;
+}
+
+.control-hint {
+    display: block;
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.45);
+    margin-top: 0.375rem;
+    line-height: 1.4;
+}
+
+/* Range input styling */
+input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    background: transparent;
+    cursor: pointer;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    background: rgba(255, 255, 255, 0.15);
+    height: 4px;
+    border-radius: 2px;
+}
+
+input[type="range"]::-moz-range-track {
+    background: rgba(255, 255, 255, 0.15);
+    height: 4px;
+    border-radius: 2px;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    margin-top: -7px;
+    height: 18px;
+    width: 18px;
+    border-radius: 50%;
+    background: #facc15;
+    border: 2px solid rgba(30, 58, 138, 0.8);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    transition: transform 0.15s ease;
+}
+
+input[type="range"]::-moz-range-thumb {
+    height: 18px;
+    width: 18px;
+    border-radius: 50%;
+    background: #facc15;
+    border: 2px solid rgba(30, 58, 138, 0.8);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    cursor: pointer;
+}
+
+input[type="range"]:hover::-webkit-slider-thumb {
+    transform: scale(1.15);
+}
+
+/* Select */
+.control-select {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: #ffffff;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    font-family: inherit;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+.control-select:focus {
+    outline: none;
+    border-color: #facc15;
+}
+
+.control-select option {
+    background: #1e3a8a;
+    color: #ffffff;
+}
+
+/* Control buttons */
+.control-buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.control-btn {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: rgba(255, 255, 255, 0.9);
+    padding: 0.625rem 0.75rem;
+    border-radius: 0.375rem;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.control-btn:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.control-btn.primary {
+    background: #facc15;
+    color: #1e3a8a;
+    border-color: #facc15;
+    grid-column: 1 / -1;
+}
+
+.control-btn.primary:hover {
+    background: #fde047;
+}
+
+/* Output */
+.lab-output {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+/* KPI ribbon */
+.kpi-ribbon {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    gap: 1px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.kpi {
+    background: rgba(30, 58, 138, 0.6);
+    padding: 1rem 1rem;
+    text-align: center;
+}
+
+.kpi-label {
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    color: rgba(255, 255, 255, 0.6);
+    text-transform: uppercase;
+    margin-bottom: 0.375rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+}
+
+.kpi-value {
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: #ffffff;
+    font-variant-numeric: tabular-nums;
+    transition: color 0.2s ease;
+}
+
+.kpi-value.flash {
+    color: #facc15;
+}
+
+/* Histogram card */
+.hist-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    padding: 1.75rem;
+}
+
+.hist-card-header {
+    margin-bottom: 1rem;
+}
+
+.hist-card-title {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin-bottom: 0.375rem;
+}
+
+.hist-card-sub {
+    font-size: 0.825rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.histogram {
+    width: 100%;
+    height: 360px;
+}
+
+.histogram svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+}
+
+.hist-bar {
+    transition: fill 0.2s ease;
+}
+
+.hist-bar.loss { fill: #ef4444; }
+.hist-bar.mediocre { fill: #93c5fd; }
+.hist-bar.winner { fill: #fbbf24; }
+.hist-bar.outlier { fill: #facc15; filter: drop-shadow(0 0 6px rgba(250, 204, 21, 0.6)); }
+
+.hist-axis text {
+    fill: rgba(255, 255, 255, 0.65);
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 10px;
+}
+
+.hist-axis line, .hist-axis path {
+    stroke: rgba(255, 255, 255, 0.15);
+}
+
+.quantile-line {
+    stroke: rgba(255, 255, 255, 0.85);
+    stroke-width: 1.5;
+    stroke-dasharray: 3 3;
+}
+
+.quantile-label {
+    fill: #ffffff;
+    font-size: 10px;
+    font-weight: 500;
+    text-anchor: middle;
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+}
+
+.quantile-label-bg {
+    fill: rgba(30, 58, 138, 0.95);
+    stroke: rgba(255, 255, 255, 0.5);
+    stroke-width: 0.5;
+    rx: 3;
+}
+
+.hist-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-top: 1rem;
+    font-size: 0.75rem;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    margin-right: 0.375rem;
+    vertical-align: middle;
+}
+
+.legend-swatch.loss { background: #ef4444; }
+.legend-swatch.mediocre { background: #93c5fd; }
+.legend-swatch.winner { background: #fbbf24; }
+.legend-swatch.outlier { background: #facc15; box-shadow: 0 0 6px rgba(250, 204, 21, 0.6); }
+
+/* Sources of return */
+.sources-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    padding: 1.75rem;
+}
+
+.sources-title {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin-bottom: 0.375rem;
+}
+
+.sources-sub {
+    font-size: 0.825rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-bottom: 1.25rem;
+}
+
+.sources-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+
+.source-item {
+    background: rgba(30, 58, 138, 0.5);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    text-align: center;
+}
+
+.source-item.highlight {
+    background: rgba(239, 68, 68, 0.15);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.source-num {
+    font-size: 1.5rem;
+    font-weight: 400;
+    color: #facc15;
+    font-variant-numeric: tabular-nums;
+    margin-bottom: 0.25rem;
+}
+
+.source-item.highlight .source-num {
+    color: #fca5a5;
+}
+
+.source-cap {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.9);
+    font-weight: 500;
+    margin-bottom: 0.125rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.source-hint {
+    font-size: 0.7rem;
+    color: rgba(255, 255, 255, 0.5);
+    line-height: 1.3;
+}
+
+/* Scenarios section */
+.scenarios-section {
+    padding: 4rem 0;
+    background: rgba(0, 0, 0, 0.1);
+}
+
+.scenarios-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+    margin-top: 2.5rem;
+}
+
+.scenario-card {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+    text-align: left;
+    color: inherit;
+    font-family: inherit;
+    width: 100%;
+}
+
+.scenario-card:hover {
+    transform: translateY(-3px);
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(250, 204, 21, 0.4);
+}
+
+.scenario-card-num {
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: rgba(250, 204, 21, 0.85);
+    letter-spacing: 0.15em;
+    margin-bottom: 0.75rem;
+}
+
+.scenario-card-title {
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin-bottom: 0.625rem;
+    line-height: 1.3;
+}
+
+.scenario-card-tagline {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.55;
+}
+
+.scenario-card-cta {
+    display: inline-flex;
+    align-items: center;
+    margin-top: 1rem;
+    font-size: 0.8rem;
+    color: #facc15;
+    font-weight: 500;
+}
+
+.scenario-card-cta span { transition: transform 0.2s ease; margin-left: 0.25rem; }
+.scenario-card:hover .scenario-card-cta span { transform: translateX(3px); }
+
+/* Methodology */
+.methodology-section {
+    padding: 2rem 0 4rem;
+}
+
+.methodology {
+    max-width: 56rem;
+    margin: 0 auto;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 1rem;
+    padding: 1.5rem 2rem;
+}
+
+.methodology-summary {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 1rem;
+    font-weight: 500;
+    color: #ffffff;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+
+.methodology-summary::-webkit-details-marker { display: none; }
+
+.methodology-chevron {
+    color: #facc15;
+    font-size: 1.25rem;
+    transition: transform 0.2s ease;
+}
+
+.methodology[open] .methodology-chevron {
+    transform: rotate(45deg);
+}
+
+.methodology-body {
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.8);
+    line-height: 1.7;
+}
+
+.methodology-body h4 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #facc15;
+    margin: 1.5rem 0 0.5rem;
+}
+
+.methodology-body h4:first-child { margin-top: 0; }
+
+.methodology-body p {
+    margin-bottom: 0.75rem;
+    font-size: 0.95rem;
+}
+
+.methodology-body ul {
+    padding-left: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.methodology-body li {
+    margin-bottom: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.methodology-body code {
+    background: rgba(0, 0, 0, 0.3);
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85rem;
+    color: #93c5fd;
+}
+
+.methodology-body strong { color: #ffffff; }
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .lab-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .lab-controls {
+        position: relative;
+        top: 0;
+        max-height: none;
+    }
+
+    .kpi-ribbon { grid-template-columns: repeat(3, 1fr); }
+    .sources-grid { grid-template-columns: repeat(2, 1fr); }
+    .scenarios-grid { grid-template-columns: repeat(2, 1fr); }
+    .use-cases { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+    .lab-hero { padding-top: 6rem; }
+    .kpi-ribbon { grid-template-columns: repeat(2, 1fr); }
+    .sources-grid { grid-template-columns: 1fr 1fr; }
+    .scenarios-grid { grid-template-columns: 1fr; }
+    .histogram { height: 280px; }
+    .preset-chips { flex-wrap: wrap; }
+}

--- a/labs/power-law/lab.js
+++ b/labs/power-law/lab.js
@@ -1,0 +1,760 @@
+/* Power Law Outlier Lab — simulation + UI */
+(function () {
+    'use strict';
+
+    // ---------- State ----------
+    const DEFAULTS = {
+        fundSize: 50,
+        N: 25,
+        reserves: 40,
+        ownership: 1.0,
+        followon: 'prorata',
+        lossRate: 50,
+        alpha: 1.2,
+        tailCap: 500,
+        mgmtFee: 2.0,
+        carry: 20,
+        life: 10,
+        trials: 10000
+    };
+
+    const PRESETS = {
+        seed:    { fundSize: 50,  N: 25, reserves: 40, ownership: 1.0, followon: 'prorata', lossRate: 50, alpha: 1.20, tailCap: 500, mgmtFee: 2.0, carry: 20, life: 10, trials: 10000 },
+        seriesA: { fundSize: 150, N: 18, reserves: 50, ownership: 1.0, followon: 'prorata', lossRate: 35, alpha: 1.50, tailCap: 120, mgmtFee: 2.0, carry: 20, life: 10, trials: 10000 },
+        growth:  { fundSize: 400, N: 12, reserves: 35, ownership: 1.0, followon: 'prorata', lossRate: 15, alpha: 1.80, tailCap: 30,  mgmtFee: 2.0, carry: 20, life: 8,  trials: 10000 },
+        custom:  null
+    };
+
+    const SCENARIOS = [
+        {
+            id: 'n-debate',
+            num: '01',
+            title: 'The N debate',
+            tagline: 'Same fund size, same outcome shape. Index 50 names — watch the tail die.',
+            full: true,
+            preset: { ...PRESETS.seed, N: 50, reserves: 25, followon: 'prorata' },
+            narrative: [
+                'Set N to 15 — the classic concentrated seed strategy — and you get fat upside and the variance to match. Slide N to 50 and the histogram visibly narrows. Same fund size. Same outcome distribution. Same expected per-company multiple. What changes is the chance that a power-law winner shows up <em>somewhere</em> in your portfolio.',
+                'The trap is intuitive: more names feels safer. And it is, if you measure "safety" as a tighter distribution around the median. But the median in venture is bad. LPs are paying for the right tail. Index a power law and you pay for the tail in fees while squeezing it out of your portfolio. The N debate is really a debate about whether you want to hold a fund that <em>could</em> return 5x, or one that almost certainly returns 1.5x.'
+            ]
+        },
+        {
+            id: 'followon',
+            num: '02',
+            title: 'Follow-on math',
+            tagline: 'Pro-rata everywhere vs. super pro-rata into winners only. Same dollars. Different fund.',
+            full: true,
+            preset: { ...PRESETS.seed, followon: 'superprorata' },
+            narrative: [
+                'Toggle follow-on between <strong>Pro-rata</strong> and <strong>Super pro-rata</strong>. Both spend the same reserve pool. Pro-rata splits the reserves evenly across the portfolio; super pro-rata loads them into the realized winners. Median TVPI moves materially. So does P(&gt;5x).',
+                'The reason: power-law math compounds. A 30x company that receives an additional follow-on dollar at a marked-up price still returns more capital than spreading that dollar across 25 average outcomes. Reserves are not a hedge — they are a second swing at the same pitch. The discipline is to put reserves where the data says, not where the relationships say.'
+            ]
+        },
+        {
+            id: 'ownership',
+            num: '03',
+            title: 'Ownership matters more than you think',
+            tagline: 'Same outcomes. Move ownership from 0.5x to 2.0x. The effect is linear and obvious.',
+            full: false,
+            preset: { ...PRESETS.seed, ownership: 1.5 }
+        },
+        {
+            id: 'seed-vs-growth',
+            num: '04',
+            title: 'Why seed beats growth at the fund level',
+            tagline: 'Identical capital. Different outcome shapes. Thinner tails cap your TVPI.',
+            full: false,
+            preset: { ...PRESETS.growth }
+        },
+        {
+            id: '1-over-n',
+            num: '05',
+            title: 'The 1/N illusion',
+            tagline: 'Uniform check sizes vs. concentration. Identical winners. Different fund returns.',
+            full: false,
+            preset: { ...PRESETS.seed, reserves: 10, N: 30 }
+        },
+        {
+            id: 'survivorship',
+            num: '06',
+            title: 'Survivorship in your memory',
+            tagline: 'Replay "Sequoia 1995" thousands of times. Most runs of identical strategy are mediocre.',
+            full: false,
+            preset: { ...PRESETS.seed, alpha: 1.10, tailCap: 1000, lossRate: 65 }
+        }
+    ];
+
+    let state = { ...DEFAULTS };
+    let lastResult = null;
+    let renderTimer = null;
+
+    // ---------- URL state ----------
+    function encodeState(s) {
+        const params = new URLSearchParams();
+        Object.keys(s).forEach(k => params.set(k, String(s[k])));
+        return params.toString();
+    }
+    function decodeState() {
+        if (!location.hash || location.hash.length < 2) return null;
+        const params = new URLSearchParams(location.hash.slice(1));
+        const out = {};
+        for (const [k, v] of params.entries()) {
+            if (k in DEFAULTS) {
+                const def = DEFAULTS[k];
+                out[k] = (typeof def === 'number') ? Number(v) : v;
+            }
+        }
+        return Object.keys(out).length ? out : null;
+    }
+    function updateHash() {
+        history.replaceState(null, '', '#' + encodeState(state));
+    }
+
+    // ---------- Simulation ----------
+
+    // Truncated Pareto sampler. alpha > 0, xMin >= 1, xMax > xMin.
+    function sampleTruncatedPareto(alpha, xMin, xMax) {
+        // F(x) = 1 - (xMin/x)^alpha. To truncate at xMax, sample u in [0, Fmax).
+        const ratio = xMin / xMax;
+        const uMax = 1 - Math.pow(ratio, alpha);
+        const u = Math.random() * uMax;
+        return xMin / Math.pow(1 - u, 1 / alpha);
+    }
+
+    // Analytic mean of truncated Pareto with xMin=1, shape alpha>1.
+    // E[X] = alpha/(alpha-1) * (1 - cap^(1-alpha)) / (1 - cap^(-alpha))
+    function meanTruncatedPareto(alpha, xMax) {
+        if (Math.abs(alpha - 1) < 1e-6) {
+            // alpha == 1 → E[X] = ln(xMax) / (1 - 1/xMax)
+            return Math.log(xMax) / (1 - 1 / xMax);
+        }
+        const num = (1 - Math.pow(xMax, 1 - alpha));
+        const den = (1 - Math.pow(xMax, -alpha));
+        return (alpha / (alpha - 1)) * (num / den);
+    }
+
+    function meanPerCompany(lossRate01, alpha, tailCap) {
+        return (1 - lossRate01) * meanTruncatedPareto(alpha, tailCap);
+    }
+
+    // One trial: returns { tvpi, top1Share, top3Share, top10Share, withoutTop1TVPI }
+    function runTrial(p) {
+        const N = p.N;
+        const reserves01 = p.reserves / 100;
+        const lossRate01 = p.lossRate / 100;
+        const alpha = p.alpha;
+        const tailCap = p.tailCap;
+        const ownership = p.ownership;
+
+        const initialCapital = p.fundSize * (1 - reserves01);  // $M deployed at entry
+        const reserveCapital = p.fundSize * reserves01;        // $M reserved
+        const initialCheck = initialCapital / N;               // $M per initial check
+
+        // Draw per-company multiples
+        const multiples = new Array(N);
+        for (let i = 0; i < N; i++) {
+            if (Math.random() < lossRate01) {
+                multiples[i] = 0;
+            } else {
+                multiples[i] = sampleTruncatedPareto(alpha, 1, tailCap);
+            }
+        }
+
+        // Determine follow-on allocation per company
+        let followOn = new Array(N).fill(0);
+        if (p.followon === 'prorata') {
+            const perCo = reserveCapital / N;
+            for (let i = 0; i < N; i++) followOn[i] = perCo;
+        } else if (p.followon === 'superprorata') {
+            // Top 30% of companies (by realized multiple) get all reserves, equally
+            const idxs = multiples
+                .map((m, i) => ({ m, i }))
+                .sort((a, b) => b.m - a.m);
+            const k = Math.max(1, Math.round(0.3 * N));
+            const perCo = reserveCapital / k;
+            for (let j = 0; j < k; j++) followOn[idxs[j].i] = perCo;
+        } else {
+            // 'none' — reserves returned at 1.0x, no follow-on
+        }
+
+        // Per-company gross return (apply ownership multiplier to outcome)
+        const grossPerCo = new Array(N);
+        for (let i = 0; i < N; i++) {
+            const invested = initialCheck + followOn[i];
+            grossPerCo[i] = invested * multiples[i] * ownership;
+        }
+
+        // If no follow-on, reserves come back as $reserveCapital * 1.0
+        const reservesReturned = (p.followon === 'none') ? reserveCapital : 0;
+
+        // Total invested across portfolio (initial + deployed reserves)
+        const totalInvested = initialCapital + (p.followon === 'none' ? 0 : reserveCapital);
+
+        let grossReturn = grossPerCo.reduce((a, b) => a + b, 0) + reservesReturned;
+
+        // Fees: mgmt fee per year over total fund
+        const totalMgmtFee = (p.mgmtFee / 100) * p.life * p.fundSize;
+
+        // Net pre-carry = gross - fees (fees come from LP commitments effectively)
+        let netPreCarry = grossReturn - totalMgmtFee;
+
+        // Carry on profits over 1.0x committed
+        let netToLP = netPreCarry;
+        if (netPreCarry > p.fundSize) {
+            const profit = netPreCarry - p.fundSize;
+            netToLP -= profit * (p.carry / 100);
+        }
+
+        const tvpi = netToLP / p.fundSize;
+
+        // Sources of return — by gross contribution, sorted desc
+        const sorted = grossPerCo.slice().sort((a, b) => b - a);
+        const totalCo = sorted.reduce((a, b) => a + b, 0) || 1; // avoid div0
+        const top1Share = sorted[0] / totalCo;
+        const top3Share = sorted.slice(0, 3).reduce((a, b) => a + b, 0) / totalCo;
+        const top10Share = sorted.slice(0, Math.min(10, N)).reduce((a, b) => a + b, 0) / totalCo;
+
+        // "Without top 1": recompute TVPI removing top company's gross
+        const grossNoTop = grossReturn - sorted[0];
+        let netNoTop = grossNoTop - totalMgmtFee;
+        if (netNoTop > p.fundSize) {
+            netNoTop -= (netNoTop - p.fundSize) * (p.carry / 100);
+        }
+        const tvpiNoTop = netNoTop / p.fundSize;
+
+        return { tvpi, top1Share, top3Share, top10Share, tvpiNoTop };
+    }
+
+    function runSimulation(p) {
+        const t0 = performance.now();
+        const trials = p.trials;
+        const tvpis = new Float64Array(trials);
+        let sumTop1 = 0, sumTop3 = 0, sumTop10 = 0, sumNoTop = 0;
+
+        for (let i = 0; i < trials; i++) {
+            const r = runTrial(p);
+            tvpis[i] = r.tvpi;
+            sumTop1 += r.top1Share;
+            sumTop3 += r.top3Share;
+            sumTop10 += r.top10Share;
+            sumNoTop += r.tvpiNoTop;
+        }
+
+        const sortedTVPI = Array.from(tvpis).sort((a, b) => a - b);
+        const q = (frac) => sortedTVPI[Math.max(0, Math.min(trials - 1, Math.floor(frac * trials)))];
+        const mean = Array.from(tvpis).reduce((a, b) => a + b, 0) / trials;
+
+        const countAbove = (thresh) => {
+            let c = 0;
+            for (let i = 0; i < trials; i++) if (tvpis[i] >= thresh) c++;
+            return c / trials;
+        };
+
+        return {
+            tvpis: Array.from(tvpis),
+            mean,
+            quantiles: {
+                p10: q(0.10), p25: q(0.25), p50: q(0.50), p75: q(0.75), p90: q(0.90),
+                p95: q(0.95), p99: q(0.99)
+            },
+            pAbove3x: countAbove(3),
+            pAbove5x: countAbove(5),
+            avgTop1Share: sumTop1 / trials,
+            avgTop3Share: sumTop3 / trials,
+            avgTop10Share: sumTop10 / trials,
+            avgTVPINoTop: sumNoTop / trials,
+            timeMs: performance.now() - t0
+        };
+    }
+
+    function pLoss(tvpis) {
+        let c = 0;
+        for (let i = 0; i < tvpis.length; i++) if (tvpis[i] < 1.0) c++;
+        return c / tvpis.length;
+    }
+
+    // ---------- D3 histogram ----------
+    const histEl = document.getElementById('histogram');
+    let histSvg = null;
+
+    function colorBucket(x) {
+        if (x < 1) return 'loss';
+        if (x < 3) return 'mediocre';
+        if (x < 10) return 'winner';
+        return 'outlier';
+    }
+
+    function renderHistogram(result) {
+        if (!window.d3) return;
+
+        const rect = histEl.getBoundingClientRect();
+        const width = rect.width;
+        const height = 360;
+        const margin = { top: 28, right: 16, bottom: 36, left: 40 };
+        const innerW = width - margin.left - margin.right;
+        const innerH = height - margin.top - margin.bottom;
+
+        const tvpis = result.tvpis;
+        // Show out to ~p99 so the outlier bucket is visible. Clamp to a humane range.
+        const xMax = Math.max(5, Math.min(30, result.quantiles.p99 * 1.1));
+
+        // Build bins. Use 36 fixed-width bins.
+        const numBins = 36;
+        const binSize = xMax / numBins;
+        const bins = new Array(numBins).fill(0);
+        let overflow = 0;
+        for (let i = 0; i < tvpis.length; i++) {
+            const v = tvpis[i];
+            if (v < 0) {
+                bins[0]++;
+            } else if (v >= xMax) {
+                overflow++;
+            } else {
+                const idx = Math.min(numBins - 1, Math.floor(v / binSize));
+                bins[idx]++;
+            }
+        }
+        // Add overflow to last bin for display
+        bins[numBins - 1] += overflow;
+
+        const total = tvpis.length;
+        const yMax = d3.max(bins) / total;
+
+        const x = d3.scaleLinear().domain([0, xMax]).range([0, innerW]);
+        const y = d3.scaleLinear().domain([0, yMax * 1.1]).range([innerH, 0]);
+
+        // Create / reuse SVG
+        let svg = d3.select(histEl).select('svg');
+        if (svg.empty()) {
+            svg = d3.select(histEl).append('svg')
+                .attr('viewBox', `0 0 ${width} ${height}`)
+                .attr('preserveAspectRatio', 'none');
+        } else {
+            svg.attr('viewBox', `0 0 ${width} ${height}`);
+        }
+        let g = svg.select('g.root');
+        if (g.empty()) {
+            g = svg.append('g').attr('class', 'root').attr('transform', `translate(${margin.left},${margin.top})`);
+            g.append('g').attr('class', 'bars');
+            g.append('g').attr('class', 'x-axis hist-axis').attr('transform', `translate(0,${innerH})`);
+            g.append('g').attr('class', 'y-axis hist-axis');
+            g.append('g').attr('class', 'quantiles');
+        } else {
+            g.attr('transform', `translate(${margin.left},${margin.top})`);
+        }
+
+        // Bars
+        const barW = innerW / numBins;
+        const barData = bins.map((c, i) => {
+            const midX = (i + 0.5) * binSize;
+            return { i, count: c, frac: c / total, cls: colorBucket(midX) };
+        });
+
+        const bars = g.select('.bars').selectAll('rect.hist-bar').data(barData);
+
+        bars.exit().remove();
+
+        const barsEnter = bars.enter().append('rect')
+            .attr('class', d => `hist-bar ${d.cls}`)
+            .attr('x', d => d.i * barW + 1)
+            .attr('width', Math.max(1, barW - 2))
+            .attr('y', innerH)
+            .attr('height', 0);
+
+        bars.merge(barsEnter)
+            .attr('class', d => `hist-bar ${d.cls}`)
+            .transition().duration(180).ease(d3.easeCubicOut)
+            .attr('x', d => d.i * barW + 1)
+            .attr('width', Math.max(1, barW - 2))
+            .attr('y', d => y(d.frac))
+            .attr('height', d => innerH - y(d.frac));
+
+        // Axes
+        const xAxis = d3.axisBottom(x)
+            .ticks(8)
+            .tickFormat(d => d + 'x');
+        const yAxis = d3.axisLeft(y)
+            .ticks(5)
+            .tickFormat(d => Math.round(d * 100) + '%');
+        g.select('.x-axis').transition().duration(180).call(xAxis);
+        g.select('.y-axis').transition().duration(180).call(yAxis);
+
+        // Quantile markers
+        const quantiles = [
+            { key: 'p10', val: result.quantiles.p10 },
+            { key: 'p25', val: result.quantiles.p25 },
+            { key: 'p50', val: result.quantiles.p50 },
+            { key: 'p75', val: result.quantiles.p75 },
+            { key: 'p90', val: result.quantiles.p90 }
+        ].filter(d => d.val <= xMax);
+
+        const qG = g.select('.quantiles');
+        const qLines = qG.selectAll('g.quantile').data(quantiles, d => d.key);
+
+        qLines.exit().remove();
+
+        const qEnter = qLines.enter().append('g').attr('class', 'quantile');
+        qEnter.append('line').attr('class', 'quantile-line').attr('y1', 0).attr('y2', innerH);
+        qEnter.append('rect').attr('class', 'quantile-label-bg').attr('rx', 3);
+        qEnter.append('text').attr('class', 'quantile-label');
+
+        const merged = qLines.merge(qEnter);
+        merged.transition().duration(180)
+            .attr('transform', d => `translate(${x(d.val)}, 0)`);
+
+        merged.select('line').attr('y1', 0).attr('y2', innerH);
+        merged.select('text')
+            .attr('y', -10)
+            .text(d => `${d.key.toUpperCase()} ${d.val.toFixed(2)}x`);
+        // Position label background after text renders
+        merged.each(function () {
+            const sel = d3.select(this);
+            const textNode = sel.select('text').node();
+            if (!textNode) return;
+            try {
+                const bb = textNode.getBBox();
+                sel.select('rect')
+                    .attr('x', bb.x - 4)
+                    .attr('y', bb.y - 1)
+                    .attr('width', bb.width + 8)
+                    .attr('height', bb.height + 2);
+            } catch (e) { /* getBBox can throw on hidden elements */ }
+        });
+    }
+
+    // ---------- UI wiring ----------
+
+    const ctlIds = {
+        fundSize: 'ctl-fundSize',
+        N: 'ctl-N',
+        reserves: 'ctl-reserves',
+        ownership: 'ctl-ownership',
+        followon: 'ctl-followon',
+        lossRate: 'ctl-lossRate',
+        alpha: 'ctl-alpha',
+        tailCap: 'ctl-tailCap',
+        mgmtFee: 'ctl-mgmtFee',
+        carry: 'ctl-carry',
+        life: 'ctl-life',
+        trials: 'ctl-trials'
+    };
+
+    const valIds = {
+        fundSize: 'val-fundSize',
+        N: 'val-N',
+        reserves: 'val-reserves',
+        ownership: 'val-ownership',
+        lossRate: 'val-lossRate',
+        alpha: 'val-alpha',
+        tailCap: 'val-tailCap',
+        mgmtFee: 'val-mgmtFee',
+        carry: 'val-carry',
+        life: 'val-life',
+        trials: 'val-trials',
+        checkSize: 'val-checkSize',
+        evMultiple: 'val-evMultiple'
+    };
+
+    function fmtUSD(M) {
+        if (M >= 1000) return `$${(M / 1000).toFixed(1)}B`;
+        return `$${M}M`;
+    }
+    function fmtCheck(M) {
+        if (M < 1) return `$${(M * 1000).toFixed(0)}K`;
+        return `$${M.toFixed(1)}M`;
+    }
+    function fmtPct(p, digits = 0) {
+        return `${(p * 100).toFixed(digits)}%`;
+    }
+    function fmtMultiple(x, digits = 2) {
+        return `${x.toFixed(digits)}x`;
+    }
+
+    function readControlsToState() {
+        state.fundSize = +document.getElementById(ctlIds.fundSize).value;
+        state.N = +document.getElementById(ctlIds.N).value;
+        state.reserves = +document.getElementById(ctlIds.reserves).value;
+        state.ownership = +document.getElementById(ctlIds.ownership).value;
+        state.followon = document.getElementById(ctlIds.followon).value;
+        state.lossRate = +document.getElementById(ctlIds.lossRate).value;
+        state.alpha = +document.getElementById(ctlIds.alpha).value;
+        state.tailCap = +document.getElementById(ctlIds.tailCap).value;
+        state.mgmtFee = +document.getElementById(ctlIds.mgmtFee).value;
+        state.carry = +document.getElementById(ctlIds.carry).value;
+        state.life = +document.getElementById(ctlIds.life).value;
+        state.trials = +document.getElementById(ctlIds.trials).value;
+    }
+
+    function writeStateToControls() {
+        document.getElementById(ctlIds.fundSize).value = state.fundSize;
+        document.getElementById(ctlIds.N).value = state.N;
+        document.getElementById(ctlIds.reserves).value = state.reserves;
+        document.getElementById(ctlIds.ownership).value = state.ownership;
+        document.getElementById(ctlIds.followon).value = state.followon;
+        document.getElementById(ctlIds.lossRate).value = state.lossRate;
+        document.getElementById(ctlIds.alpha).value = state.alpha;
+        document.getElementById(ctlIds.tailCap).value = state.tailCap;
+        document.getElementById(ctlIds.mgmtFee).value = state.mgmtFee;
+        document.getElementById(ctlIds.carry).value = state.carry;
+        document.getElementById(ctlIds.life).value = state.life;
+        document.getElementById(ctlIds.trials).value = state.trials;
+    }
+
+    function refreshLabels() {
+        document.getElementById(valIds.fundSize).textContent = fmtUSD(state.fundSize);
+        document.getElementById(valIds.N).textContent = state.N;
+        document.getElementById(valIds.reserves).textContent = `${state.reserves}%`;
+        document.getElementById(valIds.ownership).textContent = `${state.ownership.toFixed(2)}x`;
+        document.getElementById(valIds.lossRate).textContent = `${state.lossRate}%`;
+        document.getElementById(valIds.alpha).textContent = state.alpha.toFixed(2);
+        document.getElementById(valIds.tailCap).textContent = `${state.tailCap}x`;
+        document.getElementById(valIds.mgmtFee).textContent = `${state.mgmtFee.toFixed(1)}%`;
+        document.getElementById(valIds.carry).textContent = `${state.carry}%`;
+        document.getElementById(valIds.life).textContent = state.life;
+        document.getElementById(valIds.trials).textContent = state.trials.toLocaleString();
+
+        // Derived: initial check size
+        const reserves01 = state.reserves / 100;
+        const initialCheck = state.fundSize * (1 - reserves01) / state.N;
+        document.getElementById(valIds.checkSize).textContent = fmtCheck(initialCheck);
+
+        // Derived: E[per-co multiple]
+        const ev = meanPerCompany(state.lossRate / 100, state.alpha, state.tailCap);
+        document.getElementById(valIds.evMultiple).textContent = fmtMultiple(ev, 2);
+    }
+
+    function refreshKPIs(result) {
+        const mean = result.mean;
+        const q = result.quantiles;
+        document.getElementById('kpi-mean').textContent = fmtMultiple(mean);
+        document.getElementById('kpi-p50').textContent = fmtMultiple(q.p50);
+        document.getElementById('kpi-p3x').textContent = fmtPct(result.pAbove3x, 0);
+        document.getElementById('kpi-p5x').textContent = fmtPct(result.pAbove5x, 0);
+        document.getElementById('kpi-ploss').textContent = fmtPct(pLoss(result.tvpis), 0);
+        document.getElementById('kpi-time').textContent = `${result.timeMs.toFixed(0)} ms`;
+
+        // Sources
+        document.getElementById('src-top1').textContent = fmtPct(result.avgTop1Share, 0);
+        document.getElementById('src-top3').textContent = fmtPct(result.avgTop3Share, 0);
+        document.getElementById('src-top10').textContent = fmtPct(result.avgTop10Share, 0);
+        document.getElementById('src-notop').textContent = fmtMultiple(result.avgTVPINoTop);
+
+        // Trial count label
+        document.getElementById('hist-trial-count').textContent = state.trials.toLocaleString();
+    }
+
+    function rerun() {
+        refreshLabels();
+        const result = runSimulation(state);
+        lastResult = result;
+        refreshKPIs(result);
+        renderHistogram(result);
+        updateHash();
+    }
+
+    function scheduleRerun() {
+        if (renderTimer) clearTimeout(renderTimer);
+        renderTimer = setTimeout(rerun, 80);
+    }
+
+    function applyPreset(name) {
+        if (name === 'custom' || !PRESETS[name]) return;
+        state = { ...DEFAULTS, ...PRESETS[name] };
+        writeStateToControls();
+        rerun();
+    }
+
+    function setActiveChip(name) {
+        document.querySelectorAll('.preset-chip').forEach(el => {
+            el.classList.toggle('active', el.dataset.preset === name);
+        });
+    }
+
+    function detectActivePreset() {
+        // Match state against known presets (lossless for the values we track)
+        for (const [name, preset] of Object.entries(PRESETS)) {
+            if (!preset) continue;
+            let match = true;
+            for (const k of Object.keys(preset)) {
+                if (state[k] !== preset[k]) { match = false; break; }
+            }
+            if (match) return name;
+        }
+        return 'custom';
+    }
+
+    function bindControls() {
+        // Range and select inputs
+        Object.values(ctlIds).forEach(id => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const evt = el.tagName === 'SELECT' ? 'change' : 'input';
+            el.addEventListener(evt, () => {
+                readControlsToState();
+                setActiveChip(detectActivePreset());
+                refreshLabels();
+                scheduleRerun();
+            });
+        });
+
+        // Preset chips
+        document.querySelectorAll('.preset-chip').forEach(chip => {
+            chip.addEventListener('click', () => {
+                const name = chip.dataset.preset;
+                if (name === 'custom') {
+                    setActiveChip('custom');
+                    return;
+                }
+                applyPreset(name);
+                setActiveChip(name);
+            });
+        });
+
+        // Buttons
+        document.getElementById('btn-rerun').addEventListener('click', rerun);
+        document.getElementById('btn-reset').addEventListener('click', () => {
+            applyPreset('seed');
+            setActiveChip('seed');
+            hideScenarioCallout();
+        });
+        document.getElementById('btn-share').addEventListener('click', () => {
+            updateHash();
+            const url = location.href;
+            navigator.clipboard.writeText(url).then(() => {
+                const btn = document.getElementById('btn-share');
+                const orig = btn.textContent;
+                btn.textContent = 'Copied!';
+                setTimeout(() => { btn.textContent = orig; }, 1400);
+            }).catch(() => {
+                window.prompt('Copy this URL:', url);
+            });
+        });
+
+        // Scenario dismiss
+        document.getElementById('scenario-dismiss').addEventListener('click', hideScenarioCallout);
+    }
+
+    // ---------- Scenarios ----------
+    function renderScenarioCards() {
+        const grid = document.getElementById('scenarios-grid');
+        grid.innerHTML = SCENARIOS.map(s => `
+            <button class="scenario-card" data-id="${s.id}">
+                <div class="scenario-card-num">SCENARIO ${s.num}</div>
+                <div class="scenario-card-title">${s.title}</div>
+                <div class="scenario-card-tagline">${s.tagline}</div>
+                <div class="scenario-card-cta">Load scenario <span>&rarr;</span></div>
+            </button>
+        `).join('');
+
+        grid.querySelectorAll('.scenario-card').forEach(card => {
+            card.addEventListener('click', () => loadScenario(card.dataset.id));
+        });
+    }
+
+    function showScenarioCallout(scn) {
+        const co = document.getElementById('scenario-callout');
+        document.getElementById('scenario-title').textContent = `${scn.num} · ${scn.title}`;
+        const bodyEl = document.getElementById('scenario-body');
+        if (scn.full && scn.narrative) {
+            bodyEl.innerHTML = scn.narrative.map(p => `<p>${p}</p>`).join('');
+        } else {
+            bodyEl.innerHTML = `<p>${scn.tagline}</p><p style="color: rgba(255,255,255,0.55); font-style: italic;">Full narrative coming soon. Play with the sliders — see what changes.</p>`;
+        }
+        co.classList.remove('hidden');
+    }
+
+    function hideScenarioCallout() {
+        document.getElementById('scenario-callout').classList.add('hidden');
+    }
+
+    function loadScenario(id) {
+        const scn = SCENARIOS.find(s => s.id === id);
+        if (!scn) return;
+        state = { ...DEFAULTS, ...scn.preset };
+        writeStateToControls();
+        setActiveChip(detectActivePreset());
+        showScenarioCallout(scn);
+        rerun();
+        // Scroll to the lab so the user sees the result
+        document.querySelector('.lab-main').scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+
+    // ---------- Tooltip portaling ----------
+    // Tooltips inside the scrolling .lab-controls panel get clipped by its
+    // overflow. On hover/focus, switch the tooltip to position:fixed and
+    // compute coordinates from the trigger's viewport rect. Reset on leave.
+    function positionFloatingTooltip(wrap) {
+        const content = wrap.querySelector(':scope > .tip-content');
+        if (!content) return;
+        const rect = wrap.getBoundingClientRect();
+        const isBelow = content.classList.contains('tip-content--below');
+        content.classList.add('floating');
+        // Measure after switch so we know the tooltip's height.
+        const ttRect = content.getBoundingClientRect();
+        const margin = 10;
+        let top;
+        if (isBelow) {
+            top = rect.bottom + margin;
+        } else {
+            top = rect.top - ttRect.height - margin;
+            if (top < 8) top = rect.bottom + margin; // flip if no room above
+        }
+        // Horizontal: prefer left-aligned with the trigger; clamp to viewport.
+        let left = rect.left;
+        const vw = window.innerWidth;
+        if (left + ttRect.width > vw - 8) left = vw - ttRect.width - 8;
+        if (left < 8) left = 8;
+        content.style.top = top + 'px';
+        content.style.left = left + 'px';
+    }
+    function clearFloatingTooltip(wrap) {
+        const content = wrap.querySelector(':scope > .tip-content');
+        if (!content) return;
+        content.classList.remove('floating');
+        content.style.top = '';
+        content.style.left = '';
+    }
+    function bindTooltipPortals() {
+        document.querySelectorAll('.tip-wrap').forEach(wrap => {
+            wrap.addEventListener('mouseenter', () => positionFloatingTooltip(wrap));
+            wrap.addEventListener('focusin', () => positionFloatingTooltip(wrap));
+            wrap.addEventListener('mouseleave', () => clearFloatingTooltip(wrap));
+            wrap.addEventListener('focusout', () => clearFloatingTooltip(wrap));
+        });
+        // When the controls panel scrolls or the page scrolls, blur any active
+        // tooltip so it doesn't detach from its trigger.
+        const onScroll = () => {
+            document.querySelectorAll('.tip-content.floating').forEach(c => {
+                c.classList.remove('floating');
+                c.style.top = '';
+                c.style.left = '';
+            });
+        };
+        const panel = document.querySelector('.lab-controls');
+        if (panel) panel.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('scroll', onScroll, { passive: true });
+    }
+
+    // ---------- Init ----------
+    function init() {
+        // Apply URL state if present, otherwise seed preset
+        const fromHash = decodeState();
+        if (fromHash) {
+            state = { ...DEFAULTS, ...fromHash };
+        } else {
+            state = { ...DEFAULTS, ...PRESETS.seed };
+        }
+        writeStateToControls();
+        setActiveChip(detectActivePreset());
+        bindControls();
+        renderScenarioCards();
+        bindTooltipPortals();
+        rerun();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/portfolio.html
+++ b/portfolio.html
@@ -50,6 +50,7 @@
                             <div class="nav-dropdown-menu" role="menu">
                                 <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
                                 <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                                <a href="/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
                             </div>
                         </div>
                         <a href="/#team" class="nav-link">TEAM</a>


### PR DESCRIPTION
## Summary

Adds the **Power Law Outlier Lab** — an interactive Monte Carlo simulator for venture fund returns — at `/labs/power-law/`, and links it from the HACKS dropdown on the home and portfolio pages.

The lab lets an LP, GP, or curious operator describe a fund (size, N, reserves, ownership, follow-on strategy, loss rate, tail thickness, tail cap, fees, carry, life) and runs **10,000 simulated versions** of that fund. The histogram shows the full TVPI distribution with p10–p90 quantile markers; a KPI ribbon reports E[TVPI], p50, P(>3x), P(>5x), P(loss); a Sources-of-Return panel breaks down how much of each fund's gross return came from its top 1 / 3 / 10 companies.

## What's in the PR

- `labs/power-law/index.html` — page structure, identical canonical.cc header/footer, hero with plain-English copy and three use-case cards (LP / GP / curious), controls, KPI ribbon, histogram container, Sources panel, scenarios grid, methodology accordion.
- `labs/power-law/lab.css` — controls panel, custom on-brand tooltip system, histogram styling, KPI/Sources cards, scenarios grid, methodology. Reuses `/css/style.css` for header/footer/typography.
- `labs/power-law/lab.js` — Monte Carlo engine (mixture model: Bernoulli loss + truncated Pareto), D3 histogram with animated transitions, control wiring with 80ms debounce, 6 scripted scenarios (2 with full narrative copy, 4 stubs), URL-hash state for shareable links, and a tooltip portal that switches tooltips to `position: fixed` on hover so they escape the controls panel's overflow.
- `index.html` / `portfolio.html` — one new line each: a Power Law Lab entry in the HACKS dropdown.

## Math notes for reviewers

- Per-company outcome = Bernoulli(lossRate) → 0, else truncated Pareto(α, 1, tailCap).
- Sampling: `x = 1 / (1 − U·(1 − tailCap^(−α)))^(1/α)`. Empirical sample mean matches the analytic mean `α/(α−1) · (1 − cap^(1−α))/(1 − cap^(−α))` to ~1% across α ∈ [1.05, 5.0] and cap ∈ [15, 1000] (verified via Node).
- Fund TVPI = (gross return − mgmtFee · life · fundSize), then 20% carry applied to profits above 1.0x; reported net to LP.
- Calibrated presets:
  - Seed: $50M, N=25, 40% reserves, loss 50%, α=1.20, cap 500x → E[TVPI] ~1.7x, p50 ~1.3x, P(>3x) ~10%, P(loss) ~28%
  - Series A: $150M, N=18, 50% reserves, loss 35%, α=1.50, cap 120x → E[TVPI] ~1.5x, p50 ~1.3x
  - Growth: $400M, N=12, 35% reserves, loss 15%, α=1.80, cap 30x → E[TVPI] ~1.5x, p50 ~1.4x

## UX details worth knowing

- Page loads with a running simulation (Seed preset by default) — no "click to start" form.
- Every input AND output has an on-hover tooltip (29 total). Tooltips portal to `position: fixed` via JS so they escape the scrolling controls panel.
- Tail-thickness slider (α) is the most consequential. Mean and median visibly drift apart as α drops — that's the power law working.
- Scenario cards load preset configurations AND surface an opinionated 2-paragraph callout above the histogram. The N-debate and Follow-on math scenarios ship with full copy; the other four are functional with placeholder text.
- URL hash encodes the full parameter set. The "Copy share link" button puts a shareable URL on the clipboard.

## Test plan

- [ ] Visit `/labs/power-law/` and confirm the page loads with a running Seed-preset simulation
- [ ] Move the Tail thickness (α) slider — histogram should redraw with smooth transitions and the gap between E[TVPI] and p50 should widen as α drops
- [ ] Hover any control label, KPI label, Sources label, preset chip, and action button — each should show a styled tooltip explaining the variable
- [ ] Click each preset chip (Seed / Series A / Growth) and confirm the histogram and KPIs change
- [ ] Click a scenario card — it should load a preset, show the opinionated callout above the histogram, and scroll the lab into view
- [ ] Click "Copy share link" — the URL should land on clipboard and pasting into a new tab restores the same scenario
- [ ] Confirm the HACKS dropdown on `/` and `/portfolio` now lists Power Law Lab alongside Dilution Lab and Fund Modeler
- [ ] Resize to mobile (<640px) — controls should stack above the histogram; layout should remain readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)