### PR TITLE
Update @canonicalcrypto to @canonicalcc in meta tags and structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
     <meta property="twitter:title" content="Investing in a post AGI future" />
     <meta property="twitter:description" content="Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed." />
     <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
-    <meta property="twitter:creator" content="@canonicalcrypto" />
-    <meta property="twitter:site" content="@canonicalcrypto" />
+    <meta property="twitter:creator" content="@canonicalcc" />
+    <meta property="twitter:site" content="@canonicalcc" />
     
     <!-- Additional SEO -->
     <meta name="theme-color" content="#1e3a8a" />
@@ -46,7 +46,7 @@
       "url": "https://canonical.cc",
       "logo": "https://canonical.cc/images/site-logo.png",
       "sameAs": [
-        "https://x.com/canonicalcrypto"
+        "https://x.com/canonicalcc"
       ],
       "@id": "https://canonical.cc",
       "foundingDate": "2022",

--- a/labs/power-law/index.html
+++ b/labs/power-law/index.html
@@ -25,8 +25,8 @@
     <meta property="twitter:title" content="Power Law Outlier Lab | Canonical" />
     <meta property="twitter:description" content="An interactive lab for LPs. Manipulate the shape of a venture fund's outcome distribution and see what actually drives fund returns." />
     <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
-    <meta property="twitter:creator" content="@canonicalcrypto" />
-    <meta property="twitter:site" content="@canonicalcrypto" />
+    <meta property="twitter:creator" content="@canonicalcc" />
+    <meta property="twitter:site" content="@canonicalcc" />
 
     <meta name="theme-color" content="#1e3a8a" />
     <link rel="icon" type="image/x-icon" href="https://www.canonical.cc/favicon.ico" />


### PR DESCRIPTION
## Summary
Flips the 5 remaining references to the old X handle:
- `index.html` twitter:creator
- `index.html` twitter:site
- `index.html` schema.org sameAs URL
- `labs/power-law/index.html` twitter:creator
- `labs/power-law/index.html` twitter:site

The footer X link was updated to `canonicalcc` in PR #14; this cleans up the meta tags so X cards and Google's knowledge panel point at the right handle.

## Test plan
- [ ] Validate the cards via https://cards-dev.twitter.com/validator after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)