### PR TITLE
Add Physical AI Capital Flow Map under /labs/physical-ai/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Personal Claude Code state — local-only, not for the repo
+.claude/settings.local.json
+.claude/worktrees/
+.claude/static-server.js
+
+# OS junk
+.DS_Store
+
+# Jekyll local build artifacts
+_site/
+.jekyll-cache/
+.jekyll-metadata
+Gemfile.lock
+.bundle/
+vendor/

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,6 +14,7 @@
                         <a href="https://dilutionlab.canonical.cc" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
                         <a href="https://fundmodeler.canonical.cc" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
                         <a href="https://canonical.cc/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
+                        <a href="https://canonical.cc/labs/physical-ai/" class="nav-dropdown-item" role="menuitem">Physical AI Map</a>
                     </div>
                 </div>
                 <a href="https://canonical.cc/#team" class="nav-link" data-canonical-anchor="team">TEAM</a>

--- a/labs/physical-ai/data.json
+++ b/labs/physical-ai/data.json
@@ -1,0 +1,560 @@
+{
+  "meta": {
+    "version": "0.1",
+    "updated": "2026-05-15",
+    "window": "Q1 2023 - Q1 2026",
+    "sources": ["Harmonic", "Pitchbook Premium", "Crunchbase", "Sacra", "FT", "Reuters", "Bloomberg", "SEC/HKEX/SSE filings", "company press releases", "36Kr", "Caixin"],
+    "notes": "Public market caps are point-in-time snapshots and stale within weeks. Private valuations stick to last-round post-money. Rounds 'in talks' are reported but not closed; flagged explicitly."
+  },
+
+  "scenes": {
+    "valuation_chasm": {
+      "headline": "Four humanoid companies have raised more in 18 months than six entire sub-sectors combined.",
+      "lede": "Figure, Apptronik, Agility, and 1X have together captured more venture and strategic capital in 2024-25 than the entire surgical robotics, agricultural robotics, construction robotics, consumer robotics, exoskeleton, and quadruped industries combined. The chasm exists because humanoids are pricing in 2030 commercial deployment. The adjacent sectors are pricing in 2026 unit economics.",
+      "pov": "The most under-appreciated opportunity in physical AI is surgical robotics. Intuitive's monopoly cracked for the first time in 25 years with Medtronic Hugo and CMR Versius Plus FDA clearance, yet VC dollars are 1/20th of humanoids despite 10x the proven unit economics. The chasm goes both ways.",
+      "headline_bars": [
+        {"name": "Figure AI", "geo": "US", "valuation_m": 39000, "round": "Sep 2025 Series C"},
+        {"name": "1X Technologies", "geo": "NO/US", "valuation_m": 10000, "round": "target, in talks", "flag": "in-talks"},
+        {"name": "Apptronik", "geo": "US", "valuation_m": 5400, "round": "Series A ext Feb 2026", "flag": "estimated"},
+        {"name": "Agility Robotics", "geo": "US", "valuation_m": 2100, "round": "Series C 2025"}
+      ],
+      "tail_bars": [
+        {"name": "Surgical robotics", "value_m": 1500, "note": "global VC, in window"},
+        {"name": "Construction robotics", "value_m": 1400, "note": "global VC, in window"},
+        {"name": "Agricultural robotics", "value_m": 500, "note": "global VC, in window"},
+        {"name": "Quadrupeds", "value_m": 200, "note": "excl. Unitree IPO"},
+        {"name": "Exoskeletons", "value_m": 100, "note": "global VC, in window"},
+        {"name": "Consumer robotics", "value_m": 50, "note": "post iRobot Ch.11"}
+      ],
+      "summary_multiple": "15.6x",
+      "summary_label": "Top 4 humanoid valuations to six-sector sum"
+    },
+
+    "round_velocity": {
+      "headline": "The fastest markups in physical AI are not in humanoids.",
+      "lede": "Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in seven months. That's a 21.9x markup with revenue from production deployments still measured in the millions. Figure's 15x over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.",
+      "pov": "Round velocity above 2x with less than 12 months between rounds is the cleanest bubble signal in physical AI. Most of the top-left quadrant won't have proportional revenue scaling. The exception is Anduril, which is why it's the only defense unicorn with a revenue base that justifies the multiple.",
+      "data_points": [
+        {"company": "Bedrock Robotics", "months_between": 7, "multiple": 21.9, "prev_val_m": 80, "new_val_m": 1750, "category": "bubble", "sub_sector": "construction-robotics"},
+        {"company": "Figure AI", "months_between": 19, "multiple": 15.0, "prev_val_m": 2600, "new_val_m": 39000, "category": "bubble", "sub_sector": "humanoid-robotics"},
+        {"company": "Apptronik", "months_between": 11, "multiple": 3.3, "prev_val_m": 1600, "new_val_m": 5400, "category": "elevated", "sub_sector": "humanoid-robotics"},
+        {"company": "Skild AI", "months_between": 7, "multiple": 3.1, "prev_val_m": 4500, "new_val_m": 14000, "category": "elevated", "sub_sector": "foundation-models-for-robotics"},
+        {"company": "Shield AI", "months_between": 12, "multiple": 2.4, "prev_val_m": 5300, "new_val_m": 12700, "category": "elevated", "sub_sector": "defense-dual-use"},
+        {"company": "Saronic", "months_between": 13, "multiple": 2.3, "prev_val_m": 4000, "new_val_m": 9250, "category": "elevated", "sub_sector": "marine-underwater-robotics"},
+        {"company": "Anduril", "months_between": 11, "multiple": 2.0, "prev_val_m": 30500, "new_val_m": 61000, "category": "justified-by-revenue", "sub_sector": "defense-dual-use"},
+        {"company": "Mind Robotics", "months_between": 2, "multiple": 1.7, "prev_val_m": 2000, "new_val_m": 3400, "category": "elevated", "sub_sector": "industrial-automation"}
+      ]
+    },
+
+    "us_china_flows": {
+      "headline": "US kingmakers underwrite the model. China underwrites the factory.",
+      "lede": "The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10x revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. Two paths to the same physical world, two completely different unit economics.",
+      "caveat": "China shipped ~90% of humanoid units in 2025 but captured ~30% of dollars. And ~75% of those units went to universities and research institutions. Unitree's own IPO prospectus discloses >50% of revenue from the scientific research and education sector. The volume narrative needs a quality flag.",
+      "pov": "Unit volume in China is not yet commercial deployment. The structural advantage is real but the customer base is narrow. Watch for the first Chinese humanoid manufacturer to disclose >50% commercial revenue. That's the inflection.",
+      "us_flows": [
+        {"investors": ["OpenAI"], "company": "1X"},
+        {"investors": ["Microsoft", "Amazon", "OpenAI"], "company": "Figure"},
+        {"investors": ["Google", "Mercedes"], "company": "Apptronik"},
+        {"investors": ["Amazon", "SoftBank", "Nvidia"], "company": "Agility"},
+        {"investors": ["SoftBank", "Nvidia", "Bezos Expeditions"], "company": "Skild"},
+        {"investors": ["CapitalG", "Lux", "Bezos Expeditions"], "company": "Physical Intelligence"},
+        {"investors": ["JPMorgan", "BlackRock", "Bezos"], "company": "Project Prometheus"}
+      ],
+      "us_exit_path": "private mega-rounds, $1K/mo RaaS",
+      "china_flows": [
+        {"investors": ["Alibaba", "Geely"], "company": "Unitree"},
+        {"investors": ["Tencent", "JD.com"], "company": "AgiBot"},
+        {"investors": ["HongShan", "Beijing Robot Fund"], "company": "EngineAI, LimX"},
+        {"investors": ["HK govt", "Geely", "BAIC"], "company": "Galbot, Robot Era"},
+        {"investors": ["CITIC Goldstone"], "company": "Leju"},
+        {"investors": ["Meituan", "Alibaba"], "company": "X Square, Spirit AI"}
+      ],
+      "china_exit_path": "STAR Market, HKEX, A-share"
+    },
+
+    "defense_unicorns": {
+      "headline": "From two unicorns to twenty-two in three years.",
+      "lede": "In 2022, exactly two pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in twelve months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.",
+      "pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is $1.5B equity at $12.7B plus $500M Blackstone fixed-return preferred. The first sign defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble.",
+      "unicorns": [
+        {"name": "Anduril", "first_unicorn_year": 2022, "latest_val_m": 61000, "latest_round": "Series H May 2026", "highlight": true},
+        {"name": "Shield AI", "first_unicorn_year": 2022, "latest_val_m": 12700, "latest_round": "Series G Mar 2026", "structured_note": "$1.5B equity + $500M Blackstone preferred"},
+        {"name": "Saronic", "first_unicorn_year": 2024, "latest_val_m": 9250, "latest_round": "Series D Mar 2026"},
+        {"name": "Helsing", "first_unicorn_year": 2024, "latest_val_m": 18000, "latest_round": "Series D in talks", "flag": "in-talks"},
+        {"name": "CHAOS Industries", "first_unicorn_year": 2025, "latest_val_m": 4500, "latest_round": "Series D Nov 2025"},
+        {"name": "Onebrief", "first_unicorn_year": 2025, "latest_val_m": 1100, "latest_round": "$300M+ cumulative"},
+        {"name": "Castelion", "first_unicorn_year": 2025, "latest_val_m": 1500, "latest_round": "Series B Dec 2025"},
+        {"name": "Hermeus", "first_unicorn_year": 2026, "latest_val_m": 1000, "latest_round": "Series D Apr 2026"},
+        {"name": "True Anomaly", "first_unicorn_year": 2026, "latest_val_m": 2000, "latest_round": "Series C Apr 2026"},
+        {"name": "Forterra", "first_unicorn_year": 2025, "latest_val_m": 1200, "latest_round": "Series C Nov 2025"},
+        {"name": "Quantum Systems", "first_unicorn_year": 2024, "latest_val_m": 1000, "latest_round": "Series C 2024"}
+      ]
+    }
+  },
+
+  "subsectors": [
+    {
+      "id": "humanoid-robotics",
+      "number": "01",
+      "name": "Humanoid Robotics",
+      "layer": "embodiment",
+      "capital_2024_25_m": 5100,
+      "yoy_growth_pct": 169,
+      "deals_count": 26,
+      "geo_split": {"US": 50, "China": 38, "EU": 10, "RoW": 2},
+      "top_companies": [
+        {"name": "Figure AI", "geo": "US", "valuation_m": 39000, "last_round_label": "Series C Sep 2025"},
+        {"name": "Apptronik", "geo": "US", "valuation_m": 5400, "last_round_label": "Series A ext Feb 2026", "flag": "estimated"},
+        {"name": "1X Technologies", "geo": "RoW", "valuation_m": 10000, "last_round_label": "target, in talks", "flag": "in-talks"},
+        {"name": "Agility Robotics", "geo": "US", "valuation_m": 2100, "last_round_label": "Series C 2025"},
+        {"name": "Unitree", "geo": "China", "valuation_m": 6100, "last_round_label": "STAR Market IPO target Mar 2026"},
+        {"name": "AgiBot (Zhiyuan)", "geo": "China", "valuation_m": 2100, "last_round_label": "pre-HK IPO", "flag": "estimated"},
+        {"name": "Fourier", "geo": "China", "valuation_m": 1100, "last_round_label": "2025"},
+        {"name": "Neura Robotics", "geo": "EU", "valuation_m": 1200, "last_round_label": "Series B Jan 2025"},
+        {"name": "Galbot", "geo": "China", "valuation_m": 3000, "last_round_label": "Dec 2025 + Mar 2026"},
+        {"name": "Robot Era", "geo": "China", "valuation_m": 1400, "last_round_label": "Apr 2026"}
+      ],
+      "top_investors": ["Alibaba", "HongShan", "Beijing Robot Industry Dev Fund", "Matrix Partners China", "Tencent", "JD.com", "Meituan", "Nvidia NVentures", "Bezos Expeditions", "SoftBank"],
+      "canonical_pov": "Humanoid funding is concentrated in 4 US companies that have together raised more in 18 months than the entire surgical robotics industry has in its history. The only pure-play humanoid manufacturer with audited profitability at scale is Unitree, and the prospectus reveals their profitability is a 2024-25 turnaround story, not the 'profitable since 2020' narrative their PR has carried. The bear case sits in plain sight: Unitree's R&D-to-revenue ratio is 7.73%, suggesting under-investment in the next platform.",
+      "caveats": ["~75% of 2025 Chinese unit shipments to research institutions per HelloChinaTech", "Unitree prospectus discloses >50% of revenue from scientific research and education sector", "AgiBot valuation $2.1B is estimated, no primary source identified", "1X $10B round reported as 'in talks' not closed"]
+    },
+    {
+      "id": "quadrupeds",
+      "number": "02",
+      "name": "Quadrupeds",
+      "layer": "embodiment",
+      "capital_2024_25_m": 200,
+      "yoy_growth_pct": -10,
+      "deals_count": 6,
+      "geo_split": {"US": 35, "China": 50, "EU": 15, "RoW": 0},
+      "top_companies": [
+        {"name": "Boston Dynamics", "geo": "US", "valuation_m": null, "last_round_label": "Hyundai-owned"},
+        {"name": "ANYbotics", "geo": "EU", "valuation_m": null, "last_round_label": "Series B 2022"},
+        {"name": "Unitree (quadruped legacy)", "geo": "China", "valuation_m": null, "last_round_label": "see Humanoid"},
+        {"name": "Deep Robotics", "geo": "China", "valuation_m": null, "last_round_label": null},
+        {"name": "Ghost Robotics", "geo": "US", "valuation_m": 750, "last_round_label": "$750M LIG Nex1 tender 2024", "flag": "estimated"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "The quadruped market has converged toward defense and utility inspection. Spot and Ghost Vision 60 are now mostly purchased by Pentagon and energy utilities, not consumer or research markets. Unitree retains ~70% of global quadruped sales but is pivoting capital and R&D toward humanoids. The prospectus shows the dramatic revenue mix flip from quadrupeds (65% 2024) to humanoids (51%+ 2025).",
+      "caveats": ["Ghost Robotics $750M LIG Nex1 tender reported but close not independently confirmed", "Boston Dynamics unit and revenue data largely private"]
+    },
+    {
+      "id": "wheeled-warehouse-robots",
+      "number": "03",
+      "name": "Wheeled / Warehouse Robots",
+      "layer": "embodiment",
+      "capital_2024_25_m": 970,
+      "yoy_growth_pct": -48,
+      "deals_count": 70,
+      "geo_split": {"US": 55, "China": 25, "EU": 15, "RoW": 5},
+      "top_companies": [
+        {"name": "Symbotic", "geo": "US", "valuation_m": 38500, "last_round_label": "NASDAQ May 2026", "flag": "public-market-cap"},
+        {"name": "Locus Robotics", "geo": "US", "valuation_m": 2000, "last_round_label": "$438M total"},
+        {"name": "Geek+", "geo": "China", "valuation_m": null, "last_round_label": "late-stage, $545M raised"},
+        {"name": "GreyOrange", "geo": "US", "valuation_m": null, "last_round_label": "$545M cumulative"},
+        {"name": "AutoStore", "geo": "EU", "valuation_m": null, "last_round_label": "Oslo public"},
+        {"name": "Exotec", "geo": "EU", "valuation_m": null, "last_round_label": "Series D 2022"}
+      ],
+      "top_investors": ["ATL Partners", "Insight Partners", "Tiger Global", "BlackRock", "Mithril"],
+      "canonical_pov": "Symbotic vs. Amazon's internal Sequoia/Proteus is the bellwether. Third-party warehouse robotics survives only if Symbotic-style multi-customer scale is preserved. Amazon's automation target (75% by 2033, 600K fewer hires) is the demand-side ceiling for the entire third-party warehouse robotics industry.",
+      "caveats": ["Warehouse VC -48% YoY in 2025 per Tracxn", "Symbotic market cap is public and moves daily"]
+    },
+    {
+      "id": "aerial-drones",
+      "number": "04",
+      "name": "Aerial / Drones",
+      "layer": "embodiment",
+      "capital_2024_25_m": 2000,
+      "yoy_growth_pct": 60,
+      "deals_count": 38,
+      "geo_split": {"US": 60, "China": 10, "EU": 25, "RoW": 5},
+      "top_companies": [
+        {"name": "Skydio", "geo": "US", "valuation_m": 4400, "last_round_label": "Series F Apr 2026"},
+        {"name": "Zipline", "geo": "US", "valuation_m": 7600, "last_round_label": "Jan 2026"},
+        {"name": "Brinc Drones", "geo": "US", "valuation_m": null, "last_round_label": "$75M+ cumulative"},
+        {"name": "Wingtra", "geo": "EU", "valuation_m": null, "last_round_label": null},
+        {"name": "Quantum Systems", "geo": "EU", "valuation_m": 1000, "last_round_label": "Series C 2024"}
+      ],
+      "top_investors": ["Nvidia NVentures", "a16z", "Founders Fund", "Linse Capital"],
+      "canonical_pov": "Skydio's Blue UAS Cleared List plus the Trump Drone Dominance EO creates a regulatory moat against DJI. But Skydio's hardware-only revenue grew 80% while software is ~30% of mix. The moat may be regulatory, not technical.",
+      "caveats": ["Excludes defense-specific drone companies (counted in Defense)", "China drones underrepresented due to DJI dominance and IPO timing"]
+    },
+    {
+      "id": "marine-underwater-robotics",
+      "number": "05",
+      "name": "Marine / Underwater Robotics",
+      "layer": "embodiment",
+      "capital_2024_25_m": 2500,
+      "yoy_growth_pct": 200,
+      "deals_count": 14,
+      "geo_split": {"US": 85, "China": 5, "EU": 10, "RoW": 0},
+      "top_companies": [
+        {"name": "Saronic", "geo": "US", "valuation_m": 9250, "last_round_label": "Series D Mar 2026"},
+        {"name": "Saildrone", "geo": "US", "valuation_m": 600, "last_round_label": "2024"},
+        {"name": "Anduril Dive-LD/XL", "geo": "US", "valuation_m": null, "last_round_label": "DIU Feb 2024"},
+        {"name": "HavocAI", "geo": "US", "valuation_m": null, "last_round_label": null},
+        {"name": "Vatn Systems", "geo": "US", "valuation_m": null, "last_round_label": null}
+      ],
+      "top_investors": ["Kleiner Perkins", "Elad Gil", "a16z", "Lux Capital", "Founders Fund"],
+      "canonical_pov": "Marine autonomy is at the start of a 5-year deployment curve mirroring 2018-2022 aerial. The Navy's Replicator program plus structural US shipyard underproduction creates structural demand the venture market is only beginning to underwrite. Saronic's 320x revenue multiple vs. Saildrone's 14x reflects who investors think wins the procurement narrative.",
+      "caveats": ["Saronic $400M 2025 revenue projection may conflate with $392M multi-year Navy OTA contract value"]
+    },
+    {
+      "id": "surgical-robotics",
+      "number": "06",
+      "name": "Surgical Robotics",
+      "layer": "embodiment",
+      "capital_2024_25_m": 1500,
+      "yoy_growth_pct": 22,
+      "deals_count": 24,
+      "geo_split": {"US": 40, "China": 15, "EU": 40, "RoW": 5},
+      "top_companies": [
+        {"name": "CMR Surgical", "geo": "EU", "valuation_m": null, "last_round_label": "$200M Apr 2025"},
+        {"name": "Distalmotion", "geo": "EU", "valuation_m": null, "last_round_label": "$150M 2023"},
+        {"name": "Moon Surgical", "geo": "US", "valuation_m": null, "last_round_label": "J&J + Nvidia backed"},
+        {"name": "Surgerii", "geo": "China", "valuation_m": null, "last_round_label": "$100M 2025"},
+        {"name": "MMI", "geo": "EU", "valuation_m": null, "last_round_label": null}
+      ],
+      "top_investors": ["J&J JJDC", "Nvidia NVentures", "Cathay Capital"],
+      "canonical_pov": "Surgical robotics is finally seeing Intuitive's monopoly cracked. Medtronic Hugo and CMR Versius Plus in 2025-26 are the first credible US-market soft-tissue competitors in 25 years. But VC dollars are 1/20th of humanoids despite ~10x the proven unit economics. The disconnect is the most underappreciated opportunity in physical AI.",
+      "caveats": []
+    },
+    {
+      "id": "exoskeletons",
+      "number": "07",
+      "name": "Wearable Robotics / Exoskeletons",
+      "layer": "embodiment",
+      "capital_2024_25_m": 100,
+      "yoy_growth_pct": 15,
+      "deals_count": 8,
+      "geo_split": {"US": 30, "China": 5, "EU": 55, "RoW": 10},
+      "top_companies": [
+        {"name": "German Bionic", "geo": "EU", "valuation_m": null, "last_round_label": "Archimedes acq 2026"},
+        {"name": "Wandercraft", "geo": "EU", "valuation_m": null, "last_round_label": "FDA Atalante 2024"},
+        {"name": "Ekso Bionics", "geo": "US", "valuation_m": 42, "last_round_label": "NASDAQ:EKSO", "flag": "public-market-cap"},
+        {"name": "Roam Robotics", "geo": "US", "valuation_m": null, "last_round_label": null}
+      ],
+      "top_investors": ["Mubea", "Hyundai", "Honda"],
+      "canonical_pov": "Exoskeletons remain the most under-capitalized physical AI category relative to the size of the labor-strain TAM. 1/3 of workplace injuries are overexertion. Despite that, the entire global venture pool is smaller than a single Figure round.",
+      "caveats": []
+    },
+    {
+      "id": "industrial-automation",
+      "number": "08",
+      "name": "Industrial / Manufacturing Automation",
+      "layer": "domain",
+      "capital_2024_25_m": 3000,
+      "yoy_growth_pct": 85,
+      "deals_count": 42,
+      "geo_split": {"US": 70, "China": 15, "EU": 12, "RoW": 3},
+      "top_companies": [
+        {"name": "Mind Robotics", "geo": "US", "valuation_m": 3400, "last_round_label": "Series B May 2026"},
+        {"name": "Hadrian", "geo": "US", "valuation_m": null, "last_round_label": "Q4 2025"},
+        {"name": "FieldAI", "geo": "US", "valuation_m": 2000, "last_round_label": "$405M 2025"},
+        {"name": "VulcanForms", "geo": "US", "valuation_m": null, "last_round_label": "$220M 2025"},
+        {"name": "Path Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$300M+ cumulative"},
+        {"name": "Covariant (Amazon acquihire)", "geo": "US", "valuation_m": null, "last_round_label": "Aug 2024"}
+      ],
+      "top_investors": ["Eclipse Ventures", "Kleiner Perkins", "Accel", "a16z", "Khosla Ventures", "CapitalG"],
+      "canonical_pov": "Mind Robotics is the auto-OEM spin-out template. The 'factory floor as proprietary training environment' thesis is now competitive with the Figure/Apptronik humanoid playbook, and arguably better for capital efficiency since the data acquisition cost is embedded in the host's operating business. Watch which other OEMs spin out robotics units. BMW, Mercedes, Ford, Stellantis are all candidates.",
+      "caveats": ["Mind Robotics cumulative $1.015B raised in 6 months may be the fastest scaling in physical AI history"]
+    },
+    {
+      "id": "agricultural-robotics",
+      "number": "09",
+      "name": "Agricultural Robotics",
+      "layer": "domain",
+      "capital_2024_25_m": 500,
+      "yoy_growth_pct": -15,
+      "deals_count": 16,
+      "geo_split": {"US": 65, "China": 5, "EU": 25, "RoW": 5},
+      "top_companies": [
+        {"name": "Monarch Tractor", "geo": "US", "valuation_m": null, "last_round_label": "Caterpillar acq Nov 2025"},
+        {"name": "Carbon Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$70M Series D 2024"},
+        {"name": "Inari", "geo": "US", "valuation_m": null, "last_round_label": "$103M 2024"},
+        {"name": "Burro", "geo": "US", "valuation_m": null, "last_round_label": null},
+        {"name": "Ecorobotix", "geo": "EU", "valuation_m": null, "last_round_label": null}
+      ],
+      "top_investors": ["Caterpillar", "Astanor", "Nvidia NVentures", "DCVC"],
+      "canonical_pov": "Monarch's collapse-and-acquisition by Caterpillar is the morality play. Autonomy claims got too far ahead of field performance, dealer lawsuits exposed the gap, and the legacy OEM scooped the IP at a discount. Expect this pattern repeated for autonomous tractors that overpromise on Level 4 field autonomy.",
+      "caveats": ["Monarch acquisition terms undisclosed"]
+    },
+    {
+      "id": "construction-robotics",
+      "number": "10",
+      "name": "Construction Robotics",
+      "layer": "domain",
+      "capital_2024_25_m": 1400,
+      "yoy_growth_pct": 125,
+      "deals_count": 18,
+      "geo_split": {"US": 80, "China": 5, "EU": 12, "RoW": 3},
+      "top_companies": [
+        {"name": "FieldAI", "geo": "US", "valuation_m": 2000, "last_round_label": "$405M 2025"},
+        {"name": "Bedrock Robotics", "geo": "US", "valuation_m": 1750, "last_round_label": "Series B Feb 2026"},
+        {"name": "Dusty Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$69.3M cumulative"},
+        {"name": "Canvas", "geo": "US", "valuation_m": null, "last_round_label": "drywall robot"},
+        {"name": "Built Robotics", "geo": "US", "valuation_m": null, "last_round_label": "wound down workforce 2024"}
+      ],
+      "top_investors": ["Eclipse Ventures", "CapitalG", "Valor Atreides AI", "8VC", "Khosla", "Emerson Collective"],
+      "canonical_pov": "Construction robotics' boom is actually two mega-rounds (FieldAI $405M, Bedrock $270M) plus steady Series A activity at $27M average. The category is real but not at scale. Investors are pricing earthmoving autonomy at later-stage premiums and installation robotics at Series A risk.",
+      "caveats": []
+    },
+    {
+      "id": "defense-dual-use",
+      "number": "11",
+      "name": "Defense / Dual-Use",
+      "layer": "domain",
+      "capital_2024_25_m": 22000,
+      "yoy_growth_pct": 94,
+      "deals_count": 120,
+      "geo_split": {"US": 75, "China": 0, "EU": 22, "RoW": 3},
+      "top_companies": [
+        {"name": "Anduril", "geo": "US", "valuation_m": 61000, "last_round_label": "Series H May 2026"},
+        {"name": "Shield AI", "geo": "US", "valuation_m": 12700, "last_round_label": "Series G Mar 2026 ($1.5B equity + $500M Blackstone preferred)"},
+        {"name": "Saronic", "geo": "US", "valuation_m": 9250, "last_round_label": "Series D Mar 2026"},
+        {"name": "Helsing", "geo": "EU", "valuation_m": 18000, "last_round_label": "Series D in talks", "flag": "in-talks"},
+        {"name": "CHAOS Industries", "geo": "US", "valuation_m": 4500, "last_round_label": "Series D Nov 2025"},
+        {"name": "Castelion", "geo": "US", "valuation_m": 1500, "last_round_label": "Series B Dec 2025"},
+        {"name": "True Anomaly", "geo": "US", "valuation_m": 2000, "last_round_label": "Apr 2026"},
+        {"name": "Forterra", "geo": "US", "valuation_m": 1200, "last_round_label": "Series C Nov 2025"}
+      ],
+      "top_investors": ["a16z (18 deals)", "Founders Fund", "Eclipse", "General Catalyst", "8VC", "NightDragon", "Lightspeed", "Blackstone (preferred)"],
+      "canonical_pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is the first signal defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble. Anduril is the only defense unicorn with revenue ($2.2B 2025) proportional to its valuation. Most others are pricing in multi-year DoD procurement that hasn't materialized.",
+      "caveats": ["$22B+ figure depends on PitchBook vs Crunchbase methodology", "PitchBook $49.1B 2025 deal-value figure includes debt and structured financing, not pure equity"]
+    },
+    {
+      "id": "healthcare-non-surgical",
+      "number": "12",
+      "name": "Healthcare / Medical (non-surgical)",
+      "layer": "domain",
+      "capital_2024_25_m": 250,
+      "yoy_growth_pct": 10,
+      "deals_count": 12,
+      "geo_split": {"US": 55, "China": 10, "EU": 25, "RoW": 10},
+      "top_companies": [
+        {"name": "Diligent Robotics (Moxi)", "geo": "US", "valuation_m": null, "last_round_label": "Series B"},
+        {"name": "Aethon (TUG)", "geo": "US", "valuation_m": null, "last_round_label": null},
+        {"name": "Cyberdyne", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
+        {"name": "Omnicell (pharmacy)", "geo": "US", "valuation_m": null, "last_round_label": "public"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "The eldercare plus pharmacy robotics opportunity is genuinely larger than humanoids' near-term TAM and almost completely under-funded relative to demographic trajectory. This is Canonical's most defensible contrarian sleeve.",
+      "caveats": []
+    },
+    {
+      "id": "consumer-robotics",
+      "number": "13",
+      "name": "Consumer Robotics",
+      "layer": "domain",
+      "capital_2024_25_m": 50,
+      "yoy_growth_pct": -75,
+      "deals_count": 5,
+      "geo_split": {"US": 30, "China": 60, "EU": 8, "RoW": 2},
+      "top_companies": [
+        {"name": "iRobot", "geo": "US", "valuation_m": null, "last_round_label": "Ch.11 Dec 2025, sold to Shenzhen Picea"},
+        {"name": "Roborock", "geo": "China", "valuation_m": null, "last_round_label": "public"},
+        {"name": "Ecovacs", "geo": "China", "valuation_m": null, "last_round_label": "public"},
+        {"name": "Matic Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$30M Series A"},
+        {"name": "1X NEO", "geo": "RoW", "valuation_m": null, "last_round_label": "see Humanoid"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "Consumer robotics outside of vacuum and lawn-mower is essentially impossible to fund in 2025-26. iRobot's bankruptcy is the cautionary tale, and even 1X is repositioning. The category is moving to 'consumer humanoids' but that's a 2028+ TAM.",
+      "caveats": []
+    },
+    {
+      "id": "mobility-av",
+      "number": "14",
+      "name": "Mobility / Autonomous Vehicles",
+      "layer": "domain",
+      "capital_2024_25_m": 28000,
+      "yoy_growth_pct": 340,
+      "deals_count": 34,
+      "geo_split": {"US": 70, "China": 20, "EU": 10, "RoW": 0},
+      "top_companies": [
+        {"name": "Waymo", "geo": "US", "valuation_m": 126000, "last_round_label": "Series D Feb 2026"},
+        {"name": "Wayve", "geo": "EU", "valuation_m": 8600, "last_round_label": "Series D Feb 2026"},
+        {"name": "Pony.ai", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Fall 2024", "flag": "public-market-cap"},
+        {"name": "WeRide", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Fall 2024", "flag": "public-market-cap"},
+        {"name": "Applied Intuition", "geo": "US", "valuation_m": 15000, "last_round_label": "Series F Jun 2025"},
+        {"name": "Aurora Innovation", "geo": "US", "valuation_m": null, "last_round_label": "Nasdaq", "flag": "public-market-cap"},
+        {"name": "Nuro", "geo": "US", "valuation_m": 600, "last_round_label": "Series E 2024"},
+        {"name": "Waabi", "geo": "US", "valuation_m": 750, "last_round_label": "Series C Khosla-led"}
+      ],
+      "top_investors": ["Alphabet", "Dragoneer", "DST Global", "Sequoia", "Eclipse Ventures", "Khosla Ventures"],
+      "canonical_pov": "AV's recovery is real but is a barbell. Waymo plus Wayve at one end, Chinese pre-IPO bridges at the other, and almost nothing in the middle. The bubble didn't reflate uniformly. It bifurcated. Trucking AV (Waabi, Kodiak) is the underweighted sleeve relative to robotaxi attention.",
+      "caveats": ["Most of the $28B figure is Waymo's $16B February 2026 raise", "Cruise wound down Dec 2024 after $10B+ cumulative losses, the largest single AV writedown"]
+    },
+    {
+      "id": "hardware-actuation",
+      "number": "15",
+      "name": "Hardware / Actuation / Motors",
+      "layer": "stack",
+      "capital_2024_25_m": 50,
+      "yoy_growth_pct": null,
+      "deals_count": 4,
+      "geo_split": {"US": 10, "China": 30, "EU": 30, "RoW": 30},
+      "top_companies": [
+        {"name": "Harmonic Drive Systems", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
+        {"name": "Nabtesco", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
+        {"name": "Schaeffler", "geo": "EU", "valuation_m": null, "last_round_label": "Germany public, Neura partner"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "The pick-and-shovel play for humanoids is harmonic drive / strain wave gear and high-torque-density actuators. This layer is dominated by Japanese and German incumbents. Not a single US/EU venture-backed actuator company has reached $100M revenue. Unitree's prospectus discloses they manufacture their own motors, reducers, encoders, and dexterous hands in-house, with purchased parts accounting for only 14-18% of total cost, a vertical-integration playbook the US ecosystem has not replicated.",
+      "caveats": ["Most companies in this layer are public incumbents, not VC-backed"]
+    },
+    {
+      "id": "sensors-perception",
+      "number": "16",
+      "name": "Sensors / Perception",
+      "layer": "stack",
+      "capital_2024_25_m": 0,
+      "yoy_growth_pct": null,
+      "deals_count": 8,
+      "geo_split": {"US": 35, "China": 50, "EU": 15, "RoW": 0},
+      "top_companies": [
+        {"name": "Hesai", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Feb 2023", "flag": "public-market-cap"},
+        {"name": "RoboSense", "geo": "China", "valuation_m": null, "last_round_label": "HKEX Jan 2024", "flag": "public-market-cap"},
+        {"name": "Ouster (post-Stereolabs)", "geo": "US", "valuation_m": 2000, "last_round_label": "$35M + 1.8M shares for Stereolabs Feb 2026", "flag": "public-market-cap"},
+        {"name": "Luminar", "geo": "US", "valuation_m": null, "last_round_label": "Ch.11 late 2025, assets to MicroVision $33M"},
+        {"name": "Prophesee", "geo": "EU", "valuation_m": null, "last_round_label": "$127M cumulative"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "The 'perception' sub-sector is the largest single graveyard of physical AI. Billions raised via SPAC, 80%+ destroyed. But Ouster is the survivor story. From ~$408M (May 2025) to ~$2.2B (May 2026), now repositioned as 'Physical AI's first unified sensing and perception platform' post-Stereolabs acquisition. The lesson for LPs: post-SPAC consolidation produces survivors when management pivots from auto OEM dependence to broader physical AI markets.",
+      "caveats": ["Net VC into sensors/perception is negative on mark-to-market basis when including SPAC destruction", "RoboSense robotics LiDAR sales +1,142% YoY in 2025, structural shift the brief should not miss"]
+    },
+    {
+      "id": "edge-silicon",
+      "number": "17",
+      "name": "Compute / Edge Silicon for Robotics",
+      "layer": "stack",
+      "capital_2024_25_m": 600,
+      "yoy_growth_pct": 20,
+      "deals_count": 8,
+      "geo_split": {"US": 30, "China": 5, "EU": 15, "RoW": 50},
+      "top_companies": [
+        {"name": "Hailo", "geo": "RoW", "valuation_m": 1200, "last_round_label": "Series C ext Apr 2024, reportedly halved in SPAC talks"},
+        {"name": "Tenstorrent", "geo": "US", "valuation_m": 2600, "last_round_label": "Series D Dec 2024"},
+        {"name": "Axelera AI", "geo": "EU", "valuation_m": null, "last_round_label": "$68M Series B Jun 2024"},
+        {"name": "Nvidia Jetson Thor", "geo": "US", "valuation_m": null, "last_round_label": "Aug 2025 launch, $3,499"},
+        {"name": "Rebellions", "geo": "RoW", "valuation_m": 2300, "last_round_label": "Korea pre-IPO Mar 2026"}
+      ],
+      "top_investors": ["SoftBank", "Samsung", "Bezos Expeditions"],
+      "canonical_pov": "'Edge silicon for robotics' as a venture category is largely a marketing label. Hailo and Axelera are the only pure-plays with robotics as a stated focus, and Hailo just had to pivot to robotics from a stalled automotive narrative. The real 'edge silicon for robotics' company is Nvidia, with Jetson Thor capturing >70% mind share of humanoid OEMs.",
+      "caveats": ["Hailo SPAC discussions ongoing, valuation may have halved"]
+    },
+    {
+      "id": "foundation-models-for-robotics",
+      "number": "18",
+      "name": "Foundation Models for Robotics",
+      "layer": "stack",
+      "capital_2024_25_m": 3500,
+      "yoy_growth_pct": 450,
+      "deals_count": 12,
+      "geo_split": {"US": 75, "China": 5, "EU": 15, "RoW": 5},
+      "top_companies": [
+        {"name": "Skild AI", "geo": "US", "valuation_m": 14000, "last_round_label": "Jan 2026 (was $4.5B summer 2025)"},
+        {"name": "Physical Intelligence", "geo": "US", "valuation_m": 5600, "last_round_label": "Series B Nov 2025, $11B reportedly in talks", "flag": "in-talks"},
+        {"name": "Project Prometheus", "geo": "US", "valuation_m": 38000, "last_round_label": "$6.2B initial Nov 2025, $10B at $38B in talks per FT", "flag": "in-talks"},
+        {"name": "Wayve", "geo": "EU", "valuation_m": 8600, "last_round_label": "Series D Feb 2026, see also AV"},
+        {"name": "Covariant", "geo": "US", "valuation_m": null, "last_round_label": "Amazon acquihire Aug 2024"},
+        {"name": "World Labs (Fei-Fei Li)", "geo": "US", "valuation_m": 1000, "last_round_label": "$230M+ at $1B+ 2024"},
+        {"name": "Dyna Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$120M Series A Sep 2025"}
+      ],
+      "top_investors": ["SoftBank", "CapitalG", "Lux Capital", "Bezos Expeditions", "Nvidia NVentures", "JPMorgan", "BlackRock"],
+      "canonical_pov": "Foundation models for robotics collapsed onto 4 names in 18 months: PI, Skild, Wayve, Project Prometheus. Bezos personally betting $6.2B+ on Prometheus while also leading PI's prior round is the clearest signal of where the apex of physical AI capital is going. The category will likely consolidate to 2-3 winners by 2027.",
+      "caveats": ["Project Prometheus $10B/$38B round reported by FT but not closed", "PI $11B round reported by Bloomberg/TC but not closed"]
+    },
+    {
+      "id": "simulation-synthetic-data",
+      "number": "19",
+      "name": "Simulation / Synthetic Data",
+      "layer": "stack",
+      "capital_2024_25_m": 1500,
+      "yoy_growth_pct": 45,
+      "deals_count": 9,
+      "geo_split": {"US": 70, "China": 5, "EU": 15, "RoW": 10},
+      "top_companies": [
+        {"name": "Applied Intuition", "geo": "US", "valuation_m": 15000, "last_round_label": "Series F Jun 2025, $830M ARR 2025"},
+        {"name": "Foretellix", "geo": "RoW", "valuation_m": null, "last_round_label": "$135M cumulative, layoffs Jan 2026"},
+        {"name": "Nvidia Omniverse + Cosmos", "geo": "US", "valuation_m": null, "last_round_label": "platform, not a company"},
+        {"name": "Parallel Domain", "geo": "US", "valuation_m": null, "last_round_label": "merged with Foretellix Nov 2025"},
+        {"name": "Cognata", "geo": "RoW", "valuation_m": null, "last_round_label": "$23.5M, pivot to defense"}
+      ],
+      "top_investors": ["Lux Capital", "Eclipse"],
+      "canonical_pov": "The simulation layer is where Nvidia's gravitational pull is most absolute. Every named humanoid, AV, and FM company uses Cosmos or Isaac Sim. Applied Intuition is the only company that has built a credible non-Nvidia franchise at $830M ARR. The Nvidia question is whether competitive simulation can survive Cosmos becoming free.",
+      "caveats": []
+    },
+    {
+      "id": "fleet-ops-middleware",
+      "number": "20",
+      "name": "Fleet Ops / Robotics Middleware",
+      "layer": "stack",
+      "capital_2024_25_m": 120,
+      "yoy_growth_pct": 30,
+      "deals_count": 6,
+      "geo_split": {"US": 90, "China": 0, "EU": 10, "RoW": 0},
+      "top_companies": [
+        {"name": "Foxglove", "geo": "US", "valuation_m": null, "last_round_label": "$40M Series B Nov 2025, Bessemer-led"},
+        {"name": "Formant", "geo": "US", "valuation_m": null, "last_round_label": "$21M Oct 2023"},
+        {"name": "Intrinsic", "geo": "US", "valuation_m": null, "last_round_label": "Alphabet, folded into Google Feb 2026"},
+        {"name": "Roboflow", "geo": "US", "valuation_m": null, "last_round_label": "$40M Series B Aug 2024"}
+      ],
+      "top_investors": ["Bessemer Venture Partners", "BMW i Ventures"],
+      "canonical_pov": "Robotics middleware as a venture category is small. Foxglove's $58M cumulative is the high water mark. But it's strategically central. Foxglove's MCAP becoming the ROS 2 + Isaac standard makes it the GitHub of robot data. The category has a standard-setting winner emerging.",
+      "caveats": []
+    },
+    {
+      "id": "teleoperation-data-collection",
+      "number": "21",
+      "name": "Teleoperation & Data Collection",
+      "layer": "stack",
+      "capital_2024_25_m": 350,
+      "yoy_growth_pct": 200,
+      "deals_count": 8,
+      "geo_split": {"US": 40, "China": 55, "EU": 5, "RoW": 0},
+      "top_companies": [
+        {"name": "Dexterity", "geo": "US", "valuation_m": 1650, "last_round_label": "Series C-equiv Mar 2025"},
+        {"name": "Reflex Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$7M seed Mar 2024"},
+        {"name": "Sanctuary AI", "geo": "US", "valuation_m": null, "last_round_label": "$148.6M cumulative, restructuring"},
+        {"name": "AgiBot Pudong Data Center", "geo": "China", "valuation_m": null, "last_round_label": "3000sqm, ~100 robots, 30-50K data points/day"},
+        {"name": "Beijing X-Humanoid (NLJIC)", "geo": "China", "valuation_m": null, "last_round_label": "2000sqm, 133 humanoids across 13 models"}
+      ],
+      "top_investors": ["Lightspeed", "Khosla Ventures", "state-backed China funds"],
+      "canonical_pov": "Data collection is the most under-tracked and arguably most important physical AI category. China is building national humanoid data farms (395 humanoids across 9 national training facilities with 300 companies sharing standardized data) while the US relies on private RaaS data plus Scale AI. This is where China's structural advantage is widest and least visible to LPs.",
+      "caveats": []
+    },
+    {
+      "id": "safety-verification",
+      "number": "22",
+      "name": "Safety / Verification / Regulatory Tech",
+      "layer": "stack",
+      "capital_2024_25_m": 60,
+      "yoy_growth_pct": 5,
+      "deals_count": 4,
+      "geo_split": {"US": 50, "China": 0, "EU": 35, "RoW": 15},
+      "top_companies": [
+        {"name": "Foretellix", "geo": "RoW", "valuation_m": null, "last_round_label": "see Simulation"},
+        {"name": "Edge Case Research", "geo": "US", "valuation_m": null, "last_round_label": null},
+        {"name": "Inverted AI", "geo": "US", "valuation_m": null, "last_round_label": "predictive human behavior, Foretellix partner"},
+        {"name": "Monolith AI", "geo": "EU", "valuation_m": null, "last_round_label": "Coreweave-acquired Oct 2025"}
+      ],
+      "top_investors": [],
+      "canonical_pov": "Safety/verification is a category in search of a regulatory forcing function. UNECE virtual-validation mandates are the canary. Until then it's a sub-component of simulation.",
+      "caveats": []
+    }
+  ],
+
+  "adjacencies": {
+    "description": "Categories not core to physical AI but adjacent and frequently confused with it. Flagged so the taxonomy stays disciplined.",
+    "scientific_industrial_ai": {
+      "name": "Scientific & Laboratory Robotics / Industrial AI",
+      "companies": ["Project Prometheus", "Periodic Labs", "Thinking Machines Lab"],
+      "note": "Not embodied robotics but competes for the same capital pool. Project Prometheus alone is $6.2B+ raised."
+    },
+    "digital_agents": {
+      "name": "Digital Agents (Not Embodied)",
+      "companies": ["Manus (Meta acq blocked by NDRC Apr 2026)", "Recursive Superintelligence ($650M May 2026)"],
+      "note": "Pitched alongside physical AI but disembodied. Flag clearly to avoid taxonomy drift."
+    }
+  }
+}

--- a/labs/physical-ai/index.html
+++ b/labs/physical-ai/index.html
@@ -1,0 +1,338 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Physical AI Capital Flow Map | Canonical</title>
+    <meta name="description" content="Three years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged. Built by Canonical to surface where capital is actually flowing." />
+    <meta name="author" content="Canonical" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://canonical.cc/labs/physical-ai/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://canonical.cc/labs/physical-ai/" />
+    <meta property="og:title" content="Physical AI Capital Flow Map | Canonical" />
+    <meta property="og:description" content="Three years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged separately." />
+    <meta property="og:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="og:site_name" content="Canonical" />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://canonical.cc/labs/physical-ai/" />
+    <meta property="twitter:title" content="Physical AI Capital Flow Map | Canonical" />
+    <meta property="twitter:description" content="Where venture capital is actually flowing in physical AI. 22 sub-sectors. Q1 2023 to Q1 2026." />
+    <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="twitter:creator" content="@canonicalcrypto" />
+    <meta property="twitter:site" content="@canonicalcrypto" />
+
+    <meta name="theme-color" content="#1e3a8a" />
+    <link rel="icon" type="image/x-icon" href="https://www.canonical.cc/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://canonical.cc/css/style.css?v=20260514f">
+    <link rel="stylesheet" href="lab.css?v=1">
+</head>
+<body>
+    <div class="min-h-screen">
+        {% include header.html active="hacks" %}
+
+        <main>
+            <!-- HERO -->
+            <section class="pai-hero" id="map">
+                <div class="container mx-auto px-8">
+                    <div class="pai-hero-content">
+                        <span class="pai-eyebrow">[00] &nbsp; Canonical Labs &middot; Physical AI Capital Flow Map</span>
+                        <h1 class="pai-title">Where the capital is <em>actually</em> flowing in physical AI.</h1>
+                        <p class="pai-subtitle">
+                            3 years of venture investment, 22 sub-sectors, global coverage. Built by Canonical to surface real concentration, hype, and where the market is underweight relative to <span class="pai-term" data-term="tam" tabindex="0">TAM</span>.
+                        </p>
+                        <div class="pai-meta">
+                            <div class="pai-meta-item"><span class="pai-meta-key">Window</span><span class="pai-meta-val">Q1 2023 &rarr; Q1 2026</span></div>
+                            <div class="pai-meta-item"><span class="pai-meta-key">Geography</span><span class="pai-meta-val">Global, China flagged</span></div>
+                            <div class="pai-meta-item"><span class="pai-meta-key">Sources</span><span class="pai-meta-val">Harmonic &middot; Pitchbook &middot; Crunchbase &middot; primary filings</span></div>
+                            <div class="pai-meta-item"><span class="pai-meta-key">Updated</span><span class="pai-meta-val" id="pai-updated">May 15, 2026</span></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- TL;DR strip -->
+            <section class="pai-tldr">
+                <div class="container mx-auto px-8">
+                    <div class="pai-tldr-intro">The state of physical AI in four numbers. Hover each for the source and the calculation behind it.</div>
+                    <div class="pai-tldr-grid">
+                        <div class="pai-tldr-item" data-explain="tldr-total" tabindex="0">
+                            <div class="pai-stat">$40.7<span class="pai-stat-unit">B</span></div>
+                            <div class="pai-tldr-label"><strong>Total robotics VC</strong> in 2025 (CB Insights). Range $27.6&ndash;40.7B depending on category cut.</div>
+                        </div>
+                        <div class="pai-tldr-item" data-explain="tldr-concentration" tabindex="0">
+                            <div class="pai-stat">~80<span class="pai-stat-unit">%</span></div>
+                            <div class="pai-tldr-label"><strong>Capital concentration</strong> in four super-categories: humanoids, defense, AV, foundation models.</div>
+                        </div>
+                        <div class="pai-tldr-item" data-explain="tldr-defense" tabindex="0">
+                            <div class="pai-stat">2 &rarr; 22</div>
+                            <div class="pai-tldr-label"><strong>Defense unicorns</strong> over three years. Anduril alone now at $61B post Series H.</div>
+                        </div>
+                        <div class="pai-tldr-item" data-explain="tldr-chasm" tabindex="0">
+                            <div class="pai-stat">$56<span class="pai-stat-unit">B+</span></div>
+                            <div class="pai-tldr-label"><strong>Top 4 humanoid valuations</strong> exceed six adjacent sub-sectors combined. The chasm is real.</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Sub-nav (scroll-spy) -->
+            <div class="pai-subnav" id="pai-subnav">
+                <div class="container mx-auto px-8">
+                    <ul class="pai-subnav-list">
+                        <li><a href="#map" data-spy="map">Map</a></li>
+                        <li><a href="#scene-1" data-spy="scene-1">Chasm</a></li>
+                        <li><a href="#scene-2" data-spy="scene-2">Velocity</a></li>
+                        <li><a href="#scene-3" data-spy="scene-3">US &amp; China</a></li>
+                        <li><a href="#scene-4" data-spy="scene-4">Defense</a></li>
+                        <li><a href="#explorer" data-spy="explorer">Explorer</a></li>
+                        <li><a href="#methodology" data-spy="methodology">Methodology</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- SCENE 1: VALUATION CHASM -->
+            <section class="pai-scene" id="scene-1">
+                <div class="container mx-auto px-8">
+                    <div class="pai-scene-grid">
+                        <div class="pai-scene-text">
+                            <div class="pai-section-label"><span class="pai-section-num">[01]</span> The Valuation Chasm</div>
+                            <h2 class="pai-scene-h2">Four humanoid companies have raised more in 18 months than <em>six entire sub-sectors</em> combined.</h2>
+                            <p class="pai-lede">
+                                Figure, Apptronik, Agility, and 1X have together captured more venture and strategic capital in 2024&ndash;25 than the entire surgical robotics, agricultural robotics, construction robotics, consumer robotics, exoskeleton, and quadruped industries, combined. The chasm exists because humanoids are pricing in 2030 commercial deployment. The adjacent sectors are pricing in 2026 unit economics.
+                            </p>
+                            <div class="pai-pov">
+                                <div class="pai-pov-label">Canonical POV</div>
+                                <p>The most under-appreciated opportunity in physical AI is surgical robotics. Intuitive's monopoly cracked for the first time in 25 years with Medtronic Hugo and CMR Versius Plus FDA clearance, yet VC dollars are 1/20th of humanoids despite 10x the proven unit economics. The chasm goes both ways.</p>
+                            </div>
+                        </div>
+                        <div class="pai-viz" id="viz-chasm">
+                            <div class="pai-viz-title">
+                                <span>Cumulative valuation marks &middot; 2024&ndash;2026</span>
+                                <span class="pai-viz-source">$B post-money</span>
+                            </div>
+                            <div class="pai-chasm-bars" id="chasm-bars"></div>
+                            <div class="pai-chasm-summary">
+                                <strong>15.6&times;</strong> <span>Top 4 humanoid valuations to six-sector sum</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SCENE 2: ROUND VELOCITY -->
+            <section class="pai-scene" id="scene-2">
+                <div class="container mx-auto px-8">
+                    <div class="pai-scene-grid pai-flip">
+                        <div class="pai-viz" id="viz-velocity">
+                            <div class="pai-viz-title">
+                                <span>Round velocity &middot; months between rounds vs. valuation multiple</span>
+                                <span class="pai-viz-source">latest closed rounds</span>
+                            </div>
+                            <div class="pai-velocity" id="velocity-chart"></div>
+                            <div class="pai-velocity-fallback" id="velocity-fallback"></div>
+                            <div class="pai-velocity-legend">
+                                <span class="pai-dot pai-dot-bubble"></span> Bubble zone: &lt;12mo, &gt;3&times;
+                                <span class="pai-dot pai-dot-elevated"></span> Elevated
+                                <span class="pai-dot pai-dot-justified"></span> Justified by revenue
+                            </div>
+                        </div>
+                        <div class="pai-scene-text">
+                            <div class="pai-section-label"><span class="pai-section-num">[02]</span> Round Velocity</div>
+                            <h2 class="pai-scene-h2">The fastest markups in physical AI are <em>not</em> in humanoids.</h2>
+                            <p class="pai-lede">
+                                Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in seven months. That's a 21.9&times; markup with revenue from production deployments still measured in the millions. Figure's 15&times; over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.
+                            </p>
+                            <div class="pai-pov">
+                                <div class="pai-pov-label">Canonical POV</div>
+                                <p>Round velocity above 2&times; with less than 12 months between rounds is the cleanest bubble signal in physical AI. Most of the top-left quadrant won't have proportional revenue scaling. The exception is Anduril, which is why it's the only defense unicorn with a revenue base that justifies the multiple.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SCENE 3: US vs CHINA FLOWS -->
+            <section class="pai-scene" id="scene-3">
+                <div class="container mx-auto px-8">
+                    <div class="pai-scene-grid">
+                        <div class="pai-scene-text">
+                            <div class="pai-section-label"><span class="pai-section-num">[03]</span> Two Capital Ecosystems</div>
+                            <h2 class="pai-scene-h2">US kingmakers underwrite the model. China underwrites the <em>factory</em>.</h2>
+                            <p class="pai-lede">
+                                The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10&times; revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. Two paths to the same physical world, two completely different unit economics.
+                            </p>
+                            <p class="pai-lede pai-lede-small">
+                                Important caveat: China shipped ~90% of humanoid units in 2025 but captured ~30% of dollars. And ~75% of those units went to universities and research institutions. Unitree's own IPO prospectus discloses &gt;50% of revenue from the scientific research and education sector. The volume narrative needs a quality flag.
+                            </p>
+                            <div class="pai-pov">
+                                <div class="pai-pov-label">Canonical POV</div>
+                                <p>Unit volume in China is not yet commercial deployment. The structural advantage is real but the customer base is narrow. Watch for the first Chinese humanoid manufacturer to disclose &gt;50% commercial revenue. That's the inflection.</p>
+                            </div>
+                        </div>
+                        <div class="pai-flow-pair">
+                            <div class="pai-flow-panel pai-flow-us">
+                                <div class="pai-flow-head">[03A] &nbsp; US Kingmakers</div>
+                                <div class="pai-flow-title">Strategic capital underwrites RaaS exits</div>
+                                <div class="pai-flow-rows" id="flow-us"></div>
+                                <div class="pai-flow-exit">Exit path &rarr; <strong>private mega-rounds &middot; $1K/mo RaaS</strong></div>
+                            </div>
+                            <div class="pai-flow-panel pai-flow-china">
+                                <div class="pai-flow-head">[03B] &nbsp; China IPO Rush</div>
+                                <div class="pai-flow-title">Strategic + state capital underwrites public listings</div>
+                                <div class="pai-flow-rows" id="flow-china"></div>
+                                <div class="pai-flow-exit">Exit path &rarr; <strong>STAR Market &middot; HKEX &middot; A-share</strong></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SCENE 4: DEFENSE UNICORNS -->
+            <section class="pai-scene" id="scene-4">
+                <div class="container mx-auto px-8">
+                    <div class="pai-scene-grid pai-flip">
+                        <div class="pai-viz" id="viz-defense">
+                            <div class="pai-viz-title">
+                                <span>Defense unicorn formation &middot; 2022&ndash;2026</span>
+                                <span class="pai-viz-source">first crossing $1B valuation</span>
+                            </div>
+                            <div class="pai-defense-chart" id="defense-chart"></div>
+                        </div>
+                        <div class="pai-scene-text">
+                            <div class="pai-section-label"><span class="pai-section-num">[04]</span> Defense Autonomy</div>
+                            <h2 class="pai-scene-h2">From two unicorns to twenty-two <em>in three years</em>.</h2>
+                            <p class="pai-lede">
+                                In 2022, exactly two pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in twelve months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.
+                            </p>
+                            <div class="pai-pov">
+                                <div class="pai-pov-label">Canonical POV</div>
+                                <p>The most under-examined story is the capital structure. Shield AI's March 2026 round is $1.5B equity at $12.7B plus $500M Blackstone fixed-return preferred. The first sign defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- EXPLORER -->
+            <section class="pai-explorer-section" id="explorer">
+                <div class="container mx-auto px-8">
+                    <div class="pai-section-label"><span class="pai-section-num">[05]</span> Sub-sector Explorer</div>
+                    <h2 class="pai-scene-h2 pai-h2-explorer">Click into any of the <em>22 sub-sectors</em> for top companies, totals, and active investors.</h2>
+                    <p class="pai-explorer-intro">Filter by stack layer, geography, or sort by capital deployed. Every sub-sector has a Canonical POV blurb and a data-caveat flag.</p>
+
+                    <div class="pai-explorer-bar">
+                        <div class="pai-filter-group">
+                            <span class="pai-filter-label" data-term="layer" tabindex="0">Layer</span>
+                            <div class="pai-chip-row" data-filter="layer">
+                                <button class="pai-chip active" data-value="all" data-explain="all-layers">All</button>
+                                <button class="pai-chip" data-value="embodiment" data-explain="layer-embodiment">Embodiment</button>
+                                <button class="pai-chip" data-value="domain" data-explain="layer-domain">Domain</button>
+                                <button class="pai-chip" data-value="stack" data-explain="layer-stack">Stack</button>
+                            </div>
+                        </div>
+                        <div class="pai-filter-group">
+                            <span class="pai-filter-label" data-term="geo" tabindex="0">Geography</span>
+                            <div class="pai-chip-row" data-filter="geo">
+                                <button class="pai-chip active" data-value="global" data-explain="geo-global">Global</button>
+                                <button class="pai-chip" data-value="US" data-explain="geo-us">US</button>
+                                <button class="pai-chip" data-value="China" data-explain="geo-china">China</button>
+                                <button class="pai-chip" data-value="EU" data-explain="geo-eu">EU</button>
+                            </div>
+                        </div>
+                        <div class="pai-filter-group">
+                            <span class="pai-filter-label" data-term="sort" tabindex="0">Sort</span>
+                            <div class="pai-chip-row" data-filter="sort">
+                                <button class="pai-chip active" data-value="capital" data-explain="sort-capital">Capital</button>
+                                <button class="pai-chip" data-value="yoy" data-explain="sort-yoy">YoY</button>
+                                <button class="pai-chip" data-value="deals" data-explain="sort-deals">Deals</button>
+                            </div>
+                        </div>
+                        <div class="pai-filter-meta" id="filter-meta"></div>
+                    </div>
+                    <p class="pai-explorer-hint">Tip: hover any chip for what it filters. Click any card for the full company list, investor lineup, geographic split, and Canonical's POV plus the caveats behind the headline number.</p>
+
+                    <div class="pai-grid" id="sector-grid"></div>
+                </div>
+            </section>
+
+            <!-- METHODOLOGY -->
+            <section class="pai-method-section" id="methodology">
+                <div class="container mx-auto px-8">
+                    <div class="pai-section-label"><span class="pai-section-num">[06]</span> Methodology</div>
+                    <h2 class="pai-scene-h2 pai-h2-method">How this <em>was built</em>, and where the data is weakest.</h2>
+                    <div class="pai-method-grid">
+                        <div class="pai-method-col">
+                            <h3>Sources &amp; approach</h3>
+                            <ul class="pai-method-list">
+                                <li><span class="pai-method-k">Sources</span><span class="pai-method-v">Harmonic, Pitchbook Premium, Crunchbase, FT, Reuters, Bloomberg, SEC and HKEX/SSE filings, Sacra, primary company press releases, 36Kr, Caixin.</span></li>
+                                <li><span class="pai-method-k">Window</span><span class="pai-method-v">Q1 2023 through Q1 2026. Public market caps updated weekly; private rounds version-stamped at last close.</span></li>
+                                <li><span class="pai-method-k">Taxonomy</span><span class="pai-method-v">22 sub-sectors across embodiment / domain / stack layers. Multi-tagging supported. Canonical's framework, refined with each release.</span></li>
+                                <li><span class="pai-method-k">Refresh</span><span class="pai-method-v">Quarterly with running corrections. Subscribe for the next update.</span></li>
+                            </ul>
+                        </div>
+                        <div class="pai-method-col">
+                            <h3>Known limitations</h3>
+                            <ul class="pai-method-list">
+                                <li><span class="pai-method-k">Total VC '25</span><span class="pai-method-v">Reported at $27.6B (PitchBook) to $40.7B (CB Insights). We show the range. Methodology cuts diverge on what counts.</span></li>
+                                <li><span class="pai-method-k">China data</span><span class="pai-method-v">Unit-share figures (Omdia, Counterpoint) and revenue mix (HelloChinaTech) use different methodologies. We flag both.</span></li>
+                                <li><span class="pai-method-k">Rounds in talks</span><span class="pai-method-v">Several 2026 rounds (PI $11B, Helsing $18B, Project Prometheus $10B) are reported but not confirmed closed. Tagged accordingly.</span></li>
+                                <li><span class="pai-method-k">Coverage gaps</span><span class="pai-method-v">Stealth companies and unannounced rounds are by definition absent. Spot one missing? <a href="mailto:hello@canonical.cc?subject=Physical%20AI%20Map%20-%20coverage%20gap">Tell us.</a></span></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- CTA -->
+            <section class="pai-cta">
+                <div class="container mx-auto px-8">
+                    <div class="pai-cta-grid">
+                        <div>
+                            <div class="pai-section-label pai-section-label-light"><span class="pai-section-num">[07]</span> Talk to Canonical</div>
+                            <h2 class="pai-cta-h2">If you're building or investing in the <em>picks-and-shovels</em> of physical AI, we want to hear from you.</h2>
+                            <p class="pai-cta-p">Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed, pre-product friendly.</p>
+                        </div>
+                        <div class="pai-cta-actions">
+                            <a href="mailto:hello@canonical.cc?subject=Building%20in%20physical%20AI" class="pai-btn"><span>I'm building &rarr; pitch us</span><span class="pai-btn-arrow">&rarr;</span></a>
+                            <a href="mailto:hello@canonical.cc?subject=LP%20-%20Canonical%20Fund%20II" class="pai-btn"><span>I'm an LP &rarr; let's talk Fund II</span><span class="pai-btn-arrow">&rarr;</span></a>
+                            <a href="data.json" download="canonical-physical-ai-data.json" class="pai-btn"><span>Download the dataset (JSON)</span><span class="pai-btn-arrow">&darr;</span></a>
+                            <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="pai-btn"><span>Subscribe to quarterly updates</span><span class="pai-btn-arrow">&rarr;</span></a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Footnote disclaimer -->
+            <div class="pai-disclaimer">
+                <div class="container mx-auto px-8">
+                    <p>Built by <a href="https://x.com/ai" target="_blank" rel="noopener noreferrer">Anand Iyer</a> at <a href="https://canonical.cc">Canonical</a> &middot; v0.1 &middot; Educational tool. Not investment advice. Data is point-in-time and not exhaustive.</p>
+                </div>
+            </div>
+        </main>
+
+        {% include footer.html %}
+    </div>
+
+    <!-- Sector detail drawer (hidden until opened) -->
+    <div class="pai-drawer-overlay" id="drawer-overlay" aria-hidden="true"></div>
+    <aside class="pai-drawer" id="drawer" aria-hidden="true" role="dialog" aria-labelledby="drawer-title">
+        <div class="pai-drawer-inner" id="drawer-inner"></div>
+    </aside>
+
+    <!-- Tooltip element used by hero scenes -->
+    <div class="pai-tip" id="pai-tip" role="tooltip" aria-hidden="true"></div>
+
+    <script src="lab.js?v=1"></script>
+</body>
+</html>

--- a/labs/physical-ai/lab.css
+++ b/labs/physical-ai/lab.css
@@ -1,0 +1,1246 @@
+/* Physical AI Capital Flow Map - lab-specific styles
+   Inherits /css/style.css (navy gradient body, fixed header, footer).
+   Adapts the mockup's editorial composition (numbered sections, chasm bars,
+   scatter plot, flow panels, defense timeline, sub-sector grid) to the
+   canonical.cc system: navy gradient background, Aeonik display type,
+   white paper cards with slate ink. */
+
+:root {
+    --pai-navy: #1e3a8a;
+    --pai-navy-deep: #162456;
+    --pai-accent: #f97316;       /* orange-500, brighter for navy bg */
+    --pai-accent-soft: #fdba74;
+    --pai-positive: #34d399;     /* emerald-400 */
+    --pai-negative: #fca5a5;     /* red-300 */
+    --pai-on-navy-faint: rgba(255, 255, 255, 0.55);
+    --pai-on-navy-soft: rgba(255, 255, 255, 0.75);
+    --pai-on-navy-strong: rgba(255, 255, 255, 0.92);
+    --pai-card-bg: #ffffff;
+    --pai-card-bg-2: #fafafa;
+    --pai-ink: #0a0a0a;
+    --pai-ink-soft: #1f2937;     /* slate-800 */
+    --pai-ink-muted: #475569;    /* slate-600 */
+    --pai-ink-faint: #94a3b8;    /* slate-400 */
+    --pai-rule: rgba(15, 23, 42, 0.08);
+    --pai-rule-strong: rgba(15, 23, 42, 0.16);
+    --pai-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ============ TYPOGRAPHY UTILITIES ============ */
+.pai-mono { font-family: var(--pai-mono); }
+
+/* ============ HERO ============ */
+.pai-hero {
+    padding: 8rem 0 3rem;
+    text-align: left;
+}
+
+.pai-hero-content {
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.pai-eyebrow {
+    display: inline-block;
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    color: var(--pai-accent-soft);
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+}
+
+.pai-title {
+    font-size: clamp(2.5rem, 6.5vw, 5.2rem);
+    font-weight: 300;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    color: #ffffff;
+    max-width: 22ch;
+    margin: 0 0 1.5rem;
+}
+
+.pai-title em {
+    font-style: normal;
+    color: var(--pai-accent-soft);
+    font-weight: 400;
+}
+
+.pai-subtitle {
+    font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--pai-on-navy-soft);
+    max-width: 58ch;
+    margin: 0 0 2.5rem;
+}
+
+.pai-meta {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.5rem 2.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    max-width: 64rem;
+}
+
+.pai-meta-item { display: flex; flex-direction: column; gap: 0.25rem; }
+.pai-meta-key {
+    font-family: var(--pai-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    color: var(--pai-on-navy-faint);
+    text-transform: uppercase;
+}
+.pai-meta-val {
+    font-family: var(--pai-mono);
+    font-size: 0.78rem;
+    color: var(--pai-on-navy-strong);
+    line-height: 1.4;
+}
+
+/* ============ TLDR STRIP ============ */
+.pai-tldr {
+    padding: 3.5rem 0;
+    background: rgba(255, 255, 255, 0.04);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(4px);
+}
+.pai-tldr-intro {
+    font-family: var(--pai-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--pai-on-navy-faint);
+    margin-bottom: 1.75rem;
+    text-align: center;
+}
+.pai-tldr-item {
+    cursor: help;
+    transition: transform 0.15s;
+    padding: 0.5rem 0.25rem;
+    border-radius: 0.4rem;
+}
+.pai-tldr-item:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.03);
+}
+.pai-tldr-item:focus { outline: 1px dashed rgba(255, 255, 255, 0.4); outline-offset: 4px; }
+
+.pai-term {
+    border-bottom: 1px dotted rgba(253, 186, 116, 0.55);
+    cursor: help;
+    transition: border-color 0.15s;
+}
+.pai-term:hover { border-bottom-color: var(--pai-accent); }
+
+.pai-explorer-hint {
+    font-size: 0.85rem;
+    color: var(--pai-on-navy-faint);
+    margin: -0.5rem 0 1.8rem;
+    line-height: 1.55;
+    max-width: 75ch;
+}
+
+.pai-filter-label[data-term] { cursor: help; }
+.pai-filter-label[data-term]:hover { color: var(--pai-on-navy-strong); }
+.pai-chip[data-explain] { cursor: help; }
+
+.pai-tldr-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2.5rem;
+}
+
+.pai-stat {
+    font-size: 3rem;
+    font-weight: 300;
+    color: #ffffff;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.7rem;
+}
+
+.pai-stat-unit {
+    font-size: 1.5rem;
+    color: var(--pai-on-navy-soft);
+    font-weight: 300;
+    margin-left: 0.1em;
+}
+
+.pai-tldr-label {
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--pai-on-navy-soft);
+}
+
+.pai-tldr-label strong {
+    color: #ffffff;
+    font-weight: 500;
+}
+
+/* ============ SUB-NAV ============ */
+.pai-subnav {
+    position: sticky;
+    top: 72px;  /* under main canonical.cc fixed header */
+    z-index: 40;
+    background: rgba(30, 58, 138, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.65rem 0;
+}
+
+.pai-subnav-list {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+.pai-subnav-list::-webkit-scrollbar { display: none; }
+
+.pai-subnav-list li { flex: 0 0 auto; }
+
+.pai-subnav-list a {
+    display: inline-block;
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--pai-on-navy-soft);
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    transition: background 0.15s, color 0.15s;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.pai-subnav-list a:hover { background: rgba(255, 255, 255, 0.08); color: #ffffff; }
+.pai-subnav-list a.active { background: rgba(255, 255, 255, 0.12); color: #ffffff; }
+
+/* ============ SCENE SECTION BASE ============ */
+.pai-scene {
+    padding: 6rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    scroll-margin-top: 130px;
+}
+
+#explorer, #methodology, #map {
+    scroll-margin-top: 130px;
+}
+
+.pai-scene-grid {
+    display: grid;
+    grid-template-columns: 5fr 7fr;
+    gap: 4rem;
+    align-items: start;
+}
+
+.pai-scene-grid.pai-flip { grid-template-columns: 7fr 5fr; }
+
+.pai-section-label {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    color: var(--pai-accent-soft);
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 1.25rem;
+}
+.pai-section-num {
+    color: var(--pai-on-navy-faint);
+    margin-right: 0.4rem;
+}
+
+.pai-scene-text { padding-top: 0.5rem; }
+
+.pai-scene-h2 {
+    font-size: clamp(1.85rem, 3.4vw, 2.85rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 300;
+    color: #ffffff;
+    margin: 0 0 1.4rem;
+}
+
+.pai-scene-h2 em {
+    font-style: normal;
+    color: var(--pai-accent-soft);
+    font-weight: 400;
+}
+
+.pai-lede {
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--pai-on-navy-soft);
+    margin: 0 0 1.25rem;
+}
+.pai-lede-small { font-size: 0.92rem; color: var(--pai-on-navy-faint); }
+
+.pai-pov {
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+.pai-pov-label {
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.15em;
+    color: var(--pai-accent);
+    text-transform: uppercase;
+    margin-bottom: 0.7rem;
+}
+.pai-pov p {
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: var(--pai-on-navy-strong);
+    font-style: normal;
+    margin: 0;
+}
+
+/* ============ VIZ CARD CONTAINER ============ */
+.pai-viz {
+    background: var(--pai-card-bg);
+    border-radius: 0.75rem;
+    padding: 1.75rem;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.1);
+    color: var(--pai-ink);
+}
+.pai-viz-title {
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--pai-ink-muted);
+    margin-bottom: 1.25rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+.pai-viz-source { color: var(--pai-ink-faint); font-size: 0.65rem; }
+
+/* ============ CHASM CHART ============ */
+.pai-chasm-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+.pai-chasm-row {
+    display: grid;
+    grid-template-columns: 11rem 1fr 4.5rem;
+    gap: 1rem;
+    align-items: center;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: transform 0.15s;
+}
+.pai-chasm-row:hover { transform: translateX(2px); }
+.pai-chasm-row .pai-chasm-name {
+    color: var(--pai-ink-soft);
+    font-weight: 500;
+    line-height: 1.3;
+}
+.pai-chasm-row .pai-chasm-sub {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--pai-ink-faint);
+    font-weight: 400;
+    margin-top: 0.15rem;
+    font-family: var(--pai-mono);
+}
+.pai-chasm-bar {
+    height: 24px;
+    background: rgba(15, 23, 42, 0.08);
+    border-radius: 2px;
+    position: relative;
+    overflow: hidden;
+}
+.pai-chasm-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--pai-navy) 0%, var(--pai-navy-deep) 100%);
+    border-radius: 2px;
+    transition: width 0.9s cubic-bezier(.2,.8,.2,1);
+}
+.pai-chasm-row.pai-tail .pai-chasm-fill {
+    background: rgba(148, 163, 184, 0.85);  /* slate-400 */
+}
+.pai-chasm-val {
+    font-family: var(--pai-mono);
+    font-size: 0.85rem;
+    color: var(--pai-ink);
+    text-align: right;
+    font-weight: 500;
+}
+.pai-chasm-divider {
+    margin: 0.6rem 0;
+    padding-top: 0.7rem;
+    border-top: 1px dashed var(--pai-rule-strong);
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    color: var(--pai-ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+.pai-chasm-summary {
+    margin-top: 1.5rem;
+    padding-top: 1.2rem;
+    border-top: 1px solid var(--pai-rule);
+    font-family: var(--pai-mono);
+    font-size: 0.8rem;
+    color: var(--pai-ink-muted);
+    display: flex;
+    align-items: baseline;
+    gap: 0.8rem;
+}
+.pai-chasm-summary strong {
+    font-size: 1.6rem;
+    color: var(--pai-accent);
+    font-weight: 500;
+    font-style: normal;
+    line-height: 1;
+}
+
+/* ============ VELOCITY SCATTER ============ */
+.pai-velocity {
+    position: relative;
+    aspect-ratio: 1.45 / 1;
+    margin-top: 0.5rem;
+}
+.pai-velocity svg { width: 100%; height: 100%; display: block; overflow: visible; }
+
+.pai-velocity .pai-axis-line { stroke: rgba(15, 23, 42, 0.2); stroke-width: 1; }
+.pai-velocity .pai-grid-line { stroke: rgba(15, 23, 42, 0.06); stroke-width: 1; }
+.pai-velocity .pai-bubble-zone { fill: rgba(249, 115, 22, 0.06); }
+.pai-velocity .pai-bubble-zone-label {
+    font-family: var(--pai-mono); font-size: 9px; fill: var(--pai-accent);
+    letter-spacing: 0.15em;
+}
+.pai-velocity .pai-axis-text {
+    font-family: var(--pai-mono); font-size: 10px; fill: var(--pai-ink-faint);
+}
+.pai-velocity .pai-axis-title {
+    font-family: var(--pai-mono); font-size: 9.5px; fill: var(--pai-ink-muted);
+    letter-spacing: 0.18em;
+}
+
+.pai-velocity .pai-point {
+    cursor: pointer;
+    transition: r 0.15s, stroke-width 0.15s, filter 0.15s;
+}
+.pai-velocity .pai-point:hover {
+    stroke-width: 3;
+    filter: drop-shadow(0 0 8px rgba(249, 115, 22, 0.45));
+}
+.pai-velocity .pai-point-bubble { fill: var(--pai-accent); }
+.pai-velocity .pai-point-elevated { fill: var(--pai-navy); }
+.pai-velocity .pai-point-justified { fill: #15803d; }
+.pai-velocity .pai-point-label {
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 11px; font-weight: 500; fill: var(--pai-ink-soft);
+    pointer-events: none;
+}
+.pai-velocity .pai-point-sub {
+    font-family: var(--pai-mono); font-size: 9px; fill: var(--pai-ink-muted);
+    pointer-events: none;
+}
+
+.pai-velocity-fallback {
+    display: none;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin-top: 0.5rem;
+}
+.pai-velocity-fallback .pai-vf-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--pai-rule);
+    border-radius: 0.4rem;
+    background: var(--pai-card-bg-2);
+}
+.pai-velocity-fallback .pai-vf-name { font-weight: 500; color: var(--pai-ink); font-size: 0.85rem; }
+.pai-velocity-fallback .pai-vf-meta { font-family: var(--pai-mono); font-size: 0.72rem; color: var(--pai-ink-muted); }
+.pai-velocity-fallback .pai-vf-mult { font-family: var(--pai-mono); font-size: 0.95rem; font-weight: 600; }
+.pai-velocity-fallback .pai-vf-bubble { color: var(--pai-accent); }
+.pai-velocity-fallback .pai-vf-elevated { color: var(--pai-navy); }
+.pai-velocity-fallback .pai-vf-justified { color: #15803d; }
+
+.pai-velocity-legend {
+    display: flex;
+    align-items: center;
+    gap: 1.3rem;
+    flex-wrap: wrap;
+    margin-top: 1.2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--pai-rule);
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    color: var(--pai-ink-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+.pai-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 0.35rem;
+    vertical-align: middle;
+    margin-left: 0.5rem;
+}
+.pai-velocity-legend > :first-child { margin-left: 0; }
+.pai-dot-bubble { background: var(--pai-accent); }
+.pai-dot-elevated { background: var(--pai-navy); }
+.pai-dot-justified { background: #15803d; }
+
+/* ============ FLOW PANELS (Scene 3) ============ */
+.pai-flow-pair {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+}
+
+.pai-flow-panel {
+    background: var(--pai-card-bg);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.1);
+    color: var(--pai-ink);
+    display: flex;
+    flex-direction: column;
+}
+
+.pai-flow-head {
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    margin-bottom: 0.5rem;
+}
+.pai-flow-us .pai-flow-head { color: var(--pai-navy); }
+.pai-flow-china .pai-flow-head { color: var(--pai-accent); }
+
+.pai-flow-title {
+    font-size: 1.05rem;
+    line-height: 1.3;
+    margin-bottom: 1.1rem;
+    color: var(--pai-ink);
+    font-weight: 500;
+}
+
+.pai-flow-rows {
+    font-size: 0.85rem;
+    line-height: 1.6;
+    flex-grow: 1;
+}
+
+.pai-flow-row {
+    display: flex;
+    gap: 0.7rem;
+    padding: 0.55rem 0;
+    border-top: 1px solid var(--pai-rule);
+    align-items: baseline;
+}
+.pai-flow-row:first-child { border-top: none; padding-top: 0; }
+.pai-flow-actor { color: var(--pai-ink-muted); font-weight: 500; flex: 1; }
+.pai-flow-arrow { color: var(--pai-ink-faint); font-family: var(--pai-mono); font-size: 0.75rem; }
+.pai-flow-target { color: var(--pai-ink); font-weight: 600; flex: 1; text-align: right; }
+
+.pai-flow-exit {
+    margin-top: 1.1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--pai-rule);
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+.pai-flow-us .pai-flow-exit strong { color: var(--pai-navy); }
+.pai-flow-china .pai-flow-exit strong { color: var(--pai-accent); }
+
+/* ============ DEFENSE TIMELINE ============ */
+.pai-defense-chart svg { width: 100%; height: auto; display: block; overflow: visible; }
+.pai-defense-chart .pai-d-year-axis { stroke: rgba(15, 23, 42, 0.2); stroke-width: 1; }
+.pai-defense-chart .pai-d-year-tick { stroke: rgba(15, 23, 42, 0.1); stroke-width: 1; stroke-dasharray: 2, 3; }
+.pai-defense-chart .pai-d-year-text {
+    font-family: var(--pai-mono); font-size: 10px; fill: var(--pai-ink-muted);
+}
+.pai-defense-chart .pai-d-baseline {
+    font-family: var(--pai-mono); font-size: 9px; letter-spacing: 0.18em;
+}
+.pai-defense-chart .pai-d-line { stroke: rgba(30, 58, 138, 0.25); stroke-width: 1; }
+.pai-defense-chart .pai-d-dot { transition: r 0.15s, filter 0.15s; cursor: pointer; }
+.pai-defense-chart .pai-d-dot:hover { filter: drop-shadow(0 0 6px rgba(249, 115, 22, 0.5)); }
+.pai-defense-chart .pai-d-name {
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 12px; font-weight: 500; fill: var(--pai-ink-soft);
+    pointer-events: none;
+}
+.pai-defense-chart .pai-d-val {
+    font-family: var(--pai-mono); font-size: 11px; font-weight: 600;
+    pointer-events: none;
+}
+.pai-defense-chart .pai-d-meta {
+    font-family: var(--pai-mono); font-size: 9px; fill: var(--pai-ink-muted);
+    pointer-events: none;
+}
+
+/* ============ EXPLORER ============ */
+.pai-explorer-section { padding: 6rem 0 5rem; }
+
+.pai-h2-explorer {
+    max-width: 32ch;
+    margin-bottom: 1rem !important;
+}
+
+.pai-explorer-intro {
+    font-size: 1rem;
+    color: var(--pai-on-navy-soft);
+    max-width: 60ch;
+    line-height: 1.5;
+    margin-bottom: 2.5rem;
+}
+
+.pai-explorer-bar {
+    display: flex;
+    gap: 1.25rem 2rem;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.pai-filter-group { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
+.pai-filter-label {
+    font-family: var(--pai-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--pai-on-navy-faint);
+    margin-right: 0.2rem;
+}
+
+.pai-chip-row { display: flex; gap: 0.35rem; flex-wrap: wrap; }
+
+.pai-chip {
+    font-family: var(--pai-mono);
+    font-size: 0.75rem;
+    padding: 0.4rem 0.85rem;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--pai-on-navy-soft);
+    cursor: pointer;
+    border-radius: 100px;
+    transition: all 0.15s;
+    text-transform: capitalize;
+    letter-spacing: 0.02em;
+}
+.pai-chip:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+    border-color: rgba(255, 255, 255, 0.3);
+}
+.pai-chip.active {
+    background: #ffffff;
+    color: var(--pai-navy);
+    border-color: #ffffff;
+    font-weight: 500;
+}
+
+.pai-filter-meta {
+    margin-left: auto;
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-on-navy-faint);
+    letter-spacing: 0.05em;
+}
+
+.pai-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+
+.pai-card {
+    background: var(--pai-card-bg);
+    border-radius: 0.6rem;
+    padding: 1.4rem 1.3rem;
+    transition: transform 0.18s, box-shadow 0.18s;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    color: var(--pai-ink);
+    box-shadow: 0 8px 24px -10px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.08);
+    min-height: 220px;
+    border: 1px solid transparent;
+}
+.pai-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 40px -12px rgba(0, 0, 0, 0.45), 0 4px 12px rgba(0, 0, 0, 0.15);
+    border-color: rgba(249, 115, 22, 0.3);
+}
+.pai-card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+.pai-card .pai-card-num {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-faint);
+    letter-spacing: 0.1em;
+}
+.pai-card .pai-card-layer {
+    font-family: var(--pai-mono);
+    font-size: 0.62rem;
+    color: var(--pai-navy);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    background: rgba(30, 58, 138, 0.08);
+    padding: 0.2rem 0.5rem;
+    border-radius: 100px;
+}
+.pai-card h3 {
+    font-size: 1.2rem;
+    line-height: 1.2;
+    letter-spacing: -0.01em;
+    font-weight: 500;
+    color: var(--pai-ink);
+    margin: 0;
+}
+.pai-card-stats {
+    display: flex;
+    gap: 1.2rem;
+    flex-wrap: wrap;
+    margin-top: 0.2rem;
+}
+.pai-card-stat-k {
+    font-family: var(--pai-mono);
+    font-size: 0.6rem;
+    color: var(--pai-ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.15rem;
+}
+.pai-card-stat-v {
+    font-family: var(--pai-mono);
+    font-size: 0.95rem;
+    color: var(--pai-ink);
+    font-weight: 500;
+}
+.pai-card-stat-v .pai-up { color: #15803d; }
+.pai-card-stat-v .pai-down { color: #b91c1c; }
+.pai-card-stat-v .pai-na { color: var(--pai-ink-faint); }
+
+.pai-card-companies {
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: var(--pai-ink-muted);
+    margin-top: auto;
+    padding-top: 0.7rem;
+    border-top: 1px solid var(--pai-rule);
+}
+.pai-card-companies em {
+    font-style: normal;
+    color: var(--pai-ink-soft);
+}
+
+.pai-card-flag {
+    display: inline-block;
+    font-family: var(--pai-mono);
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--pai-accent);
+    background: rgba(249, 115, 22, 0.1);
+    padding: 0.15rem 0.45rem;
+    border-radius: 100px;
+    margin-left: 0.4rem;
+}
+
+.pai-card-empty {
+    grid-column: 1 / -1;
+    text-align: center;
+    color: var(--pai-on-navy-soft);
+    padding: 3rem 1rem;
+    font-family: var(--pai-mono);
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+    border-radius: 0.6rem;
+}
+
+/* ============ METHODOLOGY ============ */
+.pai-method-section { padding: 6rem 0; }
+.pai-h2-method {
+    max-width: 26ch;
+    margin-bottom: 2.5rem !important;
+}
+
+.pai-method-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+}
+
+.pai-method-col h3 {
+    font-size: 1.3rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin: 0 0 1rem;
+    letter-spacing: -0.01em;
+}
+
+.pai-method-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.pai-method-list li {
+    padding: 0.85rem 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    display: flex;
+    gap: 1.2rem;
+}
+.pai-method-list li:first-child { border-top: none; }
+.pai-method-k {
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    color: var(--pai-on-navy-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    min-width: 9rem;
+    padding-top: 0.2rem;
+    flex-shrink: 0;
+}
+.pai-method-v {
+    color: var(--pai-on-navy-soft);
+    font-size: 0.92rem;
+    line-height: 1.55;
+}
+.pai-method-v a { color: var(--pai-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.pai-method-v a:hover { color: #ffffff; }
+
+/* ============ CTA ============ */
+.pai-cta {
+    padding: 5rem 0;
+    background: rgba(0, 0, 0, 0.18);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.pai-cta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    align-items: center;
+}
+.pai-section-label-light {
+    color: rgba(255, 255, 255, 0.55) !important;
+}
+.pai-section-label-light .pai-section-num {
+    color: rgba(255, 255, 255, 0.3);
+}
+.pai-cta-h2 {
+    font-size: clamp(1.8rem, 3vw, 2.6rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 300;
+    color: #ffffff;
+    margin: 0 0 1.25rem;
+}
+.pai-cta-h2 em { font-style: normal; color: var(--pai-accent-soft); font-weight: 400; }
+.pai-cta-p {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--pai-on-navy-soft);
+    margin: 0;
+}
+
+.pai-cta-actions { display: flex; flex-direction: column; gap: 0.7rem; }
+.pai-btn {
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.1rem 1.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: #ffffff;
+    font-family: var(--pai-mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    transition: all 0.15s;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.02);
+}
+.pai-btn:hover {
+    background: #ffffff;
+    color: var(--pai-navy);
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+.pai-btn-arrow {
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 1.15rem;
+    transition: transform 0.2s;
+}
+.pai-btn:hover .pai-btn-arrow { transform: translateX(4px); }
+
+/* ============ DISCLAIMER ============ */
+.pai-disclaimer {
+    padding: 1.5rem 0 0.5rem;
+}
+.pai-disclaimer p {
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    color: var(--pai-on-navy-faint);
+    text-align: center;
+    margin: 0;
+    letter-spacing: 0.05em;
+}
+.pai-disclaimer a { color: var(--pai-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.pai-disclaimer a:hover { color: #ffffff; }
+
+/* ============ DRAWER (sector detail) ============ */
+.pai-drawer-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 90;
+}
+.pai-drawer-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.pai-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: min(640px, 100vw);
+    background: var(--pai-card-bg);
+    color: var(--pai-ink);
+    z-index: 100;
+    transform: translateX(100%);
+    transition: transform 0.32s cubic-bezier(.2,.85,.25,1);
+    overflow-y: auto;
+    box-shadow: -20px 0 40px rgba(0, 0, 0, 0.25);
+}
+.pai-drawer.open { transform: translateX(0); }
+.pai-drawer, .pai-drawer * { color: var(--pai-ink); }
+.pai-drawer .pai-d-stat-k,
+.pai-drawer .pai-d-num,
+.pai-drawer .pai-d-table th,
+.pai-drawer .pai-d-geo-col,
+.pai-drawer .pai-d-geo-legend,
+.pai-drawer .pai-d-footer { color: var(--pai-ink-faint); }
+.pai-drawer .pai-d-section-label { color: var(--pai-accent); }
+.pai-drawer .pai-card-layer { color: var(--pai-navy); }
+.pai-drawer .pai-d-pov-body { color: var(--pai-ink-soft); }
+.pai-drawer .pai-d-table .pai-d-flag { color: var(--pai-accent); }
+.pai-drawer .pai-d-table .pai-d-flag.public { color: var(--pai-navy); }
+.pai-drawer .pai-d-investor { color: var(--pai-ink-soft); }
+.pai-drawer .pai-d-footer a { color: var(--pai-navy); }
+.pai-drawer .pai-d-caveats li { color: var(--pai-ink-soft); }
+
+.pai-drawer-inner { padding: 2.5rem 2.25rem 3.5rem; }
+
+.pai-drawer-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: rgba(15, 23, 42, 0.06);
+    border: none;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s;
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 1.4rem;
+    line-height: 1;
+    color: var(--pai-ink-muted);
+}
+.pai-drawer-close:hover { background: rgba(15, 23, 42, 0.12); color: var(--pai-ink); }
+
+.pai-d-header { display: flex; flex-direction: column; gap: 0.6rem; margin-bottom: 1.5rem; }
+.pai-d-meta-row {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+}
+.pai-d-meta-row .pai-card-layer { font-size: 0.6rem; }
+.pai-d-num {
+    font-family: var(--pai-mono);
+    font-size: 0.75rem;
+    color: var(--pai-ink-faint);
+    letter-spacing: 0.1em;
+}
+.pai-d-title {
+    font-size: 2rem;
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 400;
+    color: var(--pai-ink);
+    margin: 0;
+}
+.pai-d-stats {
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+    padding: 1rem 0;
+    border-top: 1px solid var(--pai-rule);
+    border-bottom: 1px solid var(--pai-rule);
+    margin-bottom: 1.5rem;
+}
+.pai-d-stat-k {
+    font-family: var(--pai-mono);
+    font-size: 0.62rem;
+    color: var(--pai-ink-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 0.2rem;
+}
+.pai-d-stat-v {
+    font-family: var(--pai-mono);
+    font-size: 1.05rem;
+    color: var(--pai-ink);
+    font-weight: 500;
+}
+
+.pai-d-section { margin-bottom: 1.75rem; }
+.pai-d-section-label {
+    font-family: var(--pai-mono);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--pai-accent);
+    margin-bottom: 0.85rem;
+}
+.pai-d-pov-body {
+    font-size: 0.98rem;
+    line-height: 1.65;
+    color: var(--pai-ink-soft);
+    font-style: normal;
+    padding: 1rem 1.2rem;
+    background: rgba(30, 58, 138, 0.04);
+    border-left: 3px solid var(--pai-navy);
+    border-radius: 0 0.4rem 0.4rem 0;
+}
+
+.pai-d-geo {
+    display: flex;
+    height: 12px;
+    border-radius: 6px;
+    overflow: hidden;
+    margin-bottom: 0.6rem;
+    background: rgba(15, 23, 42, 0.06);
+}
+.pai-d-geo-seg { transition: filter 0.15s; }
+.pai-d-geo-seg:hover { filter: brightness(1.1); }
+.pai-d-geo-seg.us { background: var(--pai-navy); }
+.pai-d-geo-seg.china { background: var(--pai-accent); }
+.pai-d-geo-seg.eu { background: #6366f1; }
+.pai-d-geo-seg.row { background: #94a3b8; }
+.pai-d-geo-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    font-family: var(--pai-mono);
+    font-size: 0.7rem;
+    color: var(--pai-ink-muted);
+}
+.pai-d-geo-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+.pai-d-geo-legend i {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+.pai-d-geo-legend i.us { background: var(--pai-navy); }
+.pai-d-geo-legend i.china { background: var(--pai-accent); }
+.pai-d-geo-legend i.eu { background: #6366f1; }
+.pai-d-geo-legend i.row { background: #94a3b8; }
+
+.pai-d-table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+.pai-d-table th, .pai-d-table td {
+    padding: 0.55rem 0.5rem;
+    text-align: left;
+    border-bottom: 1px solid var(--pai-rule);
+}
+.pai-d-table th {
+    font-family: var(--pai-mono);
+    font-size: 0.65rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--pai-ink-faint);
+    font-weight: 500;
+}
+.pai-d-table td.pai-d-val-col {
+    font-family: var(--pai-mono);
+    font-weight: 500;
+    text-align: right;
+    white-space: nowrap;
+}
+.pai-d-table td.pai-d-geo-col {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-muted);
+    width: 3.2rem;
+}
+.pai-d-table .pai-d-flag {
+    display: inline-block;
+    font-family: var(--pai-mono);
+    font-size: 0.58rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: rgba(249, 115, 22, 0.12);
+    color: var(--pai-accent);
+    padding: 0.1rem 0.35rem;
+    border-radius: 100px;
+    margin-left: 0.35rem;
+    vertical-align: middle;
+}
+.pai-d-table .pai-d-flag.public { background: rgba(30, 58, 138, 0.1); color: var(--pai-navy); }
+
+.pai-d-investors { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.pai-d-investor {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-soft);
+    background: rgba(15, 23, 42, 0.05);
+    padding: 0.3rem 0.65rem;
+    border-radius: 100px;
+}
+
+.pai-d-caveats {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.pai-d-caveats li {
+    position: relative;
+    padding: 0.5rem 0 0.5rem 1.2rem;
+    font-size: 0.85rem;
+    color: var(--pai-ink-soft);
+    line-height: 1.55;
+    border-top: 1px solid var(--pai-rule);
+}
+.pai-d-caveats li:first-child { border-top: none; }
+.pai-d-caveats li::before {
+    content: "!";
+    position: absolute;
+    left: 0;
+    top: 0.55rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--pai-accent);
+    color: #ffffff;
+    font-family: var(--pai-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.pai-d-footer {
+    margin-top: 2rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--pai-rule);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-faint);
+}
+.pai-d-footer a {
+    color: var(--pai-navy);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+
+/* ============ HOVER TOOLTIP (hero scenes) ============ */
+.pai-tip {
+    position: fixed;
+    pointer-events: none;
+    background: rgba(10, 10, 10, 0.95);
+    color: #ffffff;
+    border: 1px solid rgba(249, 115, 22, 0.45);
+    border-radius: 0.45rem;
+    padding: 0.65rem 0.85rem;
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 0.78rem;
+    line-height: 1.45;
+    max-width: 280px;
+    z-index: 200;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+.pai-tip.show { opacity: 1; }
+.pai-tip strong { color: var(--pai-accent); font-weight: 600; display: block; margin-bottom: 0.15rem; }
+.pai-tip em { color: rgba(255, 255, 255, 0.7); font-style: normal; font-family: var(--pai-mono); font-size: 0.7rem; }
+.pai-tip { font-style: normal; }
+.pai-d-pov-body, .pai-tip, .pai-tip *, .pai-pov p, .pai-card-companies em, .pai-card-companies, .pai-title em, .pai-scene-h2 em, .pai-cta-h2 em, .pai-chasm-summary strong { font-style: normal !important; }
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 960px) {
+    .pai-scene-grid, .pai-scene-grid.pai-flip {
+        grid-template-columns: 1fr;
+        gap: 2rem;
+    }
+    .pai-grid { grid-template-columns: repeat(2, 1fr); }
+    .pai-tldr-grid { grid-template-columns: repeat(2, 1fr); }
+    .pai-flow-pair { grid-template-columns: 1fr; }
+    .pai-meta { grid-template-columns: repeat(2, 1fr); }
+    .pai-cta-grid, .pai-method-grid { grid-template-columns: 1fr; gap: 2rem; }
+    .pai-scene, .pai-explorer-section, .pai-method-section { padding: 4rem 0; }
+    .pai-hero { padding: 6rem 0 2rem; }
+}
+
+@media (max-width: 640px) {
+    .pai-grid { grid-template-columns: 1fr; }
+    .pai-tldr-grid { grid-template-columns: 1fr; gap: 1.5rem; }
+    .pai-meta { grid-template-columns: 1fr; gap: 1rem; }
+    .pai-stat { font-size: 2.4rem; }
+    .pai-chasm-row { grid-template-columns: 8.5rem 1fr 3.5rem; gap: 0.7rem; font-size: 0.78rem; }
+    .pai-velocity { display: none; }
+    .pai-velocity-fallback { display: flex; }
+    .pai-explorer-bar { gap: 1rem; }
+    .pai-filter-meta { margin-left: 0; }
+    .pai-drawer { width: 100vw; }
+    .pai-drawer-inner { padding: 2rem 1.5rem 2.5rem; }
+    .pai-subnav { top: 60px; }
+}
+
+/* When the canonical.cc header is in "scrolled" state, give the subnav a touch more contrast */
+#header.scrolled ~ main .pai-subnav { background: rgba(30, 58, 138, 0.95); }

--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -1,0 +1,823 @@
+/* Physical AI Capital Flow Map - interactive layer.
+   Fetches /labs/physical-ai/data.json, renders:
+     - Scene 1: valuation chasm horizontal bars
+     - Scene 2: round velocity SVG scatter + mobile fallback list
+     - Scene 3: US / China flow rows
+     - Scene 4: defense unicorn SVG timeline
+     - Explorer: 22 sub-sector cards with filter/sort and URL state
+     - Detail drawer on card click with full company list, investors, POV, caveats
+     - Scroll-spy sub-nav, ESC to close drawer, hover tooltips on hero scenes. */
+
+(function () {
+    'use strict';
+
+    let DATA = null;
+    const tip = document.getElementById('pai-tip');
+
+    /* Static explanations for filter chips, TLDR stats, and key terms.
+       Keep terse; the goal is to remove ambiguity, not to write paragraphs. */
+    const EXPLAIN = {
+        // hero / glossary terms
+        'tam': '<strong>Total addressable market.</strong>Estimated total revenue opportunity for a category if a product captured 100% of demand. Used here to flag categories that are tiny in VC dollars but large in real-world demand (e.g. exoskeletons).',
+
+        // layer chips
+        'layer': '<strong>Layer</strong>Where the company sits in the physical-AI stack. Embodiment = the robot itself. Domain = the use case the robot serves. Stack = the underlying tech (silicon, models, simulation, perception, middleware).',
+        'all-layers': '<strong>All layers</strong>Show every sub-sector regardless of where it sits in the stack. Default view.',
+        'layer-embodiment': '<strong>Embodiment</strong>The physical robot. Humanoids, quadrupeds, warehouse mobile robots, drones, marine, surgical, exoskeletons. Capital flows here are about the form factor and the hardware.',
+        'layer-domain': '<strong>Domain</strong>The use case the robot serves. Industrial automation, agriculture, construction, defense, healthcare, consumer, mobility. Capital flows here are about a specific end market.',
+        'layer-stack': '<strong>Stack</strong>The underlying tech the embodiment runs on. Actuators, sensors, edge silicon, foundation models, simulation, fleet ops, teleop/data, safety. Picks-and-shovels.',
+
+        // geo chips
+        'geo': '<strong>Geography</strong>Filters to sub-sectors where the selected region has at least 10% of capital deployed. Useful for surfacing where China dominates (consumer, teleop data centers) vs where it is absent (defense, marine).',
+        'geo-global': '<strong>Global</strong>All sub-sectors, all geographies. Default view.',
+        'geo-us': '<strong>US</strong>Sub-sectors where US-domiciled companies have at least 10% of capital. Most of physical AI venture sits here.',
+        'geo-china': '<strong>China</strong>Sub-sectors with material Chinese capital. Note: unit shipment share and dollar share diverge sharply; the drawer geo bar shows the dollar split.',
+        'geo-eu': '<strong>EU</strong>Sub-sectors with material European capital. Strongest in exoskeletons and surgical robotics; nascent in defense via Helsing.',
+
+        // sort chips
+        'sort': '<strong>Sort</strong>Reorders the visible cards. Capital ranks by total dollars in 2024–25, YoY by year-over-year growth rate, Deals by number of rounds.',
+        'sort-capital': '<strong>Sort by Capital</strong>Largest 2024–25 dollar volume first. Defense ($22B) and AV ($28B) lead.',
+        'sort-yoy': '<strong>Sort by YoY</strong>Fastest growing first. Foundation models for robotics (+450%) and AV (+340%) lead. Negative YoY (consumer, warehouse) sinks to the bottom.',
+        'sort-deals': '<strong>Sort by Deals</strong>Most rounds first. Defense (120+) and warehouse (70) lead by deal count even though warehouse is shrinking in dollars.',
+
+        // TLDR stats
+        'tldr-total': '<strong>$40.7B total robotics VC, 2025</strong>CB Insights wide-cut figure. PitchBook reports $27.6B with a narrower category definition. Both include venture and strategic capital; PitchBook’s separate $49.1B 2025 deal-value figure includes structured credit, so we keep equity-only here.',
+        'tldr-concentration': '<strong>~80% of capital in 4 super-categories</strong>Humanoids ($5B), defense ($22B), AV ($28B), foundation models ($3.5B) account for roughly 4/5ths of physical-AI VC in 2024–25. The other ~20% is spread across 18 sub-sectors.',
+        'tldr-defense': '<strong>2 → 22 defense unicorns</strong>In 2022, only Anduril and Shield AI were valued above $1B. By mid-2026 there are 22+. Anduril’s $61B post Series H is anchored by a $20B DoD enterprise agreement signed March 2026.',
+        'tldr-chasm': '<strong>$56B+ in 4 humanoid valuations</strong>Figure ($39B), 1X ($10B, in talks), Apptronik ($5.4B), Agility ($2.1B) sum to ~$56B. Surgical + agricultural + construction + consumer + exoskeleton + quadruped venture combined: ~$3.7B. 15× ratio.',
+    };
+
+    function showTipFor(e, key) {
+        const html = EXPLAIN[key];
+        if (!html) return;
+        showTip(e, html);
+    }
+
+    /* ---------- Utilities ---------- */
+    function el(tag, attrs, ...kids) {
+        const node = document.createElement(tag);
+        if (attrs) {
+            for (const k in attrs) {
+                if (k === 'class') node.className = attrs[k];
+                else if (k === 'html') node.innerHTML = attrs[k];
+                else if (k.startsWith('on') && typeof attrs[k] === 'function') {
+                    node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+                } else if (attrs[k] !== null && attrs[k] !== undefined) {
+                    node.setAttribute(k, attrs[k]);
+                }
+            }
+        }
+        for (const kid of kids) {
+            if (kid == null || kid === false) continue;
+            node.appendChild(kid instanceof Node ? kid : document.createTextNode(String(kid)));
+        }
+        return node;
+    }
+
+    function svg(tag, attrs, ...kids) {
+        const node = document.createElementNS('http://www.w3.org/2000/svg', tag);
+        if (attrs) {
+            for (const k in attrs) {
+                if (k === 'class') node.setAttribute('class', attrs[k]);
+                else if (k.startsWith('on') && typeof attrs[k] === 'function') {
+                    node.addEventListener(k.slice(2).toLowerCase(), attrs[k]);
+                } else if (attrs[k] !== null && attrs[k] !== undefined) {
+                    node.setAttribute(k, attrs[k]);
+                }
+            }
+        }
+        for (const kid of kids) {
+            if (kid == null || kid === false) continue;
+            node.appendChild(kid instanceof Node ? kid : document.createTextNode(String(kid)));
+        }
+        return node;
+    }
+
+    function fmtB(m) {
+        if (m == null) return '—';
+        if (m >= 1000) return '$' + (m / 1000).toFixed(m >= 10000 ? 0 : 1) + 'B';
+        if (m >= 100) return '$' + Math.round(m) + 'M';
+        return '$' + m + 'M';
+    }
+
+    function fmtPct(n) {
+        if (n == null) return '—';
+        const sign = n > 0 ? '+' : '';
+        return sign + n + '%';
+    }
+
+    /* ---------- Tooltip ---------- */
+    function showTip(e, html) {
+        tip.innerHTML = html;
+        tip.classList.add('show');
+        positionTip(e);
+    }
+    function moveTip(e) { if (tip.classList.contains('show')) positionTip(e); }
+    function hideTip() { tip.classList.remove('show'); }
+    function positionTip(e) {
+        const pad = 14;
+        const tr = tip.getBoundingClientRect();
+        let x = e.clientX + pad;
+        let y = e.clientY + pad;
+        if (x + tr.width > window.innerWidth - 8) x = e.clientX - tr.width - pad;
+        if (y + tr.height > window.innerHeight - 8) y = e.clientY - tr.height - pad;
+        tip.style.left = x + 'px';
+        tip.style.top = y + 'px';
+    }
+
+    /* ---------- SCENE 1: Valuation Chasm ---------- */
+    function renderChasm() {
+        const container = document.getElementById('chasm-bars');
+        if (!container) return;
+        const s = DATA.scenes.valuation_chasm;
+        container.innerHTML = '';
+
+        const allVals = [...s.headline_bars.map(b => b.valuation_m), ...s.tail_bars.map(b => b.value_m)];
+        const maxVal = Math.max(...allVals);
+
+        s.headline_bars.forEach(b => container.appendChild(buildChasmRow(b, false, maxVal)));
+
+        container.appendChild(el('div', { class: 'pai-chasm-divider' }, '— vs. six entire sub-sectors —'));
+
+        s.tail_bars.forEach(b => container.appendChild(buildChasmRow({
+            name: b.name,
+            valuation_m: b.value_m,
+            geo: '',
+            round: b.note
+        }, true, maxVal)));
+    }
+
+    function buildChasmRow(b, isTail, maxVal) {
+        const pct = Math.max((b.valuation_m / maxVal) * 100, 0.5);
+        const row = el('div', { class: 'pai-chasm-row' + (isTail ? ' pai-tail' : '') });
+        if (b.flag) row.dataset.flag = b.flag;
+        const name = el('span', { class: 'pai-chasm-name' });
+        name.appendChild(document.createTextNode(b.name));
+        if (b.geo || b.round) {
+            const sub = el('span', { class: 'pai-chasm-sub' });
+            sub.textContent = [b.geo, b.round].filter(Boolean).join(' · ');
+            name.appendChild(sub);
+        }
+        const barWrap = el('div', { class: 'pai-chasm-bar' });
+        const fill = el('div', { class: 'pai-chasm-fill' });
+        fill.style.width = '0%';
+        barWrap.appendChild(fill);
+        setTimeout(() => { fill.style.width = pct + '%'; }, 80);
+
+        const val = el('span', { class: 'pai-chasm-val' }, fmtB(b.valuation_m));
+
+        row.appendChild(name);
+        row.appendChild(barWrap);
+        row.appendChild(val);
+
+        row.addEventListener('mousemove', (e) => {
+            const flag = b.flag ? '<em>' + b.flag.replace('-', ' ') + '</em>' : '';
+            showTip(e, '<strong>' + b.name + '</strong>' + fmtB(b.valuation_m) +
+                (b.round ? ' · ' + b.round : '') + (flag ? '<br/>' + flag : ''));
+        });
+        row.addEventListener('mouseleave', hideTip);
+        return row;
+    }
+
+    /* ---------- SCENE 2: Round Velocity ---------- */
+    function renderVelocity() {
+        const host = document.getElementById('velocity-chart');
+        const fallback = document.getElementById('velocity-fallback');
+        if (!host) return;
+        const points = DATA.scenes.round_velocity.data_points;
+
+        // SVG version (hidden < 640px)
+        host.innerHTML = '';
+        const VB_W = 620, VB_H = 460;
+        const PAD_L = 60, PAD_R = 30, PAD_T = 20, PAD_B = 60;
+        const plotW = VB_W - PAD_L - PAD_R;
+        const plotH = VB_H - PAD_T - PAD_B;
+
+        // x: 0..24 months; y: 0..25x (log feel — use linear for now matching mockup)
+        const xMax = 24;
+        const yMax = 25;
+        const xPos = m => PAD_L + (Math.min(m, xMax) / xMax) * plotW;
+        const yPos = mult => PAD_T + plotH - (Math.min(mult, yMax) / yMax) * plotH;
+
+        const root = svg('svg', { viewBox: `0 0 ${VB_W} ${VB_H}`, preserveAspectRatio: 'xMidYMid meet' });
+
+        // grid
+        const defs = svg('defs');
+        const pattern = svg('pattern', { id: 'pai-vgrid', width: 40, height: 40, patternUnits: 'userSpaceOnUse' },
+            svg('path', { d: 'M 40 0 L 0 0 0 40', fill: 'none', stroke: 'rgba(15,23,42,0.06)', 'stroke-width': 1 })
+        );
+        defs.appendChild(pattern);
+        root.appendChild(defs);
+        root.appendChild(svg('rect', { x: PAD_L, y: PAD_T, width: plotW, height: plotH, fill: 'url(#pai-vgrid)' }));
+
+        // bubble zone overlay: months < 12, multiple > 3
+        const bzX = PAD_L;
+        const bzY = PAD_T;
+        const bzW = xPos(12) - PAD_L;
+        const bzH = yPos(3) - PAD_T;
+        root.appendChild(svg('rect', { x: bzX, y: bzY, width: bzW, height: bzH, class: 'pai-bubble-zone' }));
+        root.appendChild(svg('text', {
+            x: bzX + bzW / 2, y: bzY + 32, 'text-anchor': 'middle', class: 'pai-bubble-zone-label'
+        }, 'BUBBLE ZONE'));
+        root.appendChild(svg('text', {
+            x: bzX + bzW / 2, y: bzY + 46, 'text-anchor': 'middle',
+            class: 'pai-bubble-zone-label', style: 'opacity:0.75; font-size:8px;'
+        }, 'fast rounds, high multiples'));
+
+        // axes
+        root.appendChild(svg('line', { x1: PAD_L, y1: PAD_T + plotH, x2: PAD_L + plotW, y2: PAD_T + plotH, class: 'pai-axis-line' }));
+        root.appendChild(svg('line', { x1: PAD_L, y1: PAD_T, x2: PAD_L, y2: PAD_T + plotH, class: 'pai-axis-line' }));
+
+        // y-axis labels (multiples)
+        const yTicks = [1, 3, 6, 10, 15, 22];
+        yTicks.forEach(t => {
+            root.appendChild(svg('text', { x: PAD_L - 10, y: yPos(t) + 4, class: 'pai-axis-text', 'text-anchor': 'end' }, t + '×'));
+        });
+        // x-axis labels (months)
+        const xTicks = [0, 6, 12, 18, 24];
+        xTicks.forEach(t => {
+            root.appendChild(svg('text', { x: xPos(t), y: PAD_T + plotH + 20, class: 'pai-axis-text', 'text-anchor': 'middle' }, t));
+        });
+        root.appendChild(svg('text', {
+            x: PAD_L + plotW / 2, y: VB_H - 18, 'text-anchor': 'middle', class: 'pai-axis-title'
+        }, 'MONTHS BETWEEN ROUNDS'));
+        const yTitle = svg('text', {
+            x: 18, y: PAD_T + plotH / 2, 'text-anchor': 'middle', class: 'pai-axis-title',
+            transform: `rotate(-90, 18, ${PAD_T + plotH / 2})`
+        }, 'VALUATION MULTIPLE');
+        root.appendChild(yTitle);
+
+        // points
+        points.forEach(p => {
+            const cx = xPos(p.months_between);
+            const cy = yPos(p.multiple);
+            const cls = 'pai-point pai-point-' + (p.category === 'justified-by-revenue' ? 'justified' : p.category);
+            const r = p.multiple >= 15 ? 9 : p.multiple >= 5 ? 8 : 7;
+            const dot = svg('circle', {
+                cx, cy, r,
+                class: cls,
+                stroke: 'white',
+                'stroke-width': 2,
+                'data-company': p.company
+            });
+            dot.addEventListener('mousemove', (e) => {
+                showTip(e,
+                    '<strong>' + p.company + '</strong>' +
+                    fmtB(p.prev_val_m) + ' → ' + fmtB(p.new_val_m) +
+                    ' · <em>' + p.multiple + '×</em>' +
+                    '<br/>' + p.months_between + ' months · ' + p.category.replace(/-/g, ' ') +
+                    (p.sub_sector ? '<br/><em>tap to view ' + p.sub_sector.replace(/-/g, ' ') + '</em>' : '')
+                );
+            });
+            dot.addEventListener('mouseleave', hideTip);
+            dot.addEventListener('click', () => {
+                if (p.sub_sector) openSector(p.sub_sector);
+            });
+            root.appendChild(dot);
+
+            // label placement: prefer right of point unless near right edge
+            const labelRight = cx < PAD_L + plotW - 110;
+            const lx = labelRight ? cx + 12 : cx - 12;
+            const anchor = labelRight ? 'start' : 'end';
+            root.appendChild(svg('text', {
+                x: lx, y: cy - 4, class: 'pai-point-label', 'text-anchor': anchor
+            }, p.company));
+            root.appendChild(svg('text', {
+                x: lx, y: cy + 9, class: 'pai-point-sub', 'text-anchor': anchor
+            }, p.multiple + '×'));
+        });
+
+        host.appendChild(root);
+
+        // Mobile fallback list (sorted by multiple desc)
+        fallback.innerHTML = '';
+        const sorted = [...points].sort((a, b) => b.multiple - a.multiple);
+        sorted.forEach(p => {
+            const cat = p.category === 'justified-by-revenue' ? 'justified' : p.category;
+            const row = el('div', { class: 'pai-vf-row' },
+                el('div', null,
+                    el('div', { class: 'pai-vf-name' }, p.company),
+                    el('div', { class: 'pai-vf-meta' }, fmtB(p.prev_val_m) + ' → ' + fmtB(p.new_val_m))
+                ),
+                el('div', { class: 'pai-vf-meta' }, p.months_between + 'mo'),
+                el('div', { class: 'pai-vf-mult pai-vf-' + cat }, p.multiple + '×')
+            );
+            if (p.sub_sector) {
+                row.style.cursor = 'pointer';
+                row.addEventListener('click', () => openSector(p.sub_sector));
+            }
+            fallback.appendChild(row);
+        });
+    }
+
+    /* ---------- SCENE 3: US/China Flows ---------- */
+    function renderFlows() {
+        const us = document.getElementById('flow-us');
+        const cn = document.getElementById('flow-china');
+        if (!us || !cn) return;
+
+        us.innerHTML = '';
+        cn.innerHTML = '';
+
+        DATA.scenes.us_china_flows.us_flows.forEach(f => {
+            us.appendChild(buildFlowRow(f.investors, f.company));
+        });
+        DATA.scenes.us_china_flows.china_flows.forEach(f => {
+            cn.appendChild(buildFlowRow(f.investors, f.company));
+        });
+    }
+
+    function buildFlowRow(investors, company) {
+        const actorText = investors.join(' + ');
+        const row = el('div', { class: 'pai-flow-row' },
+            el('span', { class: 'pai-flow-actor' }, actorText),
+            el('span', { class: 'pai-flow-arrow' }, '→'),
+            el('span', { class: 'pai-flow-target' }, company)
+        );
+        row.addEventListener('mousemove', (e) => {
+            showTip(e, '<strong>' + company + '</strong>Backed by: <em>' + actorText + '</em>');
+        });
+        row.addEventListener('mouseleave', hideTip);
+        return row;
+    }
+
+    /* ---------- SCENE 4: Defense Unicorn Timeline ---------- */
+    function renderDefense() {
+        const host = document.getElementById('defense-chart');
+        if (!host) return;
+        host.innerHTML = '';
+
+        const VB_W = 720, VB_H = 490;
+        const yearX = { 2022: 80, 2024: 240, 2025: 400, 2026: 560 };
+
+        const root = svg('svg', { viewBox: `0 0 ${VB_W} ${VB_H}`, preserveAspectRatio: 'xMidYMid meet' });
+
+        // year axis verticals
+        root.appendChild(svg('line', { x1: 80, y1: 40, x2: 80, y2: 460, class: 'pai-d-year-axis' }));
+        [240, 400, 560].forEach(x => {
+            root.appendChild(svg('line', { x1: x, y1: 40, x2: x, y2: 460, class: 'pai-d-year-tick' }));
+        });
+
+        // year labels
+        Object.keys(yearX).forEach(y => {
+            root.appendChild(svg('text', {
+                x: yearX[y], y: 478, class: 'pai-d-year-text', 'text-anchor': 'middle'
+            }, y));
+        });
+
+        // baseline labels (top)
+        root.appendChild(svg('text', {
+            x: 80, y: 28, class: 'pai-d-baseline pai-d-year-text', 'text-anchor': 'middle',
+            fill: '#94a3b8'
+        }, '2 UNICORNS'));
+        root.appendChild(svg('text', {
+            x: 640, y: 28, class: 'pai-d-baseline', 'text-anchor': 'middle',
+            fill: '#f97316', 'font-weight': '600'
+        }, '22+ UNICORNS'));
+
+        const rows = DATA.scenes.defense_unicorns.unicorns;
+        const rowGap = 38;
+        const startY = 60;
+
+        rows.forEach((u, i) => {
+            const y = startY + i * rowGap;
+            const xStart = yearX[u.first_unicorn_year] || 80;
+            const xEnd = u.first_unicorn_year < 2026 ? 640 : xStart + 80;
+
+            // line from first year to latest
+            if (u.first_unicorn_year < 2026 || u.highlight) {
+                root.appendChild(svg('line', {
+                    x1: xStart, y1: y, x2: u.highlight ? 640 : xEnd, y2: y, class: 'pai-d-line'
+                }));
+            }
+
+            // first-cross dot
+            root.appendChild(svg('circle', {
+                cx: xStart, cy: y, r: u.highlight ? 5 : 4, fill: '#1e3a8a'
+            }));
+
+            // intermediate ticks for highlight (anduril)
+            if (u.highlight) {
+                root.appendChild(svg('circle', { cx: 240, cy: y, r: 5, fill: '#1e3a8a' }));
+                root.appendChild(svg('circle', { cx: 400, cy: y, r: 6, fill: '#1e3a8a' }));
+            }
+
+            // latest valuation dot
+            const latestX = u.highlight ? 640 : xEnd;
+            const latestR = u.latest_val_m >= 30000 ? 11 : u.latest_val_m >= 10000 ? 9 : u.latest_val_m >= 4000 ? 7 : 6;
+            const latestFill = u.highlight ? '#f97316' : '#1e3a8a';
+            const latestDot = svg('circle', {
+                cx: latestX, cy: y, r: latestR, fill: latestFill,
+                stroke: 'white', 'stroke-width': 2, class: 'pai-d-dot',
+                'data-name': u.name
+            });
+            latestDot.addEventListener('mousemove', (e) => {
+                showTip(e,
+                    '<strong>' + u.name + '</strong>' + fmtB(u.latest_val_m) +
+                    '<br/><em>' + u.latest_round + '</em>' +
+                    (u.structured_note ? '<br/>' + u.structured_note : '') +
+                    (u.flag ? '<br/><em>' + u.flag + '</em>' : '')
+                );
+            });
+            latestDot.addEventListener('mouseleave', hideTip);
+            root.appendChild(latestDot);
+
+            // name label (just past first-cross dot)
+            root.appendChild(svg('text', {
+                x: xStart + 14, y: y - 5, class: 'pai-d-name'
+            }, u.name));
+
+            // valuation label (right of latest dot)
+            root.appendChild(svg('text', {
+                x: latestX + 18, y: y - 4, class: 'pai-d-val',
+                fill: u.highlight ? '#f97316' : '#0a0a0a'
+            }, fmtB(u.latest_val_m)));
+            root.appendChild(svg('text', {
+                x: latestX + 18, y: y + 9, class: 'pai-d-meta'
+            }, u.latest_round.length > 32 ? u.latest_round.slice(0, 30) + '…' : u.latest_round));
+        });
+
+        host.appendChild(root);
+    }
+
+    /* ---------- EXPLORER: Cards + Filters ---------- */
+    const GEO_LABELS = { US: 'US', China: 'China', EU: 'EU', RoW: 'RoW' };
+
+    function readFilters() {
+        const p = new URLSearchParams(window.location.search);
+        return {
+            layer: p.get('layer') || 'all',
+            geo: p.get('geo') || 'global',
+            sort: p.get('sort') || 'capital',
+            sector: p.get('sector') || null
+        };
+    }
+
+    function writeFilters(f) {
+        const p = new URLSearchParams();
+        if (f.layer && f.layer !== 'all') p.set('layer', f.layer);
+        if (f.geo && f.geo !== 'global') p.set('geo', f.geo);
+        if (f.sort && f.sort !== 'capital') p.set('sort', f.sort);
+        if (f.sector) p.set('sector', f.sector);
+        const qs = p.toString();
+        const url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
+        window.history.replaceState(null, '', url);
+    }
+
+    function syncChips() {
+        const f = readFilters();
+        document.querySelectorAll('.pai-chip-row').forEach(row => {
+            const kind = row.dataset.filter;
+            const want = f[kind] || (kind === 'geo' ? 'global' : kind === 'layer' ? 'all' : 'capital');
+            row.querySelectorAll('.pai-chip').forEach(c => {
+                c.classList.toggle('active', c.dataset.value === want);
+            });
+        });
+    }
+
+    function renderSectors() {
+        const grid = document.getElementById('sector-grid');
+        if (!grid) return;
+        grid.innerHTML = '';
+
+        const f = readFilters();
+        let list = DATA.subsectors.slice();
+
+        if (f.layer && f.layer !== 'all') list = list.filter(s => s.layer === f.layer);
+        if (f.geo && f.geo !== 'global') list = list.filter(s => (s.geo_split[f.geo] || 0) >= 10);
+
+        if (f.sort === 'capital') list.sort((a, b) => (b.capital_2024_25_m || 0) - (a.capital_2024_25_m || 0));
+        else if (f.sort === 'yoy') list.sort((a, b) => (b.yoy_growth_pct == null ? -9999 : b.yoy_growth_pct) - (a.yoy_growth_pct == null ? -9999 : a.yoy_growth_pct));
+        else if (f.sort === 'deals') list.sort((a, b) => (b.deals_count || 0) - (a.deals_count || 0));
+
+        const meta = document.getElementById('filter-meta');
+        if (meta) {
+            meta.textContent = list.length === DATA.subsectors.length
+                ? 'Showing all ' + list.length + ' sub-sectors'
+                : 'Showing ' + list.length + ' of ' + DATA.subsectors.length + ' sub-sectors';
+        }
+
+        if (list.length === 0) {
+            grid.appendChild(el('div', { class: 'pai-card-empty' },
+                'No sub-sectors match those filters. Try widening the geography or layer.'));
+            return;
+        }
+
+        list.forEach(s => grid.appendChild(buildCard(s)));
+    }
+
+    function buildCard(s) {
+        const top = el('div', { class: 'pai-card-top' },
+            el('span', { class: 'pai-card-num' }, s.number),
+            el('span', { class: 'pai-card-layer' }, s.layer)
+        );
+
+        const stats = el('div', { class: 'pai-card-stats' },
+            buildStat('Capital ’24–’25', fmtB(s.capital_2024_25_m)),
+            buildStat('YoY', s.yoy_growth_pct == null
+                ? '<span class="pai-na">n/a</span>'
+                : '<span class="' + (s.yoy_growth_pct >= 0 ? 'pai-up' : 'pai-down') + '">' + fmtPct(s.yoy_growth_pct) + '</span>'),
+            buildStat('Deals', String(s.deals_count))
+        );
+
+        const topNames = s.top_companies.slice(0, 5).map(c => c.name).join(' · ');
+        const companies = el('div', { class: 'pai-card-companies', html: 'Top: <em>' + topNames + '</em>' });
+
+        const card = el('div', { class: 'pai-card' }, top, el('h3', null, s.name), stats, companies);
+        card.dataset.id = s.id;
+        card.addEventListener('click', () => openSector(s.id));
+
+        const povPreview = s.canonical_pov.length > 240 ? s.canonical_pov.slice(0, 220).trim() + '…' : s.canonical_pov;
+        card.addEventListener('mousemove', (e) => {
+            showTip(e,
+                '<strong>' + s.name + ' · Canonical POV</strong>' + povPreview +
+                '<br/><em>click for full detail</em>'
+            );
+        });
+        card.addEventListener('mouseleave', hideTip);
+        return card;
+    }
+
+    function buildStat(label, valueHtml) {
+        const v = el('div', { class: 'pai-card-stat-v', html: valueHtml });
+        return el('div', null,
+            el('div', { class: 'pai-card-stat-k' }, label),
+            v
+        );
+    }
+
+    /* ---------- DRAWER ---------- */
+    const drawer = document.getElementById('drawer');
+    const drawerInner = document.getElementById('drawer-inner');
+    const drawerOverlay = document.getElementById('drawer-overlay');
+
+    function openSector(id) {
+        const s = DATA.subsectors.find(x => x.id === id);
+        if (!s) return;
+        const f = readFilters();
+        f.sector = id;
+        writeFilters(f);
+        renderDrawer(s);
+        drawer.classList.add('open');
+        drawer.setAttribute('aria-hidden', 'false');
+        drawerOverlay.classList.add('open');
+        document.body.style.overflow = 'hidden';
+    }
+
+    function closeDrawer() {
+        drawer.classList.remove('open');
+        drawer.setAttribute('aria-hidden', 'true');
+        drawerOverlay.classList.remove('open');
+        document.body.style.overflow = '';
+        const f = readFilters();
+        f.sector = null;
+        writeFilters(f);
+    }
+
+    function renderDrawer(s) {
+        drawerInner.innerHTML = '';
+
+        // close button
+        const closeBtn = el('button', {
+            class: 'pai-drawer-close',
+            'aria-label': 'Close panel',
+            onclick: closeDrawer
+        }, '×');
+        drawerInner.appendChild(closeBtn);
+
+        // header
+        const header = el('div', { class: 'pai-d-header' },
+            el('div', { class: 'pai-d-meta-row' },
+                el('span', { class: 'pai-d-num' }, '[' + s.number + ']'),
+                el('span', { class: 'pai-card-layer' }, s.layer)
+            ),
+            el('h2', { class: 'pai-d-title', id: 'drawer-title' }, s.name)
+        );
+        drawerInner.appendChild(header);
+
+        // stats row
+        const stats = el('div', { class: 'pai-d-stats' });
+        [
+            ['Capital ’24–’25', fmtB(s.capital_2024_25_m)],
+            ['YoY', s.yoy_growth_pct == null ? '—' : fmtPct(s.yoy_growth_pct)],
+            ['Deals', String(s.deals_count)]
+        ].forEach(([k, v]) => {
+            stats.appendChild(el('div', null,
+                el('div', { class: 'pai-d-stat-k' }, k),
+                el('div', { class: 'pai-d-stat-v' }, v)
+            ));
+        });
+        drawerInner.appendChild(stats);
+
+        // POV
+        drawerInner.appendChild(el('div', { class: 'pai-d-section' },
+            el('div', { class: 'pai-d-section-label' }, 'Canonical POV'),
+            el('div', { class: 'pai-d-pov-body' }, s.canonical_pov)
+        ));
+
+        // Geo split
+        const geoSec = el('div', { class: 'pai-d-section' },
+            el('div', { class: 'pai-d-section-label' }, 'Geographic split (% of capital)')
+        );
+        const geoBar = el('div', { class: 'pai-d-geo' });
+        ['US', 'China', 'EU', 'RoW'].forEach(g => {
+            const pct = s.geo_split[g] || 0;
+            if (pct > 0) {
+                const seg = el('div', { class: 'pai-d-geo-seg ' + g.toLowerCase() });
+                seg.style.width = pct + '%';
+                seg.title = g + ': ' + pct + '%';
+                geoBar.appendChild(seg);
+            }
+        });
+        geoSec.appendChild(geoBar);
+        const legend = el('div', { class: 'pai-d-geo-legend' });
+        ['US', 'China', 'EU', 'RoW'].forEach(g => {
+            const pct = s.geo_split[g] || 0;
+            if (pct > 0) {
+                legend.appendChild(el('span', null,
+                    el('i', { class: g.toLowerCase() }), g + ' ' + pct + '%'
+                ));
+            }
+        });
+        geoSec.appendChild(legend);
+        drawerInner.appendChild(geoSec);
+
+        // Companies table
+        const compSec = el('div', { class: 'pai-d-section' },
+            el('div', { class: 'pai-d-section-label' }, 'Top companies (' + s.top_companies.length + ')')
+        );
+        const table = el('table', { class: 'pai-d-table' });
+        const thead = el('thead', null,
+            el('tr', null,
+                el('th', null, 'Company'),
+                el('th', { class: 'pai-d-geo-col' }, 'Geo'),
+                el('th', null, 'Last round'),
+                el('th', { class: 'pai-d-val-col' }, 'Val')
+            )
+        );
+        table.appendChild(thead);
+        const tbody = el('tbody');
+        s.top_companies.forEach(c => {
+            const nameCell = el('td');
+            nameCell.appendChild(document.createTextNode(c.name));
+            if (c.flag) {
+                const flagEl = el('span', { class: 'pai-d-flag' + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
+                nameCell.appendChild(flagEl);
+            }
+            tbody.appendChild(el('tr', null,
+                nameCell,
+                el('td', { class: 'pai-d-geo-col' }, c.geo),
+                el('td', null, c.last_round_label || '—'),
+                el('td', { class: 'pai-d-val-col' }, fmtB(c.valuation_m))
+            ));
+        });
+        table.appendChild(tbody);
+        compSec.appendChild(table);
+        drawerInner.appendChild(compSec);
+
+        // Investors
+        if (s.top_investors && s.top_investors.length) {
+            const invSec = el('div', { class: 'pai-d-section' },
+                el('div', { class: 'pai-d-section-label' }, 'Active investors')
+            );
+            const invList = el('div', { class: 'pai-d-investors' });
+            s.top_investors.forEach(i => invList.appendChild(el('span', { class: 'pai-d-investor' }, i)));
+            invSec.appendChild(invList);
+            drawerInner.appendChild(invSec);
+        }
+
+        // Caveats
+        if (s.caveats && s.caveats.length) {
+            const cavSec = el('div', { class: 'pai-d-section' },
+                el('div', { class: 'pai-d-section-label' }, 'Data caveats')
+            );
+            const list = el('ul', { class: 'pai-d-caveats' });
+            s.caveats.forEach(c => list.appendChild(el('li', null, c)));
+            cavSec.appendChild(list);
+            drawerInner.appendChild(cavSec);
+        }
+
+        // Footer
+        const updated = (DATA.meta && DATA.meta.updated) ? DATA.meta.updated : '';
+        const sub = encodeURIComponent('Physical AI Map — ' + s.name);
+        drawerInner.appendChild(el('div', { class: 'pai-d-footer' },
+            el('span', null, 'Last updated ' + updated + ' · v' + (DATA.meta && DATA.meta.version || '0.1')),
+            el('a', { href: 'mailto:hello@canonical.cc?subject=' + sub }, 'Discuss this sub-sector →')
+        ));
+
+        drawer.scrollTop = 0;
+    }
+
+    /* ---------- FILTER WIRE-UP ---------- */
+    function bindFilters() {
+        document.querySelectorAll('.pai-chip-row').forEach(row => {
+            const kind = row.dataset.filter;
+            row.addEventListener('click', (e) => {
+                const chip = e.target.closest('.pai-chip');
+                if (!chip) return;
+                const f = readFilters();
+                f[kind] = chip.dataset.value;
+                writeFilters(f);
+                syncChips();
+                renderSectors();
+            });
+        });
+    }
+
+    /* ---------- SCROLL-SPY SUB-NAV ---------- */
+    function bindScrollSpy() {
+        const links = Array.from(document.querySelectorAll('.pai-subnav-list a'));
+        const map = new Map();
+        links.forEach(a => {
+            const id = a.dataset.spy;
+            const sec = document.getElementById(id);
+            if (sec) map.set(id, { a, sec });
+        });
+
+        function update() {
+            const y = window.scrollY + window.innerHeight * 0.35;
+            let activeId = null;
+            for (const [id, { sec }] of map) {
+                if (sec.offsetTop <= y) activeId = id;
+            }
+            links.forEach(a => a.classList.toggle('active', a.dataset.spy === activeId));
+        }
+
+        window.addEventListener('scroll', update, { passive: true });
+        update();
+    }
+
+    /* ---------- INIT ---------- */
+    async function init() {
+        try {
+            const res = await fetch('data.json', { cache: 'no-cache' });
+            DATA = await res.json();
+        } catch (err) {
+            console.error('Failed to load data.json', err);
+            document.getElementById('sector-grid').innerHTML =
+                '<div class="pai-card-empty">Failed to load dataset. Reload the page or check the network tab.</div>';
+            return;
+        }
+
+        // updated stamp
+        const updatedEl = document.getElementById('pai-updated');
+        if (updatedEl && DATA.meta && DATA.meta.updated) {
+            const d = new Date(DATA.meta.updated + 'T00:00:00');
+            updatedEl.textContent = d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+        }
+
+        renderChasm();
+        renderVelocity();
+        renderFlows();
+        renderDefense();
+        bindFilters();
+        syncChips();
+        renderSectors();
+        bindScrollSpy();
+
+        // global tip tracking (so tip follows cursor when over interactive elements that registered mousemove)
+        document.addEventListener('mousemove', moveTip, { passive: true });
+
+        // Delegated hover tooltips for any element with data-explain or data-term.
+        // Lets us add explanatory copy by marking HTML without rebinding handlers.
+        document.addEventListener('mouseover', (e) => {
+            const t = e.target.closest('[data-explain], [data-term]');
+            if (!t) return;
+            const key = t.dataset.explain || t.dataset.term;
+            showTipFor(e, key);
+        });
+        document.addEventListener('mouseout', (e) => {
+            const t = e.target.closest('[data-explain], [data-term]');
+            if (t) hideTip();
+        });
+        document.addEventListener('focusin', (e) => {
+            const t = e.target.closest('[data-explain], [data-term]');
+            if (!t) return;
+            const key = t.dataset.explain || t.dataset.term;
+            const html = EXPLAIN[key];
+            if (!html) return;
+            const r = t.getBoundingClientRect();
+            tip.innerHTML = html;
+            tip.classList.add('show');
+            tip.style.left = (r.left + r.width / 2) + 'px';
+            tip.style.top = (r.bottom + 8) + 'px';
+        });
+        document.addEventListener('focusout', hideTip);
+
+        // open sector from URL if present
+        const f = readFilters();
+        if (f.sector) openSector(f.sector);
+
+        // close drawer interactions
+        drawerOverlay.addEventListener('click', closeDrawer);
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && drawer.classList.contains('open')) closeDrawer();
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
## Summary

Interactive single-page map of where venture capital is flowing in physical AI from Q1 2023 → Q1 2026. 22 sub-sectors, 4 hero scenes, opinionated Canonical POV on every sub-sector. Lives at `/labs/physical-ai/`, surfaces from the HACKS dropdown.

## What's in here

- **Hero + TL;DR strip** — landscape framed by 4 numbers ($40.7B total, ~80% concentration, 2→22 defense unicorns, $56B+ humanoid chasm), each with a tooltip showing the source and calculation
- **4 hero scenes** — valuation chasm (humanoid vs 6-sub-sector tail), round velocity scatter with bubble-zone overlay, US-kingmaker vs China-IPO capital flows, defense unicorn formation timeline (2→22 in 3 years)
- **Explorer** — 22 sub-sector cards filterable by layer (embodiment / domain / stack), geography (global / US / China / EU), sortable by capital / YoY / deals. All state in URL so any combination is shareable
- **Detail drawer** — full company list with valuations and round labels, investor lineup, geographic split bar, long-form Canonical POV, data caveats, mailto to discuss
- **Tooltips everywhere** — chasm bars, velocity dots, flow rows, defense dots, filter chips, TLDR stats, sector cards (POV preview), TAM glossary term
- **Deep linking** — `?layer=stack&sort=yoy&sector=foundation-models-for-robotics` filters the grid AND auto-opens the drawer on load
- **Mobile pass** — scatter plot falls back to a sorted velocity list, grid collapses to one column, drawer goes full width, sub-nav horizontally scrolls
- **No backend** — data lives in `/labs/physical-ai/data.json` checked into the repo. Quarterly refresh is a PR

## File layout

- `labs/physical-ai/index.html` — page scaffold, sections wired through Jekyll includes for header / footer
- `labs/physical-ai/lab.css` — adapts the editorial composition to canonical.cc's navy gradient + Aeonik system with white-paper viz cards and orange accent
- `labs/physical-ai/lab.js` — vanilla JS, fetches data.json, renders all scenes and cards, owns filter / drawer / scroll-spy / tooltip state
- `labs/physical-ai/data.json` — single source of truth: 22 sub-sectors, 4 scenes, 8 velocity points, 11 defense unicorns. Sourced from Harmonic, PitchBook, Crunchbase, FT, Reuters, Bloomberg, SEC/HKEX/SSE filings, 36Kr, Caixin
- `_includes/header.html` — adds `Physical AI Map` to the HACKS dropdown
- `.gitignore` — new file. Excludes personal `.claude/` state and Jekyll local build artifacts

## Test plan

- [ ] Confirm Jekyll header / footer render on the GitHub Pages preview URL (locally `{% include %}` shows as text without bundler)
- [ ] Hero, TL;DR, all 4 hero scenes render at 1280 / 1440 desktop widths
- [ ] All 22 explorer cards render with correct number, layer pill, capital / YoY / deals stats
- [ ] Layer / geo / sort chips filter and reorder cards correctly; URL updates
- [ ] Click a card → drawer opens with companies, investors, geo bar, POV, caveats. URL gets `?sector=...`. ESC closes; overlay click closes
- [ ] Deep link `?layer=embodiment&sort=yoy&sector=humanoid-robotics` restores filters and auto-opens drawer
- [ ] Hover tooltips fire on chasm bars, scatter dots, flow rows, defense dots, filter chips, TLDR stats, sector cards (POV preview), TAM glossary term
- [ ] Bedrock Robotics scatter dot click navigates to Construction Robotics drawer
- [ ] Mobile (375px): velocity scatter is hidden, fallback list shows 8 rows; grid is one column; sub-nav scrolls horizontally; drawer is full-width
- [ ] Physical AI Map link visible in HACKS dropdown across canonical.cc, dilutionlab, fundmodeler, power-law
- [ ] No 404s on `data.json`, `lab.css`, `lab.js`
- [ ] No console errors on page load

## Phase 2 (not in this PR)

- Live public market caps (Hesai, RoboSense, Symbotic, Ouster, Ekso) with a daily-refreshed live indicator
- Investor focus view: click any investor → see all their physical-AI portfolio companies
- CSV download generator at build time (currently exports the JSON as-is)
- Per-sub-sector OG images for nicer X previews
- Comparison mode: pin 2–3 sub-sectors side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)