### PR TITLE
Add Canonical Labs section to homepage (4 cards, horizontal scroll)

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -34,6 +34,7 @@
         <a href="https://canonical.cc/labs/dilutionlab/" class="nav-mobile-sublink">Dilution Lab</a>
         <a href="https://canonical.cc/labs/fundmodeler/" class="nav-mobile-sublink">Fund Modeler</a>
         <a href="https://canonical.cc/labs/power-law/" class="nav-mobile-sublink">Power Law Lab</a>
+        <a href="https://canonical.cc/labs/physical-ai/" class="nav-mobile-sublink">Physical AI Map</a>
         <a href="https://canonical.cc/#team" class="nav-mobile-link" data-canonical-anchor="team">TEAM</a>
     </nav>
 </header>

--- a/css/style.css
+++ b/css/style.css
@@ -1132,3 +1132,45 @@ html {
         display: flex;
     }
 }
+
+/* Labs section cards (homepage) */
+.lab-card {
+    width: 280px;
+    background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    transition: all 0.3s ease;
+    flex-shrink: 0;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    min-height: 180px;
+    font-family: 'Aeonik Regular', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.lab-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2);
+}
+
+.lab-card-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #111827;
+    margin-bottom: 0.5rem;
+}
+
+.lab-card-description {
+    color: #475569;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin-bottom: 1rem;
+    flex-grow: 1;
+}
+
+.lab-card-cta {
+    color: #1e3a8a;
+    font-size: 0.875rem;
+    font-weight: 500;
+}

--- a/index.html
+++ b/index.html
@@ -197,6 +197,50 @@
             </section>
 
 
+            <!-- Labs Section -->
+            <section id="labs" class="section-padding">
+                <div class="max-w-7xl mx-auto px-8">
+                    <h2 class="section-title">Canonical Labs</h2>
+                    <p class="section-subtitle">
+                        Free, interactive tools we build for founders, GPs, and LPs.
+                    </p>
+
+                    <div class="overflow-x-auto portfolio-carousel">
+                        <div class="flex gap-8 pb-4" style="width: max-content">
+                            <a href="/labs/dilutionlab/" class="lab-card flex-shrink-0">
+                                <h3 class="lab-card-title">Dilution Lab</h3>
+                                <p class="lab-card-description">
+                                    Model SAFEs, priced rounds, option pools, and exit math. See what every term sheet actually costs you.
+                                </p>
+                                <span class="lab-card-cta">Try it &rarr;</span>
+                            </a>
+                            <a href="/labs/fundmodeler/" class="lab-card flex-shrink-0">
+                                <h3 class="lab-card-title">Fund Modeler</h3>
+                                <p class="lab-card-description">
+                                    Size your fund, model portfolio construction, and forecast TVPI, DPI, MOIC, and IRR.
+                                </p>
+                                <span class="lab-card-cta">Try it &rarr;</span>
+                            </a>
+                            <a href="/labs/power-law/" class="lab-card flex-shrink-0">
+                                <h3 class="lab-card-title">Power Law Lab</h3>
+                                <p class="lab-card-description">
+                                    Manipulate a venture fund's outcome distribution and see what actually drives fund returns.
+                                </p>
+                                <span class="lab-card-cta">Try it &rarr;</span>
+                            </a>
+                            <a href="/labs/physical-ai/" class="lab-card flex-shrink-0">
+                                <h3 class="lab-card-title">Physical AI Map</h3>
+                                <p class="lab-card-description">
+                                    Three years of venture investment in physical AI, mapped across 22 sub-sectors.
+                                </p>
+                                <span class="lab-card-cta">Try it &rarr;</span>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+
             <!-- Substack Section -->
             <section id="substack" class="section-padding">
                 <div class="max-w-7xl mx-auto px-8">


### PR DESCRIPTION
## Summary
Adds a "Canonical Labs" section to the homepage between Portfolio and Substack. Same horizontal-scroll carousel pattern as Select Portfolio. One card per lab: Dilution Lab, Fund Modeler, Power Law Lab, Physical AI Map.

Also: adds Physical AI Map to the mobile hamburger nav. It was already in the desktop LABS dropdown but missing from mobile — caught while building this section.

## Diff
- [index.html](index.html) — new `<section id="labs">` block
- [css/style.css](css/style.css) — new `.lab-card*` rules (scoped, no existing styles touched)
- [_includes/header.html](_includes/header.html) — mobile nav sync (1 line added)

## Test plan
- [ ] Homepage shows the 4 lab cards between Portfolio and Substack
- [ ] Cards scroll horizontally on narrow viewports, lift on hover
- [ ] Clicking each card lands on the correct lab
- [ ] Mobile hamburger now lists all 4 labs

🤖 Generated with [Claude Code](https://claude.com/claude-code)