### PR TITLE
Physical AI Map: investor view, daily quotes, company SEO links, copy polish

### DIFF
--- a/.github/workflows/refresh-quotes.yml
+++ b/.github/workflows/refresh-quotes.yml
@@ -1,0 +1,38 @@
+name: Refresh public market quotes
+
+on:
+  schedule:
+    # 22:00 UTC weekdays — after US market close (16:00 ET / 21:00 GMT, with cushion).
+    # Picks up HKEX overnight too since those markets closed earlier.
+    - cron: '0 22 * * 1-5'
+  workflow_dispatch:  # Manual trigger from the Actions tab
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch quotes from Stooq and update data.json
+        run: node scripts/refresh-quotes.mjs
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet labs/physical-ai/data.json; then
+            echo "No quote changes today."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add labs/physical-ai/data.json
+          git commit -m "chore(physical-ai): refresh live quotes ($(date -u +%Y-%m-%d))"
+          git push

--- a/labs/physical-ai/data.json
+++ b/labs/physical-ai/data.json
@@ -3,95 +3,352 @@
     "version": "0.1",
     "updated": "2026-05-15",
     "window": "Q1 2023 - Q1 2026",
-    "sources": ["Harmonic", "Pitchbook Premium", "Crunchbase", "Sacra", "FT", "Reuters", "Bloomberg", "SEC/HKEX/SSE filings", "company press releases", "36Kr", "Caixin"],
+    "sources": [
+      "Harmonic",
+      "Pitchbook Premium",
+      "Crunchbase",
+      "Sacra",
+      "FT",
+      "Reuters",
+      "Bloomberg",
+      "SEC/HKEX/SSE filings",
+      "company press releases",
+      "36Kr",
+      "Caixin"
+    ],
     "notes": "Public market caps are point-in-time snapshots and stale within weeks. Private valuations stick to last-round post-money. Rounds 'in talks' are reported but not closed; flagged explicitly."
   },
-
   "scenes": {
     "valuation_chasm": {
-      "headline": "Four humanoid companies have raised more in 18 months than six entire sub-sectors combined.",
+      "headline": "4 humanoid companies have raised more in 18 months than 6 entire sub-sectors combined.",
       "lede": "Figure, Apptronik, Agility, and 1X have together captured more venture and strategic capital in 2024-25 than the entire surgical robotics, agricultural robotics, construction robotics, consumer robotics, exoskeleton, and quadruped industries combined. The chasm exists because humanoids are pricing in 2030 commercial deployment. The adjacent sectors are pricing in 2026 unit economics.",
       "pov": "The most under-appreciated opportunity in physical AI is surgical robotics. Intuitive's monopoly cracked for the first time in 25 years with Medtronic Hugo and CMR Versius Plus FDA clearance, yet VC dollars are 1/20th of humanoids despite 10x the proven unit economics. The chasm goes both ways.",
       "headline_bars": [
-        {"name": "Figure AI", "geo": "US", "valuation_m": 39000, "round": "Sep 2025 Series C"},
-        {"name": "1X Technologies", "geo": "NO/US", "valuation_m": 10000, "round": "target, in talks", "flag": "in-talks"},
-        {"name": "Apptronik", "geo": "US", "valuation_m": 5400, "round": "Series A ext Feb 2026", "flag": "estimated"},
-        {"name": "Agility Robotics", "geo": "US", "valuation_m": 2100, "round": "Series C 2025"}
+        {
+          "name": "Figure AI",
+          "geo": "US",
+          "valuation_m": 39000,
+          "round": "Sep 2025 Series C"
+        },
+        {
+          "name": "1X Technologies",
+          "geo": "NO/US",
+          "valuation_m": 10000,
+          "round": "target, in talks",
+          "flag": "in-talks"
+        },
+        {
+          "name": "Apptronik",
+          "geo": "US",
+          "valuation_m": 5400,
+          "round": "Series A ext Feb 2026",
+          "flag": "estimated"
+        },
+        {
+          "name": "Agility Robotics",
+          "geo": "US",
+          "valuation_m": 2100,
+          "round": "Series C 2025"
+        }
       ],
       "tail_bars": [
-        {"name": "Surgical robotics", "value_m": 1500, "note": "global VC, in window"},
-        {"name": "Construction robotics", "value_m": 1400, "note": "global VC, in window"},
-        {"name": "Agricultural robotics", "value_m": 500, "note": "global VC, in window"},
-        {"name": "Quadrupeds", "value_m": 200, "note": "excl. Unitree IPO"},
-        {"name": "Exoskeletons", "value_m": 100, "note": "global VC, in window"},
-        {"name": "Consumer robotics", "value_m": 50, "note": "post iRobot Ch.11"}
+        {
+          "name": "Surgical robotics",
+          "value_m": 1500,
+          "note": "global VC, in window"
+        },
+        {
+          "name": "Construction robotics",
+          "value_m": 1400,
+          "note": "global VC, in window"
+        },
+        {
+          "name": "Agricultural robotics",
+          "value_m": 500,
+          "note": "global VC, in window"
+        },
+        {
+          "name": "Quadrupeds",
+          "value_m": 200,
+          "note": "excl. Unitree IPO"
+        },
+        {
+          "name": "Exoskeletons",
+          "value_m": 100,
+          "note": "global VC, in window"
+        },
+        {
+          "name": "Consumer robotics",
+          "value_m": 50,
+          "note": "post iRobot Ch.11"
+        }
       ],
       "summary_multiple": "15.6x",
-      "summary_label": "Top 4 humanoid valuations to six-sector sum"
+      "summary_label": "Top 4 humanoid valuations to 6-sector sum"
     },
-
     "round_velocity": {
       "headline": "The fastest markups in physical AI are not in humanoids.",
-      "lede": "Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in seven months. That's a 21.9x markup with revenue from production deployments still measured in the millions. Figure's 15x over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.",
+      "lede": "Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in 7 months. That's a 21.9x markup with revenue from production deployments still measured in the millions. Figure's 15x over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.",
       "pov": "Round velocity above 2x with less than 12 months between rounds is the cleanest bubble signal in physical AI. Most of the top-left quadrant won't have proportional revenue scaling. The exception is Anduril, which is why it's the only defense unicorn with a revenue base that justifies the multiple.",
       "data_points": [
-        {"company": "Bedrock Robotics", "months_between": 7, "multiple": 21.9, "prev_val_m": 80, "new_val_m": 1750, "category": "bubble", "sub_sector": "construction-robotics"},
-        {"company": "Figure AI", "months_between": 19, "multiple": 15.0, "prev_val_m": 2600, "new_val_m": 39000, "category": "bubble", "sub_sector": "humanoid-robotics"},
-        {"company": "Apptronik", "months_between": 11, "multiple": 3.3, "prev_val_m": 1600, "new_val_m": 5400, "category": "elevated", "sub_sector": "humanoid-robotics"},
-        {"company": "Skild AI", "months_between": 7, "multiple": 3.1, "prev_val_m": 4500, "new_val_m": 14000, "category": "elevated", "sub_sector": "foundation-models-for-robotics"},
-        {"company": "Shield AI", "months_between": 12, "multiple": 2.4, "prev_val_m": 5300, "new_val_m": 12700, "category": "elevated", "sub_sector": "defense-dual-use"},
-        {"company": "Saronic", "months_between": 13, "multiple": 2.3, "prev_val_m": 4000, "new_val_m": 9250, "category": "elevated", "sub_sector": "marine-underwater-robotics"},
-        {"company": "Anduril", "months_between": 11, "multiple": 2.0, "prev_val_m": 30500, "new_val_m": 61000, "category": "justified-by-revenue", "sub_sector": "defense-dual-use"},
-        {"company": "Mind Robotics", "months_between": 2, "multiple": 1.7, "prev_val_m": 2000, "new_val_m": 3400, "category": "elevated", "sub_sector": "industrial-automation"}
+        {
+          "company": "Bedrock Robotics",
+          "months_between": 7,
+          "multiple": 21.9,
+          "prev_val_m": 80,
+          "new_val_m": 1750,
+          "category": "bubble",
+          "sub_sector": "construction-robotics"
+        },
+        {
+          "company": "Figure AI",
+          "months_between": 19,
+          "multiple": 15,
+          "prev_val_m": 2600,
+          "new_val_m": 39000,
+          "category": "bubble",
+          "sub_sector": "humanoid-robotics"
+        },
+        {
+          "company": "Apptronik",
+          "months_between": 11,
+          "multiple": 3.3,
+          "prev_val_m": 1600,
+          "new_val_m": 5400,
+          "category": "elevated",
+          "sub_sector": "humanoid-robotics"
+        },
+        {
+          "company": "Skild AI",
+          "months_between": 7,
+          "multiple": 3.1,
+          "prev_val_m": 4500,
+          "new_val_m": 14000,
+          "category": "elevated",
+          "sub_sector": "foundation-models-for-robotics"
+        },
+        {
+          "company": "Shield AI",
+          "months_between": 12,
+          "multiple": 2.4,
+          "prev_val_m": 5300,
+          "new_val_m": 12700,
+          "category": "elevated",
+          "sub_sector": "defense-dual-use"
+        },
+        {
+          "company": "Saronic",
+          "months_between": 13,
+          "multiple": 2.3,
+          "prev_val_m": 4000,
+          "new_val_m": 9250,
+          "category": "elevated",
+          "sub_sector": "marine-underwater-robotics"
+        },
+        {
+          "company": "Anduril",
+          "months_between": 11,
+          "multiple": 2,
+          "prev_val_m": 30500,
+          "new_val_m": 61000,
+          "category": "justified-by-revenue",
+          "sub_sector": "defense-dual-use"
+        },
+        {
+          "company": "Mind Robotics",
+          "months_between": 2,
+          "multiple": 1.7,
+          "prev_val_m": 2000,
+          "new_val_m": 3400,
+          "category": "elevated",
+          "sub_sector": "industrial-automation"
+        }
       ]
     },
-
     "us_china_flows": {
       "headline": "US kingmakers underwrite the model. China underwrites the factory.",
-      "lede": "The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10x revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. Two paths to the same physical world, two completely different unit economics.",
+      "lede": "The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10x revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. 2 paths to the same physical world, 2 completely different unit economics.",
       "caveat": "China shipped ~90% of humanoid units in 2025 but captured ~30% of dollars. And ~75% of those units went to universities and research institutions. Unitree's own IPO prospectus discloses >50% of revenue from the scientific research and education sector. The volume narrative needs a quality flag.",
       "pov": "Unit volume in China is not yet commercial deployment. The structural advantage is real but the customer base is narrow. Watch for the first Chinese humanoid manufacturer to disclose >50% commercial revenue. That's the inflection.",
       "us_flows": [
-        {"investors": ["OpenAI"], "company": "1X"},
-        {"investors": ["Microsoft", "Amazon", "OpenAI"], "company": "Figure"},
-        {"investors": ["Google", "Mercedes"], "company": "Apptronik"},
-        {"investors": ["Amazon", "SoftBank", "Nvidia"], "company": "Agility"},
-        {"investors": ["SoftBank", "Nvidia", "Bezos Expeditions"], "company": "Skild"},
-        {"investors": ["CapitalG", "Lux", "Bezos Expeditions"], "company": "Physical Intelligence"},
-        {"investors": ["JPMorgan", "BlackRock", "Bezos"], "company": "Project Prometheus"}
+        {
+          "investors": [
+            "OpenAI"
+          ],
+          "company": "1X"
+        },
+        {
+          "investors": [
+            "Microsoft",
+            "Amazon",
+            "OpenAI"
+          ],
+          "company": "Figure"
+        },
+        {
+          "investors": [
+            "Google",
+            "Mercedes"
+          ],
+          "company": "Apptronik"
+        },
+        {
+          "investors": [
+            "Amazon",
+            "SoftBank",
+            "Nvidia"
+          ],
+          "company": "Agility"
+        },
+        {
+          "investors": [
+            "SoftBank",
+            "Nvidia",
+            "Bezos Expeditions"
+          ],
+          "company": "Skild"
+        },
+        {
+          "investors": [
+            "CapitalG",
+            "Lux",
+            "Bezos Expeditions"
+          ],
+          "company": "Physical Intelligence"
+        },
+        {
+          "investors": [
+            "JPMorgan",
+            "BlackRock",
+            "Bezos"
+          ],
+          "company": "Project Prometheus"
+        }
       ],
       "us_exit_path": "private mega-rounds, $1K/mo RaaS",
       "china_flows": [
-        {"investors": ["Alibaba", "Geely"], "company": "Unitree"},
-        {"investors": ["Tencent", "JD.com"], "company": "AgiBot"},
-        {"investors": ["HongShan", "Beijing Robot Fund"], "company": "EngineAI, LimX"},
-        {"investors": ["HK govt", "Geely", "BAIC"], "company": "Galbot, Robot Era"},
-        {"investors": ["CITIC Goldstone"], "company": "Leju"},
-        {"investors": ["Meituan", "Alibaba"], "company": "X Square, Spirit AI"}
+        {
+          "investors": [
+            "Alibaba",
+            "Geely"
+          ],
+          "company": "Unitree"
+        },
+        {
+          "investors": [
+            "Tencent",
+            "JD.com"
+          ],
+          "company": "AgiBot"
+        },
+        {
+          "investors": [
+            "HongShan",
+            "Beijing Robot Fund"
+          ],
+          "company": "EngineAI, LimX"
+        },
+        {
+          "investors": [
+            "HK govt",
+            "Geely",
+            "BAIC"
+          ],
+          "company": "Galbot, Robot Era"
+        },
+        {
+          "investors": [
+            "CITIC Goldstone"
+          ],
+          "company": "Leju"
+        },
+        {
+          "investors": [
+            "Meituan",
+            "Alibaba"
+          ],
+          "company": "X Square, Spirit AI"
+        }
       ],
       "china_exit_path": "STAR Market, HKEX, A-share"
     },
-
     "defense_unicorns": {
-      "headline": "From two unicorns to twenty-two in three years.",
-      "lede": "In 2022, exactly two pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in twelve months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.",
+      "headline": "From 2 unicorns to 22 in 3 years.",
+      "lede": "In 2022, exactly 2 pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in 12 months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.",
       "pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is $1.5B equity at $12.7B plus $500M Blackstone fixed-return preferred. The first sign defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble.",
       "unicorns": [
-        {"name": "Anduril", "first_unicorn_year": 2022, "latest_val_m": 61000, "latest_round": "Series H May 2026", "highlight": true},
-        {"name": "Shield AI", "first_unicorn_year": 2022, "latest_val_m": 12700, "latest_round": "Series G Mar 2026", "structured_note": "$1.5B equity + $500M Blackstone preferred"},
-        {"name": "Saronic", "first_unicorn_year": 2024, "latest_val_m": 9250, "latest_round": "Series D Mar 2026"},
-        {"name": "Helsing", "first_unicorn_year": 2024, "latest_val_m": 18000, "latest_round": "Series D in talks", "flag": "in-talks"},
-        {"name": "CHAOS Industries", "first_unicorn_year": 2025, "latest_val_m": 4500, "latest_round": "Series D Nov 2025"},
-        {"name": "Onebrief", "first_unicorn_year": 2025, "latest_val_m": 1100, "latest_round": "$300M+ cumulative"},
-        {"name": "Castelion", "first_unicorn_year": 2025, "latest_val_m": 1500, "latest_round": "Series B Dec 2025"},
-        {"name": "Hermeus", "first_unicorn_year": 2026, "latest_val_m": 1000, "latest_round": "Series D Apr 2026"},
-        {"name": "True Anomaly", "first_unicorn_year": 2026, "latest_val_m": 2000, "latest_round": "Series C Apr 2026"},
-        {"name": "Forterra", "first_unicorn_year": 2025, "latest_val_m": 1200, "latest_round": "Series C Nov 2025"},
-        {"name": "Quantum Systems", "first_unicorn_year": 2024, "latest_val_m": 1000, "latest_round": "Series C 2024"}
+        {
+          "name": "Anduril",
+          "first_unicorn_year": 2022,
+          "latest_val_m": 61000,
+          "latest_round": "Series H May 2026",
+          "highlight": true
+        },
+        {
+          "name": "Shield AI",
+          "first_unicorn_year": 2022,
+          "latest_val_m": 12700,
+          "latest_round": "Series G Mar 2026",
+          "structured_note": "$1.5B equity + $500M Blackstone preferred"
+        },
+        {
+          "name": "Saronic",
+          "first_unicorn_year": 2024,
+          "latest_val_m": 9250,
+          "latest_round": "Series D Mar 2026"
+        },
+        {
+          "name": "Helsing",
+          "first_unicorn_year": 2024,
+          "latest_val_m": 18000,
+          "latest_round": "Series D in talks",
+          "flag": "in-talks"
+        },
+        {
+          "name": "CHAOS Industries",
+          "first_unicorn_year": 2025,
+          "latest_val_m": 4500,
+          "latest_round": "Series D Nov 2025"
+        },
+        {
+          "name": "Onebrief",
+          "first_unicorn_year": 2025,
+          "latest_val_m": 1100,
+          "latest_round": "$300M+ cumulative"
+        },
+        {
+          "name": "Castelion",
+          "first_unicorn_year": 2025,
+          "latest_val_m": 1500,
+          "latest_round": "Series B Dec 2025"
+        },
+        {
+          "name": "Hermeus",
+          "first_unicorn_year": 2026,
+          "latest_val_m": 1000,
+          "latest_round": "Series D Apr 2026"
+        },
+        {
+          "name": "True Anomaly",
+          "first_unicorn_year": 2026,
+          "latest_val_m": 2000,
+          "latest_round": "Series C Apr 2026"
+        },
+        {
+          "name": "Forterra",
+          "first_unicorn_year": 2025,
+          "latest_val_m": 1200,
+          "latest_round": "Series C Nov 2025"
+        },
+        {
+          "name": "Quantum Systems",
+          "first_unicorn_year": 2024,
+          "latest_val_m": 1000,
+          "latest_round": "Series C 2024"
+        }
       ]
     }
   },
-
   "subsectors": [
     {
       "id": "humanoid-robotics",
@@ -101,22 +358,96 @@
       "capital_2024_25_m": 5100,
       "yoy_growth_pct": 169,
       "deals_count": 26,
-      "geo_split": {"US": 50, "China": 38, "EU": 10, "RoW": 2},
+      "geo_split": {
+        "US": 50,
+        "China": 38,
+        "EU": 10,
+        "RoW": 2
+      },
       "top_companies": [
-        {"name": "Figure AI", "geo": "US", "valuation_m": 39000, "last_round_label": "Series C Sep 2025"},
-        {"name": "Apptronik", "geo": "US", "valuation_m": 5400, "last_round_label": "Series A ext Feb 2026", "flag": "estimated"},
-        {"name": "1X Technologies", "geo": "RoW", "valuation_m": 10000, "last_round_label": "target, in talks", "flag": "in-talks"},
-        {"name": "Agility Robotics", "geo": "US", "valuation_m": 2100, "last_round_label": "Series C 2025"},
-        {"name": "Unitree", "geo": "China", "valuation_m": 6100, "last_round_label": "STAR Market IPO target Mar 2026"},
-        {"name": "AgiBot (Zhiyuan)", "geo": "China", "valuation_m": 2100, "last_round_label": "pre-HK IPO", "flag": "estimated"},
-        {"name": "Fourier", "geo": "China", "valuation_m": 1100, "last_round_label": "2025"},
-        {"name": "Neura Robotics", "geo": "EU", "valuation_m": 1200, "last_round_label": "Series B Jan 2025"},
-        {"name": "Galbot", "geo": "China", "valuation_m": 3000, "last_round_label": "Dec 2025 + Mar 2026"},
-        {"name": "Robot Era", "geo": "China", "valuation_m": 1400, "last_round_label": "Apr 2026"}
+        {
+          "name": "Figure AI",
+          "geo": "US",
+          "valuation_m": 39000,
+          "last_round_label": "Series C Sep 2025"
+        },
+        {
+          "name": "Apptronik",
+          "geo": "US",
+          "valuation_m": 5400,
+          "last_round_label": "Series A ext Feb 2026",
+          "flag": "estimated"
+        },
+        {
+          "name": "1X Technologies",
+          "geo": "RoW",
+          "valuation_m": 10000,
+          "last_round_label": "target, in talks",
+          "flag": "in-talks"
+        },
+        {
+          "name": "Agility Robotics",
+          "geo": "US",
+          "valuation_m": 2100,
+          "last_round_label": "Series C 2025"
+        },
+        {
+          "name": "Unitree",
+          "geo": "China",
+          "valuation_m": 6100,
+          "last_round_label": "STAR Market IPO target Mar 2026"
+        },
+        {
+          "name": "AgiBot (Zhiyuan)",
+          "geo": "China",
+          "valuation_m": 2100,
+          "last_round_label": "pre-HK IPO",
+          "flag": "estimated"
+        },
+        {
+          "name": "Fourier",
+          "geo": "China",
+          "valuation_m": 1100,
+          "last_round_label": "2025"
+        },
+        {
+          "name": "Neura Robotics",
+          "geo": "EU",
+          "valuation_m": 1200,
+          "last_round_label": "Series B Jan 2025"
+        },
+        {
+          "name": "Galbot",
+          "geo": "China",
+          "valuation_m": 3000,
+          "last_round_label": "Dec 2025 + Mar 2026"
+        },
+        {
+          "name": "Robot Era",
+          "geo": "China",
+          "valuation_m": 1400,
+          "last_round_label": "Apr 2026"
+        }
       ],
-      "top_investors": ["Alibaba", "HongShan", "Beijing Robot Industry Dev Fund", "Matrix Partners China", "Tencent", "JD.com", "Meituan", "Nvidia NVentures", "Bezos Expeditions", "SoftBank"],
+      "top_investors": [
+        "Alibaba",
+        "HongShan",
+        "Beijing Robot Industry Dev Fund",
+        "Matrix Partners China",
+        "Tencent",
+        "JD.com",
+        "Meituan",
+        "Nvidia NVentures",
+        "Bezos Expeditions",
+        "SoftBank"
+      ],
       "canonical_pov": "Humanoid funding is concentrated in 4 US companies that have together raised more in 18 months than the entire surgical robotics industry has in its history. The only pure-play humanoid manufacturer with audited profitability at scale is Unitree, and the prospectus reveals their profitability is a 2024-25 turnaround story, not the 'profitable since 2020' narrative their PR has carried. The bear case sits in plain sight: Unitree's R&D-to-revenue ratio is 7.73%, suggesting under-investment in the next platform.",
-      "caveats": ["~75% of 2025 Chinese unit shipments to research institutions per HelloChinaTech", "Unitree prospectus discloses >50% of revenue from scientific research and education sector", "AgiBot valuation $2.1B is estimated, no primary source identified", "1X $10B round reported as 'in talks' not closed"]
+      "caveats": [
+        "~75% of 2025 Chinese unit shipments to research institutions per HelloChinaTech",
+        "Unitree prospectus discloses >50% of revenue from scientific research and education sector",
+        "AgiBot valuation $2.1B is estimated, no primary source identified",
+        "1X $10B round reported as 'in talks' not closed"
+      ]
     },
     {
       "id": "quadrupeds",
@@ -126,17 +457,51 @@
       "capital_2024_25_m": 200,
       "yoy_growth_pct": -10,
       "deals_count": 6,
-      "geo_split": {"US": 35, "China": 50, "EU": 15, "RoW": 0},
+      "geo_split": {
+        "US": 35,
+        "China": 50,
+        "EU": 15,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Boston Dynamics", "geo": "US", "valuation_m": null, "last_round_label": "Hyundai-owned"},
-        {"name": "ANYbotics", "geo": "EU", "valuation_m": null, "last_round_label": "Series B 2022"},
-        {"name": "Unitree (quadruped legacy)", "geo": "China", "valuation_m": null, "last_round_label": "see Humanoid"},
-        {"name": "Deep Robotics", "geo": "China", "valuation_m": null, "last_round_label": null},
-        {"name": "Ghost Robotics", "geo": "US", "valuation_m": 750, "last_round_label": "$750M LIG Nex1 tender 2024", "flag": "estimated"}
+        {
+          "name": "Boston Dynamics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Hyundai-owned"
+        },
+        {
+          "name": "ANYbotics",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Series B 2022"
+        },
+        {
+          "name": "Unitree (quadruped legacy)",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "see Humanoid"
+        },
+        {
+          "name": "Deep Robotics",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Ghost Robotics",
+          "geo": "US",
+          "valuation_m": 750,
+          "last_round_label": "$750M LIG Nex1 tender 2024",
+          "flag": "estimated"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "The quadruped market has converged toward defense and utility inspection. Spot and Ghost Vision 60 are now mostly purchased by Pentagon and energy utilities, not consumer or research markets. Unitree retains ~70% of global quadruped sales but is pivoting capital and R&D toward humanoids. The prospectus shows the dramatic revenue mix flip from quadrupeds (65% 2024) to humanoids (51%+ 2025).",
-      "caveats": ["Ghost Robotics $750M LIG Nex1 tender reported but close not independently confirmed", "Boston Dynamics unit and revenue data largely private"]
+      "caveats": [
+        "Ghost Robotics $750M LIG Nex1 tender reported but close not independently confirmed",
+        "Boston Dynamics unit and revenue data largely private"
+      ]
     },
     {
       "id": "wheeled-warehouse-robots",
@@ -146,18 +511,64 @@
       "capital_2024_25_m": 970,
       "yoy_growth_pct": -48,
       "deals_count": 70,
-      "geo_split": {"US": 55, "China": 25, "EU": 15, "RoW": 5},
+      "geo_split": {
+        "US": 55,
+        "China": 25,
+        "EU": 15,
+        "RoW": 5
+      },
       "top_companies": [
-        {"name": "Symbotic", "geo": "US", "valuation_m": 38500, "last_round_label": "NASDAQ May 2026", "flag": "public-market-cap"},
-        {"name": "Locus Robotics", "geo": "US", "valuation_m": 2000, "last_round_label": "$438M total"},
-        {"name": "Geek+", "geo": "China", "valuation_m": null, "last_round_label": "late-stage, $545M raised"},
-        {"name": "GreyOrange", "geo": "US", "valuation_m": null, "last_round_label": "$545M cumulative"},
-        {"name": "AutoStore", "geo": "EU", "valuation_m": null, "last_round_label": "Oslo public"},
-        {"name": "Exotec", "geo": "EU", "valuation_m": null, "last_round_label": "Series D 2022"}
+        {
+          "name": "Symbotic",
+          "geo": "US",
+          "valuation_m": 38500,
+          "last_round_label": "NASDAQ May 2026",
+          "flag": "public-market-cap",
+          "ticker": "SYM"
+        },
+        {
+          "name": "Locus Robotics",
+          "geo": "US",
+          "valuation_m": 2000,
+          "last_round_label": "$438M total"
+        },
+        {
+          "name": "Geek+",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "late-stage, $545M raised"
+        },
+        {
+          "name": "GreyOrange",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$545M cumulative"
+        },
+        {
+          "name": "AutoStore",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Oslo public"
+        },
+        {
+          "name": "Exotec",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Series D 2022"
+        }
       ],
-      "top_investors": ["ATL Partners", "Insight Partners", "Tiger Global", "BlackRock", "Mithril"],
+      "top_investors": [
+        "ATL Partners",
+        "Insight Partners",
+        "Tiger Global",
+        "BlackRock",
+        "Mithril"
+      ],
       "canonical_pov": "Symbotic vs. Amazon's internal Sequoia/Proteus is the bellwether. Third-party warehouse robotics survives only if Symbotic-style multi-customer scale is preserved. Amazon's automation target (75% by 2033, 600K fewer hires) is the demand-side ceiling for the entire third-party warehouse robotics industry.",
-      "caveats": ["Warehouse VC -48% YoY in 2025 per Tracxn", "Symbotic market cap is public and moves daily"]
+      "caveats": [
+        "Warehouse VC -48% YoY in 2025 per Tracxn",
+        "Symbotic market cap is public and moves daily"
+      ]
     },
     {
       "id": "aerial-drones",
@@ -167,17 +578,55 @@
       "capital_2024_25_m": 2000,
       "yoy_growth_pct": 60,
       "deals_count": 38,
-      "geo_split": {"US": 60, "China": 10, "EU": 25, "RoW": 5},
+      "geo_split": {
+        "US": 60,
+        "China": 10,
+        "EU": 25,
+        "RoW": 5
+      },
       "top_companies": [
-        {"name": "Skydio", "geo": "US", "valuation_m": 4400, "last_round_label": "Series F Apr 2026"},
-        {"name": "Zipline", "geo": "US", "valuation_m": 7600, "last_round_label": "Jan 2026"},
-        {"name": "Brinc Drones", "geo": "US", "valuation_m": null, "last_round_label": "$75M+ cumulative"},
-        {"name": "Wingtra", "geo": "EU", "valuation_m": null, "last_round_label": null},
-        {"name": "Quantum Systems", "geo": "EU", "valuation_m": 1000, "last_round_label": "Series C 2024"}
+        {
+          "name": "Skydio",
+          "geo": "US",
+          "valuation_m": 4400,
+          "last_round_label": "Series F Apr 2026"
+        },
+        {
+          "name": "Zipline",
+          "geo": "US",
+          "valuation_m": 7600,
+          "last_round_label": "Jan 2026"
+        },
+        {
+          "name": "Brinc Drones",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$75M+ cumulative"
+        },
+        {
+          "name": "Wingtra",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Quantum Systems",
+          "geo": "EU",
+          "valuation_m": 1000,
+          "last_round_label": "Series C 2024"
+        }
       ],
-      "top_investors": ["Nvidia NVentures", "a16z", "Founders Fund", "Linse Capital"],
+      "top_investors": [
+        "Nvidia NVentures",
+        "a16z",
+        "Founders Fund",
+        "Linse Capital"
+      ],
       "canonical_pov": "Skydio's Blue UAS Cleared List plus the Trump Drone Dominance EO creates a regulatory moat against DJI. But Skydio's hardware-only revenue grew 80% while software is ~30% of mix. The moat may be regulatory, not technical.",
-      "caveats": ["Excludes defense-specific drone companies (counted in Defense)", "China drones underrepresented due to DJI dominance and IPO timing"]
+      "caveats": [
+        "Excludes defense-specific drone companies (counted in Defense)",
+        "China drones underrepresented due to DJI dominance and IPO timing"
+      ]
     },
     {
       "id": "marine-underwater-robotics",
@@ -187,17 +636,55 @@
       "capital_2024_25_m": 2500,
       "yoy_growth_pct": 200,
       "deals_count": 14,
-      "geo_split": {"US": 85, "China": 5, "EU": 10, "RoW": 0},
+      "geo_split": {
+        "US": 85,
+        "China": 5,
+        "EU": 10,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Saronic", "geo": "US", "valuation_m": 9250, "last_round_label": "Series D Mar 2026"},
-        {"name": "Saildrone", "geo": "US", "valuation_m": 600, "last_round_label": "2024"},
-        {"name": "Anduril Dive-LD/XL", "geo": "US", "valuation_m": null, "last_round_label": "DIU Feb 2024"},
-        {"name": "HavocAI", "geo": "US", "valuation_m": null, "last_round_label": null},
-        {"name": "Vatn Systems", "geo": "US", "valuation_m": null, "last_round_label": null}
+        {
+          "name": "Saronic",
+          "geo": "US",
+          "valuation_m": 9250,
+          "last_round_label": "Series D Mar 2026"
+        },
+        {
+          "name": "Saildrone",
+          "geo": "US",
+          "valuation_m": 600,
+          "last_round_label": "2024"
+        },
+        {
+          "name": "Anduril Dive-LD/XL",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "DIU Feb 2024"
+        },
+        {
+          "name": "HavocAI",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Vatn Systems",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        }
       ],
-      "top_investors": ["Kleiner Perkins", "Elad Gil", "a16z", "Lux Capital", "Founders Fund"],
+      "top_investors": [
+        "Kleiner Perkins",
+        "Elad Gil",
+        "a16z",
+        "Lux Capital",
+        "Founders Fund"
+      ],
       "canonical_pov": "Marine autonomy is at the start of a 5-year deployment curve mirroring 2018-2022 aerial. The Navy's Replicator program plus structural US shipyard underproduction creates structural demand the venture market is only beginning to underwrite. Saronic's 320x revenue multiple vs. Saildrone's 14x reflects who investors think wins the procurement narrative.",
-      "caveats": ["Saronic $400M 2025 revenue projection may conflate with $392M multi-year Navy OTA contract value"]
+      "caveats": [
+        "Saronic $400M 2025 revenue projection may conflate with $392M multi-year Navy OTA contract value"
+      ]
     },
     {
       "id": "surgical-robotics",
@@ -207,15 +694,49 @@
       "capital_2024_25_m": 1500,
       "yoy_growth_pct": 22,
       "deals_count": 24,
-      "geo_split": {"US": 40, "China": 15, "EU": 40, "RoW": 5},
+      "geo_split": {
+        "US": 40,
+        "China": 15,
+        "EU": 40,
+        "RoW": 5
+      },
       "top_companies": [
-        {"name": "CMR Surgical", "geo": "EU", "valuation_m": null, "last_round_label": "$200M Apr 2025"},
-        {"name": "Distalmotion", "geo": "EU", "valuation_m": null, "last_round_label": "$150M 2023"},
-        {"name": "Moon Surgical", "geo": "US", "valuation_m": null, "last_round_label": "J&J + Nvidia backed"},
-        {"name": "Surgerii", "geo": "China", "valuation_m": null, "last_round_label": "$100M 2025"},
-        {"name": "MMI", "geo": "EU", "valuation_m": null, "last_round_label": null}
+        {
+          "name": "CMR Surgical",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "$200M Apr 2025"
+        },
+        {
+          "name": "Distalmotion",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "$150M 2023"
+        },
+        {
+          "name": "Moon Surgical",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "J&J + Nvidia backed"
+        },
+        {
+          "name": "Surgerii",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "$100M 2025"
+        },
+        {
+          "name": "MMI",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": null
+        }
       ],
-      "top_investors": ["J&J JJDC", "Nvidia NVentures", "Cathay Capital"],
+      "top_investors": [
+        "J&J JJDC",
+        "Nvidia NVentures",
+        "Cathay Capital"
+      ],
       "canonical_pov": "Surgical robotics is finally seeing Intuitive's monopoly cracked. Medtronic Hugo and CMR Versius Plus in 2025-26 are the first credible US-market soft-tissue competitors in 25 years. But VC dollars are 1/20th of humanoids despite ~10x the proven unit economics. The disconnect is the most underappreciated opportunity in physical AI.",
       "caveats": []
     },
@@ -227,14 +748,45 @@
       "capital_2024_25_m": 100,
       "yoy_growth_pct": 15,
       "deals_count": 8,
-      "geo_split": {"US": 30, "China": 5, "EU": 55, "RoW": 10},
+      "geo_split": {
+        "US": 30,
+        "China": 5,
+        "EU": 55,
+        "RoW": 10
+      },
       "top_companies": [
-        {"name": "German Bionic", "geo": "EU", "valuation_m": null, "last_round_label": "Archimedes acq 2026"},
-        {"name": "Wandercraft", "geo": "EU", "valuation_m": null, "last_round_label": "FDA Atalante 2024"},
-        {"name": "Ekso Bionics", "geo": "US", "valuation_m": 42, "last_round_label": "NASDAQ:EKSO", "flag": "public-market-cap"},
-        {"name": "Roam Robotics", "geo": "US", "valuation_m": null, "last_round_label": null}
+        {
+          "name": "German Bionic",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Archimedes acq 2026"
+        },
+        {
+          "name": "Wandercraft",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "FDA Atalante 2024"
+        },
+        {
+          "name": "Ekso Bionics",
+          "geo": "US",
+          "valuation_m": 42,
+          "last_round_label": "NASDAQ:EKSO",
+          "flag": "public-market-cap",
+          "ticker": "EKSO"
+        },
+        {
+          "name": "Roam Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        }
       ],
-      "top_investors": ["Mubea", "Hyundai", "Honda"],
+      "top_investors": [
+        "Mubea",
+        "Hyundai",
+        "Honda"
+      ],
       "canonical_pov": "Exoskeletons remain the most under-capitalized physical AI category relative to the size of the labor-strain TAM. 1/3 of workplace injuries are overexertion. Despite that, the entire global venture pool is smaller than a single Figure round.",
       "caveats": []
     },
@@ -246,18 +798,62 @@
       "capital_2024_25_m": 3000,
       "yoy_growth_pct": 85,
       "deals_count": 42,
-      "geo_split": {"US": 70, "China": 15, "EU": 12, "RoW": 3},
+      "geo_split": {
+        "US": 70,
+        "China": 15,
+        "EU": 12,
+        "RoW": 3
+      },
       "top_companies": [
-        {"name": "Mind Robotics", "geo": "US", "valuation_m": 3400, "last_round_label": "Series B May 2026"},
-        {"name": "Hadrian", "geo": "US", "valuation_m": null, "last_round_label": "Q4 2025"},
-        {"name": "FieldAI", "geo": "US", "valuation_m": 2000, "last_round_label": "$405M 2025"},
-        {"name": "VulcanForms", "geo": "US", "valuation_m": null, "last_round_label": "$220M 2025"},
-        {"name": "Path Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$300M+ cumulative"},
-        {"name": "Covariant (Amazon acquihire)", "geo": "US", "valuation_m": null, "last_round_label": "Aug 2024"}
+        {
+          "name": "Mind Robotics",
+          "geo": "US",
+          "valuation_m": 3400,
+          "last_round_label": "Series B May 2026"
+        },
+        {
+          "name": "Hadrian",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Q4 2025"
+        },
+        {
+          "name": "FieldAI",
+          "geo": "US",
+          "valuation_m": 2000,
+          "last_round_label": "$405M 2025"
+        },
+        {
+          "name": "VulcanForms",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$220M 2025"
+        },
+        {
+          "name": "Path Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$300M+ cumulative"
+        },
+        {
+          "name": "Covariant (Amazon acquihire)",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Aug 2024"
+        }
       ],
-      "top_investors": ["Eclipse Ventures", "Kleiner Perkins", "Accel", "a16z", "Khosla Ventures", "CapitalG"],
+      "top_investors": [
+        "Eclipse Ventures",
+        "Kleiner Perkins",
+        "Accel",
+        "a16z",
+        "Khosla Ventures",
+        "CapitalG"
+      ],
       "canonical_pov": "Mind Robotics is the auto-OEM spin-out template. The 'factory floor as proprietary training environment' thesis is now competitive with the Figure/Apptronik humanoid playbook, and arguably better for capital efficiency since the data acquisition cost is embedded in the host's operating business. Watch which other OEMs spin out robotics units. BMW, Mercedes, Ford, Stellantis are all candidates.",
-      "caveats": ["Mind Robotics cumulative $1.015B raised in 6 months may be the fastest scaling in physical AI history"]
+      "caveats": [
+        "Mind Robotics cumulative $1.015B raised in 6 months may be the fastest scaling in physical AI history"
+      ]
     },
     {
       "id": "agricultural-robotics",
@@ -267,17 +863,54 @@
       "capital_2024_25_m": 500,
       "yoy_growth_pct": -15,
       "deals_count": 16,
-      "geo_split": {"US": 65, "China": 5, "EU": 25, "RoW": 5},
+      "geo_split": {
+        "US": 65,
+        "China": 5,
+        "EU": 25,
+        "RoW": 5
+      },
       "top_companies": [
-        {"name": "Monarch Tractor", "geo": "US", "valuation_m": null, "last_round_label": "Caterpillar acq Nov 2025"},
-        {"name": "Carbon Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$70M Series D 2024"},
-        {"name": "Inari", "geo": "US", "valuation_m": null, "last_round_label": "$103M 2024"},
-        {"name": "Burro", "geo": "US", "valuation_m": null, "last_round_label": null},
-        {"name": "Ecorobotix", "geo": "EU", "valuation_m": null, "last_round_label": null}
+        {
+          "name": "Monarch Tractor",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Caterpillar acq Nov 2025"
+        },
+        {
+          "name": "Carbon Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$70M Series D 2024"
+        },
+        {
+          "name": "Inari",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$103M 2024"
+        },
+        {
+          "name": "Burro",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Ecorobotix",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": null
+        }
       ],
-      "top_investors": ["Caterpillar", "Astanor", "Nvidia NVentures", "DCVC"],
+      "top_investors": [
+        "Caterpillar",
+        "Astanor",
+        "Nvidia NVentures",
+        "DCVC"
+      ],
       "canonical_pov": "Monarch's collapse-and-acquisition by Caterpillar is the morality play. Autonomy claims got too far ahead of field performance, dealer lawsuits exposed the gap, and the legacy OEM scooped the IP at a discount. Expect this pattern repeated for autonomous tractors that overpromise on Level 4 field autonomy.",
-      "caveats": ["Monarch acquisition terms undisclosed"]
+      "caveats": [
+        "Monarch acquisition terms undisclosed"
+      ]
     },
     {
       "id": "construction-robotics",
@@ -287,16 +920,53 @@
       "capital_2024_25_m": 1400,
       "yoy_growth_pct": 125,
       "deals_count": 18,
-      "geo_split": {"US": 80, "China": 5, "EU": 12, "RoW": 3},
+      "geo_split": {
+        "US": 80,
+        "China": 5,
+        "EU": 12,
+        "RoW": 3
+      },
       "top_companies": [
-        {"name": "FieldAI", "geo": "US", "valuation_m": 2000, "last_round_label": "$405M 2025"},
-        {"name": "Bedrock Robotics", "geo": "US", "valuation_m": 1750, "last_round_label": "Series B Feb 2026"},
-        {"name": "Dusty Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$69.3M cumulative"},
-        {"name": "Canvas", "geo": "US", "valuation_m": null, "last_round_label": "drywall robot"},
-        {"name": "Built Robotics", "geo": "US", "valuation_m": null, "last_round_label": "wound down workforce 2024"}
+        {
+          "name": "FieldAI",
+          "geo": "US",
+          "valuation_m": 2000,
+          "last_round_label": "$405M 2025"
+        },
+        {
+          "name": "Bedrock Robotics",
+          "geo": "US",
+          "valuation_m": 1750,
+          "last_round_label": "Series B Feb 2026"
+        },
+        {
+          "name": "Dusty Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$69.3M cumulative"
+        },
+        {
+          "name": "Canvas",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "drywall robot"
+        },
+        {
+          "name": "Built Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "wound down workforce 2024"
+        }
       ],
-      "top_investors": ["Eclipse Ventures", "CapitalG", "Valor Atreides AI", "8VC", "Khosla", "Emerson Collective"],
-      "canonical_pov": "Construction robotics' boom is actually two mega-rounds (FieldAI $405M, Bedrock $270M) plus steady Series A activity at $27M average. The category is real but not at scale. Investors are pricing earthmoving autonomy at later-stage premiums and installation robotics at Series A risk.",
+      "top_investors": [
+        "Eclipse Ventures",
+        "CapitalG",
+        "Valor Atreides AI",
+        "8VC",
+        "Khosla",
+        "Emerson Collective"
+      ],
+      "canonical_pov": "Construction robotics' boom is actually 2 mega-rounds (FieldAI $405M, Bedrock $270M) plus steady Series A activity at $27M average. The category is real but not at scale. Investors are pricing earthmoving autonomy at later-stage premiums and installation robotics at Series A risk.",
       "caveats": []
     },
     {
@@ -307,20 +977,78 @@
       "capital_2024_25_m": 22000,
       "yoy_growth_pct": 94,
       "deals_count": 120,
-      "geo_split": {"US": 75, "China": 0, "EU": 22, "RoW": 3},
+      "geo_split": {
+        "US": 75,
+        "China": 0,
+        "EU": 22,
+        "RoW": 3
+      },
       "top_companies": [
-        {"name": "Anduril", "geo": "US", "valuation_m": 61000, "last_round_label": "Series H May 2026"},
-        {"name": "Shield AI", "geo": "US", "valuation_m": 12700, "last_round_label": "Series G Mar 2026 ($1.5B equity + $500M Blackstone preferred)"},
-        {"name": "Saronic", "geo": "US", "valuation_m": 9250, "last_round_label": "Series D Mar 2026"},
-        {"name": "Helsing", "geo": "EU", "valuation_m": 18000, "last_round_label": "Series D in talks", "flag": "in-talks"},
-        {"name": "CHAOS Industries", "geo": "US", "valuation_m": 4500, "last_round_label": "Series D Nov 2025"},
-        {"name": "Castelion", "geo": "US", "valuation_m": 1500, "last_round_label": "Series B Dec 2025"},
-        {"name": "True Anomaly", "geo": "US", "valuation_m": 2000, "last_round_label": "Apr 2026"},
-        {"name": "Forterra", "geo": "US", "valuation_m": 1200, "last_round_label": "Series C Nov 2025"}
+        {
+          "name": "Anduril",
+          "geo": "US",
+          "valuation_m": 61000,
+          "last_round_label": "Series H May 2026"
+        },
+        {
+          "name": "Shield AI",
+          "geo": "US",
+          "valuation_m": 12700,
+          "last_round_label": "Series G Mar 2026 ($1.5B equity + $500M Blackstone preferred)"
+        },
+        {
+          "name": "Saronic",
+          "geo": "US",
+          "valuation_m": 9250,
+          "last_round_label": "Series D Mar 2026"
+        },
+        {
+          "name": "Helsing",
+          "geo": "EU",
+          "valuation_m": 18000,
+          "last_round_label": "Series D in talks",
+          "flag": "in-talks"
+        },
+        {
+          "name": "CHAOS Industries",
+          "geo": "US",
+          "valuation_m": 4500,
+          "last_round_label": "Series D Nov 2025"
+        },
+        {
+          "name": "Castelion",
+          "geo": "US",
+          "valuation_m": 1500,
+          "last_round_label": "Series B Dec 2025"
+        },
+        {
+          "name": "True Anomaly",
+          "geo": "US",
+          "valuation_m": 2000,
+          "last_round_label": "Apr 2026"
+        },
+        {
+          "name": "Forterra",
+          "geo": "US",
+          "valuation_m": 1200,
+          "last_round_label": "Series C Nov 2025"
+        }
       ],
-      "top_investors": ["a16z (18 deals)", "Founders Fund", "Eclipse", "General Catalyst", "8VC", "NightDragon", "Lightspeed", "Blackstone (preferred)"],
+      "top_investors": [
+        "a16z (18 deals)",
+        "Founders Fund",
+        "Eclipse",
+        "General Catalyst",
+        "8VC",
+        "NightDragon",
+        "Lightspeed",
+        "Blackstone (preferred)"
+      ],
       "canonical_pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is the first signal defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble. Anduril is the only defense unicorn with revenue ($2.2B 2025) proportional to its valuation. Most others are pricing in multi-year DoD procurement that hasn't materialized.",
-      "caveats": ["$22B+ figure depends on PitchBook vs Crunchbase methodology", "PitchBook $49.1B 2025 deal-value figure includes debt and structured financing, not pure equity"]
+      "caveats": [
+        "$22B+ figure depends on PitchBook vs Crunchbase methodology",
+        "PitchBook $49.1B 2025 deal-value figure includes debt and structured financing, not pure equity"
+      ]
     },
     {
       "id": "healthcare-non-surgical",
@@ -330,12 +1058,37 @@
       "capital_2024_25_m": 250,
       "yoy_growth_pct": 10,
       "deals_count": 12,
-      "geo_split": {"US": 55, "China": 10, "EU": 25, "RoW": 10},
+      "geo_split": {
+        "US": 55,
+        "China": 10,
+        "EU": 25,
+        "RoW": 10
+      },
       "top_companies": [
-        {"name": "Diligent Robotics (Moxi)", "geo": "US", "valuation_m": null, "last_round_label": "Series B"},
-        {"name": "Aethon (TUG)", "geo": "US", "valuation_m": null, "last_round_label": null},
-        {"name": "Cyberdyne", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
-        {"name": "Omnicell (pharmacy)", "geo": "US", "valuation_m": null, "last_round_label": "public"}
+        {
+          "name": "Diligent Robotics (Moxi)",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Series B"
+        },
+        {
+          "name": "Aethon (TUG)",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Cyberdyne",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "Japan public"
+        },
+        {
+          "name": "Omnicell (pharmacy)",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "public"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "The eldercare plus pharmacy robotics opportunity is genuinely larger than humanoids' near-term TAM and almost completely under-funded relative to demographic trajectory. This is Canonical's most defensible contrarian sleeve.",
@@ -349,13 +1102,43 @@
       "capital_2024_25_m": 50,
       "yoy_growth_pct": -75,
       "deals_count": 5,
-      "geo_split": {"US": 30, "China": 60, "EU": 8, "RoW": 2},
+      "geo_split": {
+        "US": 30,
+        "China": 60,
+        "EU": 8,
+        "RoW": 2
+      },
       "top_companies": [
-        {"name": "iRobot", "geo": "US", "valuation_m": null, "last_round_label": "Ch.11 Dec 2025, sold to Shenzhen Picea"},
-        {"name": "Roborock", "geo": "China", "valuation_m": null, "last_round_label": "public"},
-        {"name": "Ecovacs", "geo": "China", "valuation_m": null, "last_round_label": "public"},
-        {"name": "Matic Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$30M Series A"},
-        {"name": "1X NEO", "geo": "RoW", "valuation_m": null, "last_round_label": "see Humanoid"}
+        {
+          "name": "iRobot",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Ch.11 Dec 2025, sold to Shenzhen Picea"
+        },
+        {
+          "name": "Roborock",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "public"
+        },
+        {
+          "name": "Ecovacs",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "public"
+        },
+        {
+          "name": "Matic Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$30M Series A"
+        },
+        {
+          "name": "1X NEO",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "see Humanoid"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "Consumer robotics outside of vacuum and lawn-mower is essentially impossible to fund in 2025-26. iRobot's bankruptcy is the cautionary tale, and even 1X is repositioning. The category is moving to 'consumer humanoids' but that's a 2028+ TAM.",
@@ -369,20 +1152,81 @@
       "capital_2024_25_m": 28000,
       "yoy_growth_pct": 340,
       "deals_count": 34,
-      "geo_split": {"US": 70, "China": 20, "EU": 10, "RoW": 0},
+      "geo_split": {
+        "US": 70,
+        "China": 20,
+        "EU": 10,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Waymo", "geo": "US", "valuation_m": 126000, "last_round_label": "Series D Feb 2026"},
-        {"name": "Wayve", "geo": "EU", "valuation_m": 8600, "last_round_label": "Series D Feb 2026"},
-        {"name": "Pony.ai", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Fall 2024", "flag": "public-market-cap"},
-        {"name": "WeRide", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Fall 2024", "flag": "public-market-cap"},
-        {"name": "Applied Intuition", "geo": "US", "valuation_m": 15000, "last_round_label": "Series F Jun 2025"},
-        {"name": "Aurora Innovation", "geo": "US", "valuation_m": null, "last_round_label": "Nasdaq", "flag": "public-market-cap"},
-        {"name": "Nuro", "geo": "US", "valuation_m": 600, "last_round_label": "Series E 2024"},
-        {"name": "Waabi", "geo": "US", "valuation_m": 750, "last_round_label": "Series C Khosla-led"}
+        {
+          "name": "Waymo",
+          "geo": "US",
+          "valuation_m": 126000,
+          "last_round_label": "Series D Feb 2026"
+        },
+        {
+          "name": "Wayve",
+          "geo": "EU",
+          "valuation_m": 8600,
+          "last_round_label": "Series D Feb 2026"
+        },
+        {
+          "name": "Pony.ai",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "Nasdaq IPO Fall 2024",
+          "flag": "public-market-cap",
+          "ticker": "PONY"
+        },
+        {
+          "name": "WeRide",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "Nasdaq IPO Fall 2024",
+          "flag": "public-market-cap",
+          "ticker": "WRD"
+        },
+        {
+          "name": "Applied Intuition",
+          "geo": "US",
+          "valuation_m": 15000,
+          "last_round_label": "Series F Jun 2025"
+        },
+        {
+          "name": "Aurora Innovation",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Nasdaq",
+          "flag": "public-market-cap",
+          "ticker": "AUR"
+        },
+        {
+          "name": "Nuro",
+          "geo": "US",
+          "valuation_m": 600,
+          "last_round_label": "Series E 2024"
+        },
+        {
+          "name": "Waabi",
+          "geo": "US",
+          "valuation_m": 750,
+          "last_round_label": "Series C Khosla-led"
+        }
       ],
-      "top_investors": ["Alphabet", "Dragoneer", "DST Global", "Sequoia", "Eclipse Ventures", "Khosla Ventures"],
+      "top_investors": [
+        "Alphabet",
+        "Dragoneer",
+        "DST Global",
+        "Sequoia",
+        "Eclipse Ventures",
+        "Khosla Ventures"
+      ],
       "canonical_pov": "AV's recovery is real but is a barbell. Waymo plus Wayve at one end, Chinese pre-IPO bridges at the other, and almost nothing in the middle. The bubble didn't reflate uniformly. It bifurcated. Trucking AV (Waabi, Kodiak) is the underweighted sleeve relative to robotaxi attention.",
-      "caveats": ["Most of the $28B figure is Waymo's $16B February 2026 raise", "Cruise wound down Dec 2024 after $10B+ cumulative losses, the largest single AV writedown"]
+      "caveats": [
+        "Most of the $28B figure is Waymo's $16B February 2026 raise",
+        "Cruise wound down Dec 2024 after $10B+ cumulative losses, the largest single AV writedown"
+      ]
     },
     {
       "id": "hardware-actuation",
@@ -392,15 +1236,37 @@
       "capital_2024_25_m": 50,
       "yoy_growth_pct": null,
       "deals_count": 4,
-      "geo_split": {"US": 10, "China": 30, "EU": 30, "RoW": 30},
+      "geo_split": {
+        "US": 10,
+        "China": 30,
+        "EU": 30,
+        "RoW": 30
+      },
       "top_companies": [
-        {"name": "Harmonic Drive Systems", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
-        {"name": "Nabtesco", "geo": "RoW", "valuation_m": null, "last_round_label": "Japan public"},
-        {"name": "Schaeffler", "geo": "EU", "valuation_m": null, "last_round_label": "Germany public, Neura partner"}
+        {
+          "name": "Harmonic Drive Systems",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "Japan public"
+        },
+        {
+          "name": "Nabtesco",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "Japan public"
+        },
+        {
+          "name": "Schaeffler",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Germany public, Neura partner"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "The pick-and-shovel play for humanoids is harmonic drive / strain wave gear and high-torque-density actuators. This layer is dominated by Japanese and German incumbents. Not a single US/EU venture-backed actuator company has reached $100M revenue. Unitree's prospectus discloses they manufacture their own motors, reducers, encoders, and dexterous hands in-house, with purchased parts accounting for only 14-18% of total cost, a vertical-integration playbook the US ecosystem has not replicated.",
-      "caveats": ["Most companies in this layer are public incumbents, not VC-backed"]
+      "caveats": [
+        "Most companies in this layer are public incumbents, not VC-backed"
+      ]
     },
     {
       "id": "sensors-perception",
@@ -410,17 +1276,56 @@
       "capital_2024_25_m": 0,
       "yoy_growth_pct": null,
       "deals_count": 8,
-      "geo_split": {"US": 35, "China": 50, "EU": 15, "RoW": 0},
+      "geo_split": {
+        "US": 35,
+        "China": 50,
+        "EU": 15,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Hesai", "geo": "China", "valuation_m": null, "last_round_label": "Nasdaq IPO Feb 2023", "flag": "public-market-cap"},
-        {"name": "RoboSense", "geo": "China", "valuation_m": null, "last_round_label": "HKEX Jan 2024", "flag": "public-market-cap"},
-        {"name": "Ouster (post-Stereolabs)", "geo": "US", "valuation_m": 2000, "last_round_label": "$35M + 1.8M shares for Stereolabs Feb 2026", "flag": "public-market-cap"},
-        {"name": "Luminar", "geo": "US", "valuation_m": null, "last_round_label": "Ch.11 late 2025, assets to MicroVision $33M"},
-        {"name": "Prophesee", "geo": "EU", "valuation_m": null, "last_round_label": "$127M cumulative"}
+        {
+          "name": "Hesai",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "Nasdaq IPO Feb 2023",
+          "flag": "public-market-cap",
+          "ticker": "HSAI"
+        },
+        {
+          "name": "RoboSense",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "HKEX Jan 2024",
+          "flag": "public-market-cap",
+          "ticker": "2498.HK"
+        },
+        {
+          "name": "Ouster (post-Stereolabs)",
+          "geo": "US",
+          "valuation_m": 2000,
+          "last_round_label": "$35M + 1.8M shares for Stereolabs Feb 2026",
+          "flag": "public-market-cap",
+          "ticker": "OUST"
+        },
+        {
+          "name": "Luminar",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Ch.11 late 2025, assets to MicroVision $33M"
+        },
+        {
+          "name": "Prophesee",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "$127M cumulative"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "The 'perception' sub-sector is the largest single graveyard of physical AI. Billions raised via SPAC, 80%+ destroyed. But Ouster is the survivor story. From ~$408M (May 2025) to ~$2.2B (May 2026), now repositioned as 'Physical AI's first unified sensing and perception platform' post-Stereolabs acquisition. The lesson for LPs: post-SPAC consolidation produces survivors when management pivots from auto OEM dependence to broader physical AI markets.",
-      "caveats": ["Net VC into sensors/perception is negative on mark-to-market basis when including SPAC destruction", "RoboSense robotics LiDAR sales +1,142% YoY in 2025, structural shift the brief should not miss"]
+      "caveats": [
+        "Net VC into sensors/perception is negative on mark-to-market basis when including SPAC destruction",
+        "RoboSense robotics LiDAR sales +1,142% YoY in 2025, structural shift the brief should not miss"
+      ]
     },
     {
       "id": "edge-silicon",
@@ -430,17 +1335,53 @@
       "capital_2024_25_m": 600,
       "yoy_growth_pct": 20,
       "deals_count": 8,
-      "geo_split": {"US": 30, "China": 5, "EU": 15, "RoW": 50},
+      "geo_split": {
+        "US": 30,
+        "China": 5,
+        "EU": 15,
+        "RoW": 50
+      },
       "top_companies": [
-        {"name": "Hailo", "geo": "RoW", "valuation_m": 1200, "last_round_label": "Series C ext Apr 2024, reportedly halved in SPAC talks"},
-        {"name": "Tenstorrent", "geo": "US", "valuation_m": 2600, "last_round_label": "Series D Dec 2024"},
-        {"name": "Axelera AI", "geo": "EU", "valuation_m": null, "last_round_label": "$68M Series B Jun 2024"},
-        {"name": "Nvidia Jetson Thor", "geo": "US", "valuation_m": null, "last_round_label": "Aug 2025 launch, $3,499"},
-        {"name": "Rebellions", "geo": "RoW", "valuation_m": 2300, "last_round_label": "Korea pre-IPO Mar 2026"}
+        {
+          "name": "Hailo",
+          "geo": "RoW",
+          "valuation_m": 1200,
+          "last_round_label": "Series C ext Apr 2024, reportedly halved in SPAC talks"
+        },
+        {
+          "name": "Tenstorrent",
+          "geo": "US",
+          "valuation_m": 2600,
+          "last_round_label": "Series D Dec 2024"
+        },
+        {
+          "name": "Axelera AI",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "$68M Series B Jun 2024"
+        },
+        {
+          "name": "Nvidia Jetson Thor",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Aug 2025 launch, $3,499"
+        },
+        {
+          "name": "Rebellions",
+          "geo": "RoW",
+          "valuation_m": 2300,
+          "last_round_label": "Korea pre-IPO Mar 2026"
+        }
       ],
-      "top_investors": ["SoftBank", "Samsung", "Bezos Expeditions"],
+      "top_investors": [
+        "SoftBank",
+        "Samsung",
+        "Bezos Expeditions"
+      ],
       "canonical_pov": "'Edge silicon for robotics' as a venture category is largely a marketing label. Hailo and Axelera are the only pure-plays with robotics as a stated focus, and Hailo just had to pivot to robotics from a stalled automotive narrative. The real 'edge silicon for robotics' company is Nvidia, with Jetson Thor capturing >70% mind share of humanoid OEMs.",
-      "caveats": ["Hailo SPAC discussions ongoing, valuation may have halved"]
+      "caveats": [
+        "Hailo SPAC discussions ongoing, valuation may have halved"
+      ]
     },
     {
       "id": "foundation-models-for-robotics",
@@ -450,19 +1391,72 @@
       "capital_2024_25_m": 3500,
       "yoy_growth_pct": 450,
       "deals_count": 12,
-      "geo_split": {"US": 75, "China": 5, "EU": 15, "RoW": 5},
+      "geo_split": {
+        "US": 75,
+        "China": 5,
+        "EU": 15,
+        "RoW": 5
+      },
       "top_companies": [
-        {"name": "Skild AI", "geo": "US", "valuation_m": 14000, "last_round_label": "Jan 2026 (was $4.5B summer 2025)"},
-        {"name": "Physical Intelligence", "geo": "US", "valuation_m": 5600, "last_round_label": "Series B Nov 2025, $11B reportedly in talks", "flag": "in-talks"},
-        {"name": "Project Prometheus", "geo": "US", "valuation_m": 38000, "last_round_label": "$6.2B initial Nov 2025, $10B at $38B in talks per FT", "flag": "in-talks"},
-        {"name": "Wayve", "geo": "EU", "valuation_m": 8600, "last_round_label": "Series D Feb 2026, see also AV"},
-        {"name": "Covariant", "geo": "US", "valuation_m": null, "last_round_label": "Amazon acquihire Aug 2024"},
-        {"name": "World Labs (Fei-Fei Li)", "geo": "US", "valuation_m": 1000, "last_round_label": "$230M+ at $1B+ 2024"},
-        {"name": "Dyna Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$120M Series A Sep 2025"}
+        {
+          "name": "Skild AI",
+          "geo": "US",
+          "valuation_m": 14000,
+          "last_round_label": "Jan 2026 (was $4.5B summer 2025)"
+        },
+        {
+          "name": "Physical Intelligence",
+          "geo": "US",
+          "valuation_m": 5600,
+          "last_round_label": "Series B Nov 2025, $11B reportedly in talks",
+          "flag": "in-talks"
+        },
+        {
+          "name": "Project Prometheus",
+          "geo": "US",
+          "valuation_m": 38000,
+          "last_round_label": "$6.2B initial Nov 2025, $10B at $38B in talks per FT",
+          "flag": "in-talks"
+        },
+        {
+          "name": "Wayve",
+          "geo": "EU",
+          "valuation_m": 8600,
+          "last_round_label": "Series D Feb 2026, see also AV"
+        },
+        {
+          "name": "Covariant",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Amazon acquihire Aug 2024"
+        },
+        {
+          "name": "World Labs (Fei-Fei Li)",
+          "geo": "US",
+          "valuation_m": 1000,
+          "last_round_label": "$230M+ at $1B+ 2024"
+        },
+        {
+          "name": "Dyna Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$120M Series A Sep 2025"
+        }
       ],
-      "top_investors": ["SoftBank", "CapitalG", "Lux Capital", "Bezos Expeditions", "Nvidia NVentures", "JPMorgan", "BlackRock"],
+      "top_investors": [
+        "SoftBank",
+        "CapitalG",
+        "Lux Capital",
+        "Bezos Expeditions",
+        "Nvidia NVentures",
+        "JPMorgan",
+        "BlackRock"
+      ],
       "canonical_pov": "Foundation models for robotics collapsed onto 4 names in 18 months: PI, Skild, Wayve, Project Prometheus. Bezos personally betting $6.2B+ on Prometheus while also leading PI's prior round is the clearest signal of where the apex of physical AI capital is going. The category will likely consolidate to 2-3 winners by 2027.",
-      "caveats": ["Project Prometheus $10B/$38B round reported by FT but not closed", "PI $11B round reported by Bloomberg/TC but not closed"]
+      "caveats": [
+        "Project Prometheus $10B/$38B round reported by FT but not closed",
+        "PI $11B round reported by Bloomberg/TC but not closed"
+      ]
     },
     {
       "id": "simulation-synthetic-data",
@@ -472,15 +1466,48 @@
       "capital_2024_25_m": 1500,
       "yoy_growth_pct": 45,
       "deals_count": 9,
-      "geo_split": {"US": 70, "China": 5, "EU": 15, "RoW": 10},
+      "geo_split": {
+        "US": 70,
+        "China": 5,
+        "EU": 15,
+        "RoW": 10
+      },
       "top_companies": [
-        {"name": "Applied Intuition", "geo": "US", "valuation_m": 15000, "last_round_label": "Series F Jun 2025, $830M ARR 2025"},
-        {"name": "Foretellix", "geo": "RoW", "valuation_m": null, "last_round_label": "$135M cumulative, layoffs Jan 2026"},
-        {"name": "Nvidia Omniverse + Cosmos", "geo": "US", "valuation_m": null, "last_round_label": "platform, not a company"},
-        {"name": "Parallel Domain", "geo": "US", "valuation_m": null, "last_round_label": "merged with Foretellix Nov 2025"},
-        {"name": "Cognata", "geo": "RoW", "valuation_m": null, "last_round_label": "$23.5M, pivot to defense"}
+        {
+          "name": "Applied Intuition",
+          "geo": "US",
+          "valuation_m": 15000,
+          "last_round_label": "Series F Jun 2025, $830M ARR 2025"
+        },
+        {
+          "name": "Foretellix",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "$135M cumulative, layoffs Jan 2026"
+        },
+        {
+          "name": "Nvidia Omniverse + Cosmos",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "platform, not a company"
+        },
+        {
+          "name": "Parallel Domain",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "merged with Foretellix Nov 2025"
+        },
+        {
+          "name": "Cognata",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "$23.5M, pivot to defense"
+        }
       ],
-      "top_investors": ["Lux Capital", "Eclipse"],
+      "top_investors": [
+        "Lux Capital",
+        "Eclipse"
+      ],
       "canonical_pov": "The simulation layer is where Nvidia's gravitational pull is most absolute. Every named humanoid, AV, and FM company uses Cosmos or Isaac Sim. Applied Intuition is the only company that has built a credible non-Nvidia franchise at $830M ARR. The Nvidia question is whether competitive simulation can survive Cosmos becoming free.",
       "caveats": []
     },
@@ -492,14 +1519,42 @@
       "capital_2024_25_m": 120,
       "yoy_growth_pct": 30,
       "deals_count": 6,
-      "geo_split": {"US": 90, "China": 0, "EU": 10, "RoW": 0},
+      "geo_split": {
+        "US": 90,
+        "China": 0,
+        "EU": 10,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Foxglove", "geo": "US", "valuation_m": null, "last_round_label": "$40M Series B Nov 2025, Bessemer-led"},
-        {"name": "Formant", "geo": "US", "valuation_m": null, "last_round_label": "$21M Oct 2023"},
-        {"name": "Intrinsic", "geo": "US", "valuation_m": null, "last_round_label": "Alphabet, folded into Google Feb 2026"},
-        {"name": "Roboflow", "geo": "US", "valuation_m": null, "last_round_label": "$40M Series B Aug 2024"}
+        {
+          "name": "Foxglove",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$40M Series B Nov 2025, Bessemer-led"
+        },
+        {
+          "name": "Formant",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$21M Oct 2023"
+        },
+        {
+          "name": "Intrinsic",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Alphabet, folded into Google Feb 2026"
+        },
+        {
+          "name": "Roboflow",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$40M Series B Aug 2024"
+        }
       ],
-      "top_investors": ["Bessemer Venture Partners", "BMW i Ventures"],
+      "top_investors": [
+        "Bessemer Venture Partners",
+        "BMW i Ventures"
+      ],
       "canonical_pov": "Robotics middleware as a venture category is small. Foxglove's $58M cumulative is the high water mark. But it's strategically central. Foxglove's MCAP becoming the ROS 2 + Isaac standard makes it the GitHub of robot data. The category has a standard-setting winner emerging.",
       "caveats": []
     },
@@ -511,15 +1566,49 @@
       "capital_2024_25_m": 350,
       "yoy_growth_pct": 200,
       "deals_count": 8,
-      "geo_split": {"US": 40, "China": 55, "EU": 5, "RoW": 0},
+      "geo_split": {
+        "US": 40,
+        "China": 55,
+        "EU": 5,
+        "RoW": 0
+      },
       "top_companies": [
-        {"name": "Dexterity", "geo": "US", "valuation_m": 1650, "last_round_label": "Series C-equiv Mar 2025"},
-        {"name": "Reflex Robotics", "geo": "US", "valuation_m": null, "last_round_label": "$7M seed Mar 2024"},
-        {"name": "Sanctuary AI", "geo": "US", "valuation_m": null, "last_round_label": "$148.6M cumulative, restructuring"},
-        {"name": "AgiBot Pudong Data Center", "geo": "China", "valuation_m": null, "last_round_label": "3000sqm, ~100 robots, 30-50K data points/day"},
-        {"name": "Beijing X-Humanoid (NLJIC)", "geo": "China", "valuation_m": null, "last_round_label": "2000sqm, 133 humanoids across 13 models"}
+        {
+          "name": "Dexterity",
+          "geo": "US",
+          "valuation_m": 1650,
+          "last_round_label": "Series C-equiv Mar 2025"
+        },
+        {
+          "name": "Reflex Robotics",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$7M seed Mar 2024"
+        },
+        {
+          "name": "Sanctuary AI",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "$148.6M cumulative, restructuring"
+        },
+        {
+          "name": "AgiBot Pudong Data Center",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "3000sqm, ~100 robots, 30-50K data points/day"
+        },
+        {
+          "name": "Beijing X-Humanoid (NLJIC)",
+          "geo": "China",
+          "valuation_m": null,
+          "last_round_label": "2000sqm, 133 humanoids across 13 models"
+        }
       ],
-      "top_investors": ["Lightspeed", "Khosla Ventures", "state-backed China funds"],
+      "top_investors": [
+        "Lightspeed",
+        "Khosla Ventures",
+        "state-backed China funds"
+      ],
       "canonical_pov": "Data collection is the most under-tracked and arguably most important physical AI category. China is building national humanoid data farms (395 humanoids across 9 national training facilities with 300 companies sharing standardized data) while the US relies on private RaaS data plus Scale AI. This is where China's structural advantage is widest and least visible to LPs.",
       "caveats": []
     },
@@ -531,30 +1620,115 @@
       "capital_2024_25_m": 60,
       "yoy_growth_pct": 5,
       "deals_count": 4,
-      "geo_split": {"US": 50, "China": 0, "EU": 35, "RoW": 15},
+      "geo_split": {
+        "US": 50,
+        "China": 0,
+        "EU": 35,
+        "RoW": 15
+      },
       "top_companies": [
-        {"name": "Foretellix", "geo": "RoW", "valuation_m": null, "last_round_label": "see Simulation"},
-        {"name": "Edge Case Research", "geo": "US", "valuation_m": null, "last_round_label": null},
-        {"name": "Inverted AI", "geo": "US", "valuation_m": null, "last_round_label": "predictive human behavior, Foretellix partner"},
-        {"name": "Monolith AI", "geo": "EU", "valuation_m": null, "last_round_label": "Coreweave-acquired Oct 2025"}
+        {
+          "name": "Foretellix",
+          "geo": "RoW",
+          "valuation_m": null,
+          "last_round_label": "see Simulation"
+        },
+        {
+          "name": "Edge Case Research",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": null
+        },
+        {
+          "name": "Inverted AI",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "predictive human behavior, Foretellix partner"
+        },
+        {
+          "name": "Monolith AI",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Coreweave-acquired Oct 2025"
+        }
       ],
       "top_investors": [],
       "canonical_pov": "Safety/verification is a category in search of a regulatory forcing function. UNECE virtual-validation mandates are the canary. Until then it's a sub-component of simulation.",
       "caveats": []
     }
   ],
-
   "adjacencies": {
     "description": "Categories not core to physical AI but adjacent and frequently confused with it. Flagged so the taxonomy stays disciplined.",
     "scientific_industrial_ai": {
       "name": "Scientific & Laboratory Robotics / Industrial AI",
-      "companies": ["Project Prometheus", "Periodic Labs", "Thinking Machines Lab"],
+      "companies": [
+        "Project Prometheus",
+        "Periodic Labs",
+        "Thinking Machines Lab"
+      ],
       "note": "Not embodied robotics but competes for the same capital pool. Project Prometheus alone is $6.2B+ raised."
     },
     "digital_agents": {
       "name": "Digital Agents (Not Embodied)",
-      "companies": ["Manus (Meta acq blocked by NDRC Apr 2026)", "Recursive Superintelligence ($650M May 2026)"],
+      "companies": [
+        "Manus (Meta acq blocked by NDRC Apr 2026)",
+        "Recursive Superintelligence ($650M May 2026)"
+      ],
       "note": "Pitched alongside physical AI but disembodied. Flag clearly to avoid taxonomy drift."
     }
+  },
+  "live_quotes": {
+    "updated": "2026-05-16",
+    "source": "Stooq",
+    "quotes": {
+      "SYM": {
+        "price": 47.32,
+        "open": 48.79,
+        "change_pct": -3.01,
+        "date": "2026-05-15"
+      },
+      "PONY": {
+        "price": 8.29,
+        "open": 8.5,
+        "change_pct": -2.47,
+        "date": "2026-05-15"
+      },
+      "WRD": {
+        "price": 7.14,
+        "open": 7.43,
+        "change_pct": -3.9,
+        "date": "2026-05-15"
+      },
+      "AUR": {
+        "price": 7.71,
+        "open": 7.97,
+        "change_pct": -3.26,
+        "date": "2026-05-15"
+      },
+      "HSAI": {
+        "price": 22.44,
+        "open": 22.56,
+        "change_pct": -0.53,
+        "date": "2026-05-15"
+      },
+      "2498.HK": {
+        "price": 33.96,
+        "open": 34.5,
+        "change_pct": -1.57,
+        "date": "2026-05-15"
+      },
+      "OUST": {
+        "price": 34.86,
+        "open": 33.38,
+        "change_pct": 4.43,
+        "date": "2026-05-15"
+      }
+    },
+    "errors": [
+      {
+        "ticker": "EKSO",
+        "error": "No close price for ekso.us (row: EKSO.US,N/D,N/D,N/D,N/D,N/D,N/D,N/D)"
+      }
+    ]
   }
 }

--- a/labs/physical-ai/index.html
+++ b/labs/physical-ai/index.html
@@ -6,7 +6,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Physical AI Capital Flow Map | Canonical</title>
-    <meta name="description" content="Three years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged. Built by Canonical to surface where capital is actually flowing." />
+    <meta name="description" content="3 years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged. Built by Canonical to surface where capital is actually flowing." />
     <meta name="author" content="Canonical" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://canonical.cc/labs/physical-ai/" />
@@ -15,7 +15,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://canonical.cc/labs/physical-ai/" />
     <meta property="og:title" content="Physical AI Capital Flow Map | Canonical" />
-    <meta property="og:description" content="Three years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged separately." />
+    <meta property="og:description" content="3 years of venture investment in physical AI, mapped. 22 sub-sectors, global with China tagged separately." />
     <meta property="og:image" content="https://canonical.cc/images/site-logo.png" />
     <meta property="og:site_name" content="Canonical" />
 
@@ -64,7 +64,7 @@
             <!-- TL;DR strip -->
             <section class="pai-tldr">
                 <div class="container mx-auto px-8">
-                    <div class="pai-tldr-intro">The state of physical AI in four numbers. Hover each for the source and the calculation behind it.</div>
+                    <div class="pai-tldr-intro">The state of physical AI in 4 numbers. Hover each for the source and the calculation behind it.</div>
                     <div class="pai-tldr-grid">
                         <div class="pai-tldr-item" data-explain="tldr-total" tabindex="0">
                             <div class="pai-stat">$40.7<span class="pai-stat-unit">B</span></div>
@@ -72,15 +72,15 @@
                         </div>
                         <div class="pai-tldr-item" data-explain="tldr-concentration" tabindex="0">
                             <div class="pai-stat">~80<span class="pai-stat-unit">%</span></div>
-                            <div class="pai-tldr-label"><strong>Capital concentration</strong> in four super-categories: humanoids, defense, AV, foundation models.</div>
+                            <div class="pai-tldr-label"><strong>Capital concentration</strong> in 4 super-categories: humanoids, defense, AV, foundation models.</div>
                         </div>
                         <div class="pai-tldr-item" data-explain="tldr-defense" tabindex="0">
                             <div class="pai-stat">2 &rarr; 22</div>
-                            <div class="pai-tldr-label"><strong>Defense unicorns</strong> over three years. Anduril alone now at $61B post Series H.</div>
+                            <div class="pai-tldr-label"><strong>Defense unicorns</strong> over 3 years. Anduril alone now at $61B post Series H.</div>
                         </div>
                         <div class="pai-tldr-item" data-explain="tldr-chasm" tabindex="0">
                             <div class="pai-stat">$56<span class="pai-stat-unit">B+</span></div>
-                            <div class="pai-tldr-label"><strong>Top 4 humanoid valuations</strong> exceed six adjacent sub-sectors combined. The chasm is real.</div>
+                            <div class="pai-tldr-label"><strong>Top 4 humanoid valuations</strong> exceed 6 adjacent sub-sectors combined. The chasm is real.</div>
                         </div>
                     </div>
                 </div>
@@ -107,7 +107,7 @@
                     <div class="pai-scene-grid">
                         <div class="pai-scene-text">
                             <div class="pai-section-label"><span class="pai-section-num">[01]</span> The Valuation Chasm</div>
-                            <h2 class="pai-scene-h2">Four humanoid companies have raised more in 18 months than <em>six entire sub-sectors</em> combined.</h2>
+                            <h2 class="pai-scene-h2">4 humanoid companies have raised more in 18 months than <em>6 entire sub-sectors</em> combined.</h2>
                             <p class="pai-lede">
                                 Figure, Apptronik, Agility, and 1X have together captured more venture and strategic capital in 2024&ndash;25 than the entire surgical robotics, agricultural robotics, construction robotics, consumer robotics, exoskeleton, and quadruped industries, combined. The chasm exists because humanoids are pricing in 2030 commercial deployment. The adjacent sectors are pricing in 2026 unit economics.
                             </p>
@@ -123,7 +123,7 @@
                             </div>
                             <div class="pai-chasm-bars" id="chasm-bars"></div>
                             <div class="pai-chasm-summary">
-                                <strong>15.6&times;</strong> <span>Top 4 humanoid valuations to six-sector sum</span>
+                                <strong>15.6&times;</strong> <span>Top 4 humanoid valuations to 6-sector sum</span>
                             </div>
                         </div>
                     </div>
@@ -151,7 +151,7 @@
                             <div class="pai-section-label"><span class="pai-section-num">[02]</span> Round Velocity</div>
                             <h2 class="pai-scene-h2">The fastest markups in physical AI are <em>not</em> in humanoids.</h2>
                             <p class="pai-lede">
-                                Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in seven months. That's a 21.9&times; markup with revenue from production deployments still measured in the millions. Figure's 15&times; over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.
+                                Bedrock Robotics, a construction robotics startup from ex-Waymo engineers, went from $80M cumulative to a $1.75B Series B in 7 months. That's a 21.9&times; markup with revenue from production deployments still measured in the millions. Figure's 15&times; over 19 months is the headline, but Bedrock's velocity is the leading indicator: when a single category gets a Waymo-pedigree mega-round, it pulls the entire stack with it.
                             </p>
                             <div class="pai-pov">
                                 <div class="pai-pov-label">Canonical POV</div>
@@ -167,10 +167,10 @@
                 <div class="container mx-auto px-8">
                     <div class="pai-scene-grid">
                         <div class="pai-scene-text">
-                            <div class="pai-section-label"><span class="pai-section-num">[03]</span> Two Capital Ecosystems</div>
+                            <div class="pai-section-label"><span class="pai-section-num">[03]</span> 2 Capital Ecosystems</div>
                             <h2 class="pai-scene-h2">US kingmakers underwrite the model. China underwrites the <em>factory</em>.</h2>
                             <p class="pai-lede">
-                                The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10&times; revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. Two paths to the same physical world, two completely different unit economics.
+                                The US humanoid ecosystem is funded by cloud strategics with RaaS exit paths and 10&times; revenue multiples. The Chinese ecosystem is funded by tech giants, state guidance funds, and EV-OEM strategic capital, and exits to public markets. 2 paths to the same physical world, 2 completely different unit economics.
                             </p>
                             <p class="pai-lede pai-lede-small">
                                 Important caveat: China shipped ~90% of humanoid units in 2025 but captured ~30% of dollars. And ~75% of those units went to universities and research institutions. Unitree's own IPO prospectus discloses &gt;50% of revenue from the scientific research and education sector. The volume narrative needs a quality flag.
@@ -211,9 +211,9 @@
                         </div>
                         <div class="pai-scene-text">
                             <div class="pai-section-label"><span class="pai-section-num">[04]</span> Defense Autonomy</div>
-                            <h2 class="pai-scene-h2">From two unicorns to twenty-two <em>in three years</em>.</h2>
+                            <h2 class="pai-scene-h2">From 2 unicorns to <em>22 in 3 years</em>.</h2>
                             <p class="pai-lede">
-                                In 2022, exactly two pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in twelve months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.
+                                In 2022, exactly 2 pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in 12 months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.
                             </p>
                             <div class="pai-pov">
                                 <div class="pai-pov-label">Canonical POV</div>
@@ -305,9 +305,8 @@
                         </div>
                         <div class="pai-cta-actions">
                             <a href="mailto:hello@canonical.cc?subject=Building%20in%20physical%20AI" class="pai-btn"><span>I'm building &rarr; pitch us</span><span class="pai-btn-arrow">&rarr;</span></a>
-                            <a href="mailto:hello@canonical.cc?subject=LP%20-%20Canonical%20Fund%20II" class="pai-btn"><span>I'm an LP &rarr; let's talk Fund II</span><span class="pai-btn-arrow">&rarr;</span></a>
                             <a href="data.json" download="canonical-physical-ai-data.json" class="pai-btn"><span>Download the dataset (JSON)</span><span class="pai-btn-arrow">&darr;</span></a>
-                            <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="pai-btn"><span>Subscribe to quarterly updates</span><span class="pai-btn-arrow">&rarr;</span></a>
+                            <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="pai-btn"><span>Subscribe to updates</span><span class="pai-btn-arrow">&rarr;</span></a>
                         </div>
                     </div>
                 </div>

--- a/labs/physical-ai/lab.css
+++ b/labs/physical-ai/lab.css
@@ -1126,6 +1126,52 @@
 }
 .pai-d-table .pai-d-flag.public { background: rgba(30, 58, 138, 0.1); color: var(--pai-navy); }
 
+/* ============ COMPANY OUTBOUND LINKS ============
+   Used everywhere a company name renders. Subtle by default (color inherits),
+   underline on hover. Keep these crawler-visible — no nofollow, real anchors. */
+.pai-co-link {
+    color: inherit;
+    text-decoration: none;
+    border-bottom: 1px dotted rgba(30, 58, 138, 0.35);
+    transition: border-bottom-color 0.15s, color 0.15s;
+}
+.pai-co-link:hover {
+    border-bottom-color: var(--pai-navy);
+    color: var(--pai-navy);
+}
+.pai-co-link:focus { outline: 2px solid rgba(249, 115, 22, 0.55); outline-offset: 1px; }
+
+/* On the navy-gradient sections (cards on dark), tweak the underline tone */
+.pai-chasm-name .pai-co-link,
+.pai-flow-target .pai-co-link,
+.pai-card-companies .pai-co-link {
+    border-bottom-color: rgba(30, 58, 138, 0.25);
+}
+.pai-chasm-name .pai-co-link:hover,
+.pai-flow-target .pai-co-link:hover,
+.pai-card-companies .pai-co-link:hover {
+    border-bottom-color: var(--pai-navy);
+}
+
+/* Investor-view "named portfolio companies" pills become anchor tags */
+.pai-d-investor-co {
+    cursor: pointer;
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+}
+.pai-d-investor-co:hover {
+    background: rgba(30, 58, 138, 0.08);
+    color: var(--pai-navy);
+}
+
+/* SVG anchors on velocity scatter + defense timeline labels — keep crawler-visible.
+   Cursor pointer on the underlying text, hover state via filter for the dot/label color. */
+.pai-svg-co-link, .pai-defense-chart a, .pai-velocity a { cursor: pointer; }
+.pai-defense-chart a text:hover, .pai-velocity a text:hover {
+    fill: var(--pai-accent);
+    text-decoration: underline;
+}
+
 /* Live quote dot + price line */
 .pai-live-dot {
     display: inline-block;

--- a/labs/physical-ai/lab.css
+++ b/labs/physical-ai/lab.css
@@ -1126,6 +1126,58 @@
 }
 .pai-d-table .pai-d-flag.public { background: rgba(30, 58, 138, 0.1); color: var(--pai-navy); }
 
+/* Live quote dot + price line */
+.pai-live-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #10b981;
+    margin-left: 0.4rem;
+    vertical-align: middle;
+    box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.7);
+    animation: pai-live-pulse 2s infinite;
+    cursor: help;
+}
+@keyframes pai-live-pulse {
+    0%   { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.55); }
+    70%  { box-shadow: 0 0 0 8px rgba(16, 185, 129, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+}
+.pai-live-meta {
+    display: inline-flex;
+    gap: 0.55rem;
+    align-items: baseline;
+    margin-top: 0.25rem;
+    margin-left: 0;
+    padding-top: 0.2rem;
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-muted);
+    flex-wrap: wrap;
+}
+.pai-live-ticker {
+    font-weight: 600;
+    color: #10b981;
+    letter-spacing: 0.04em;
+}
+.pai-live-price { color: var(--pai-ink); font-weight: 500; }
+.pai-live-delta { font-weight: 500; }
+.pai-live-up { color: #047857; }
+.pai-live-down { color: #b91c1c; }
+
+.pai-live-footnote {
+    font-family: var(--pai-mono);
+    font-size: 0.68rem;
+    color: var(--pai-ink-faint);
+    line-height: 1.45;
+    margin-top: 0.7rem;
+    padding-top: 0.7rem;
+    border-top: 1px dashed var(--pai-rule);
+    letter-spacing: 0.02em;
+}
+.pai-live-footnote-stale { color: var(--pai-ink-muted); }
+
 .pai-d-investors { display: flex; flex-wrap: wrap; gap: 0.4rem; }
 .pai-d-investor {
     font-family: var(--pai-mono);
@@ -1135,6 +1187,87 @@
     padding: 0.3rem 0.65rem;
     border-radius: 100px;
 }
+.pai-d-investor-btn {
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-family: var(--pai-mono);
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.pai-d-investor-btn:hover {
+    background: rgba(30, 58, 138, 0.08);
+    border-color: rgba(30, 58, 138, 0.3);
+    color: var(--pai-navy);
+}
+.pai-d-investor-btn:focus { outline: 2px solid rgba(249, 115, 22, 0.55); outline-offset: 1px; }
+.pai-d-section-note {
+    font-size: 0.78rem;
+    color: var(--pai-ink-faint);
+    margin-bottom: 0.7rem;
+    line-height: 1.45;
+}
+.pai-investor-label { background: rgba(249, 115, 22, 0.12); color: var(--pai-accent) !important; }
+.pai-investor-ann { color: var(--pai-accent) !important; font-family: var(--pai-mono); font-size: 0.75rem; }
+.pai-investor-layers { font-size: 0.85rem; letter-spacing: 0.05em; }
+.pai-investor-sector-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    gap: 0.6rem;
+}
+.pai-investor-sector-card {
+    background: rgba(15, 23, 42, 0.03);
+    border: 1px solid var(--pai-rule);
+    border-radius: 0.5rem;
+    padding: 0.85rem 0.9rem;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, transform 0.15s;
+}
+.pai-investor-sector-card:hover {
+    background: rgba(30, 58, 138, 0.05);
+    border-color: rgba(30, 58, 138, 0.3);
+    transform: translateY(-1px);
+}
+.pai-investor-sector-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.45rem;
+}
+.pai-investor-sector-name {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--pai-ink);
+    line-height: 1.2;
+    margin-bottom: 0.35rem;
+}
+.pai-investor-sector-stat {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    color: var(--pai-ink-muted);
+}
+
+/* Make flow row investor names look clickable */
+.pai-flow-actor-link {
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: var(--pai-navy);
+    font-weight: 500;
+    font-family: inherit;
+    font-size: inherit;
+    cursor: pointer;
+    text-underline-offset: 3px;
+    transition: color 0.15s, text-decoration-color 0.15s;
+    text-decoration: underline dotted rgba(30, 58, 138, 0.35);
+}
+.pai-flow-china .pai-flow-actor-link {
+    color: var(--pai-accent);
+    text-decoration-color: rgba(249, 115, 22, 0.4);
+}
+.pai-flow-actor-link:hover {
+    text-decoration: underline solid currentColor;
+}
+.pai-flow-actor-link:focus { outline: 2px solid rgba(249, 115, 22, 0.55); outline-offset: 1px; }
 
 .pai-d-caveats {
     list-style: none;

--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -29,6 +29,214 @@
     };
     const BLACKLIST_INVESTORS = new Set(['state-backed china funds']);  // generic placeholder, not a focusable entity
 
+    /* Company → official corporate URL. Source of truth for outbound links.
+       Keep aligned with names in data.json scenes + subsectors[].top_companies.
+       Used by companyLink() everywhere a company is rendered. */
+    const COMPANY_URLS = {
+        // Humanoid robotics
+        'Figure AI': 'https://www.figure.ai',
+        'Figure': 'https://www.figure.ai',
+        'Apptronik': 'https://apptronik.com',
+        'Agility Robotics': 'https://agilityrobotics.com',
+        'Agility': 'https://agilityrobotics.com',
+        '1X Technologies': 'https://www.1x.tech',
+        '1X': 'https://www.1x.tech',
+        '1X NEO': 'https://www.1x.tech',
+        'Unitree': 'https://www.unitree.com',
+        'Unitree (quadruped legacy)': 'https://www.unitree.com',
+        'AgiBot (Zhiyuan)': 'https://www.zhiyuan-robot.com',
+        'AgiBot': 'https://www.zhiyuan-robot.com',
+        'Fourier': 'https://fourier.com',
+        'Neura Robotics': 'https://neura-robotics.com',
+        'Galbot': 'https://www.galbot.com',
+        'Robot Era': 'https://www.robotera.com',
+        'EngineAI': 'https://www.engineai.com',
+        'LimX': 'https://www.limxdynamics.com',
+        'Leju': 'https://www.lejurobot.com',
+        'X Square': 'https://x2.ai',
+        'Spirit AI': 'https://www.spiritai.com',
+
+        // Quadrupeds
+        'Boston Dynamics': 'https://bostondynamics.com',
+        'ANYbotics': 'https://www.anybotics.com',
+        'Deep Robotics': 'https://www.deeprobotics.cn',
+        'Ghost Robotics': 'https://www.ghostrobotics.io',
+
+        // Wheeled / warehouse
+        'Symbotic': 'https://www.symbotic.com',
+        'Locus Robotics': 'https://locusrobotics.com',
+        'Geek+': 'https://www.geekplus.com',
+        'GreyOrange': 'https://www.greyorange.com',
+        'AutoStore': 'https://www.autostoresystem.com',
+        'Exotec': 'https://www.exotec.com',
+
+        // Aerial / drones
+        'Skydio': 'https://www.skydio.com',
+        'Zipline': 'https://www.flyzipline.com',
+        'Brinc Drones': 'https://www.brincdrones.com',
+        'Brinc': 'https://www.brincdrones.com',
+        'Wingtra': 'https://wingtra.com',
+        'Quantum Systems': 'https://www.quantum-systems.com',
+
+        // Marine / underwater
+        'Saronic': 'https://www.saronic.com',
+        'Saildrone': 'https://www.saildrone.com',
+        'Anduril Dive-LD/XL': 'https://www.anduril.com',
+        'Anduril Dive': 'https://www.anduril.com',
+        'HavocAI': 'https://www.havocai.com',
+        'Vatn Systems': 'https://www.vatnsystems.com',
+        'Vatn': 'https://www.vatnsystems.com',
+
+        // Surgical
+        'CMR Surgical': 'https://cmrsurgical.com',
+        'Distalmotion': 'https://www.distalmotion.com',
+        'Moon Surgical': 'https://www.moonsurgical.com',
+        'Surgerii': 'https://www.surgerii.com',
+        'MMI': 'https://www.mmimicro.com',
+
+        // Exoskeletons / wearable
+        'German Bionic': 'https://www.germanbionic.com',
+        'Wandercraft': 'https://www.wandercraft.eu',
+        'Ekso Bionics': 'https://www.eksobionics.com',
+        'Roam Robotics': 'https://www.roamrobotics.com',
+
+        // Industrial / manufacturing
+        'Mind Robotics': 'https://www.mindrobotics.com',
+        'Hadrian': 'https://www.hadrian.co',
+        'FieldAI': 'https://fieldai.com',
+        'VulcanForms': 'https://vulcanforms.com',
+        'Path Robotics': 'https://www.path-robotics.com',
+        'Covariant': 'https://covariant.ai',
+        'Covariant (Amazon acquihire)': 'https://covariant.ai',
+
+        // Agricultural
+        'Monarch Tractor': 'https://www.monarchtractor.com',
+        'Carbon Robotics': 'https://carbonrobotics.com',
+        'Inari': 'https://inari.com',
+        'Burro': 'https://burro.ai',
+        'Ecorobotix': 'https://ecorobotix.com',
+
+        // Construction
+        'Bedrock Robotics': 'https://bedrockrobotics.com',
+        'Dusty Robotics': 'https://www.dustyrobotics.com',
+        'Canvas': 'https://canvas.build',
+        'Built Robotics': 'https://www.builtrobotics.com',
+
+        // Defense / dual-use
+        'Anduril': 'https://www.anduril.com',
+        'Shield AI': 'https://shield.ai',
+        'Helsing': 'https://helsing.ai',
+        'CHAOS Industries': 'https://chaos.com',
+        'Onebrief': 'https://www.onebrief.com',
+        'Castelion': 'https://www.castelion.com',
+        'Hermeus': 'https://www.hermeus.com',
+        'True Anomaly': 'https://www.trueanomaly.space',
+        'Forterra': 'https://forterrarobotics.com',
+
+        // Healthcare (non-surgical)
+        'Diligent Robotics (Moxi)': 'https://www.diligentrobots.com',
+        'Diligent Robotics': 'https://www.diligentrobots.com',
+        'Aethon (TUG)': 'https://aethon.com',
+        'Cyberdyne': 'https://www.cyberdyne.jp',
+        'Omnicell (pharmacy)': 'https://www.omnicell.com',
+        'Omnicell': 'https://www.omnicell.com',
+
+        // Consumer
+        'iRobot': 'https://www.irobot.com',
+        'Roborock': 'https://us.roborock.com',
+        'Ecovacs': 'https://www.ecovacs.com',
+        'Matic Robotics': 'https://maticrobots.com',
+
+        // Mobility / AV
+        'Waymo': 'https://waymo.com',
+        'Wayve': 'https://wayve.ai',
+        'Pony.ai': 'https://www.pony.ai',
+        'WeRide': 'https://www.weride.ai',
+        'Applied Intuition': 'https://www.appliedintuition.com',
+        'Aurora Innovation': 'https://aurora.tech',
+        'Aurora': 'https://aurora.tech',
+        'Nuro': 'https://www.nuro.ai',
+        'Waabi': 'https://waabi.ai',
+
+        // Hardware / actuation
+        'Harmonic Drive Systems': 'https://www.hds.co.jp',
+        'Nabtesco': 'https://www.nabtesco.com',
+        'Schaeffler': 'https://www.schaeffler.com',
+
+        // Sensors / perception
+        'Hesai': 'https://www.hesaitech.com',
+        'RoboSense': 'https://www.robosense.ai',
+        'Ouster': 'https://ouster.com',
+        'Ouster (post-Stereolabs)': 'https://ouster.com',
+        'Luminar': 'https://www.luminartech.com',
+        'Prophesee': 'https://www.prophesee.ai',
+
+        // Edge silicon
+        'Hailo': 'https://hailo.ai',
+        'Tenstorrent': 'https://tenstorrent.com',
+        'Axelera AI': 'https://www.axelera.ai',
+        'Nvidia Jetson Thor': 'https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-thor',
+        'Rebellions': 'https://rebellions.ai',
+
+        // Foundation models for robotics
+        'Skild AI': 'https://www.skild.ai',
+        'Skild': 'https://www.skild.ai',
+        'Physical Intelligence': 'https://www.physicalintelligence.company',
+        'Project Prometheus': 'https://www.physicalintelligence.company',
+        'World Labs (Fei-Fei Li)': 'https://www.worldlabs.ai',
+        'World Labs': 'https://www.worldlabs.ai',
+        'Dyna Robotics': 'https://www.dyna.co',
+
+        // Simulation / synthetic data
+        'Foretellix': 'https://www.foretellix.com',
+        'Nvidia Omniverse + Cosmos': 'https://www.nvidia.com/en-us/omniverse',
+        'Parallel Domain': 'https://paralleldomain.com',
+        'Cognata': 'https://www.cognata.com',
+
+        // Fleet ops / middleware
+        'Foxglove': 'https://foxglove.dev',
+        'Formant': 'https://formant.io',
+        'Intrinsic': 'https://www.intrinsic.ai',
+        'Roboflow': 'https://roboflow.com',
+
+        // Teleop / data collection
+        'Dexterity': 'https://dexterity.ai',
+        'Reflex Robotics': 'https://reflexrobotics.com',
+        'Sanctuary AI': 'https://www.sanctuary.ai',
+
+        // Safety / verification
+        'Edge Case Research': 'https://www.edge-case-research.com',
+        'Inverted AI': 'https://www.inverted.ai',
+        'Monolith AI': 'https://www.monolithai.com'
+    };
+
+    /* Returns an anchor element for a company name if a URL is mapped, else a plain text node.
+       Uses target=_blank with rel=noopener; SEO-friendly (no nofollow) so we pass juice. */
+    function companyLink(name, opts) {
+        const url = COMPANY_URLS[name];
+        if (!url) return document.createTextNode(name);
+        const a = el('a', {
+            href: url,
+            target: '_blank',
+            rel: 'noopener',
+            class: 'pai-co-link' + (opts && opts.className ? ' ' + opts.className : '')
+        }, name);
+        // Prevent click from bubbling to a card click handler when the link is inside a clickable card
+        a.addEventListener('click', (e) => e.stopPropagation());
+        return a;
+    }
+
+    /* Build a "Top: a · b · c" line as a fragment with company links where known. */
+    function companyListInline(names, separator) {
+        const sep = separator || ' · ';
+        const frag = document.createDocumentFragment();
+        names.forEach((name, i) => {
+            if (i > 0) frag.appendChild(document.createTextNode(sep));
+            frag.appendChild(companyLink(name));
+        });
+        return frag;
+    }
+
     /* Static explanations for filter chips, TLDR stats, and key terms.
        Keep terse; the goal is to remove ambiguity, not to write paragraphs. */
     const EXPLAIN = {
@@ -197,7 +405,9 @@
         const row = el('div', { class: 'pai-chasm-row' + (isTail ? ' pai-tail' : '') });
         if (b.flag) row.dataset.flag = b.flag;
         const name = el('span', { class: 'pai-chasm-name' });
-        name.appendChild(document.createTextNode(b.name));
+        // Wrap top-4 humanoid headline names in outbound links. Tail bars are sub-sector
+        // category names ("Surgical robotics") — those stay as plain text.
+        name.appendChild(isTail ? document.createTextNode(b.name) : companyLink(b.name));
         if (b.geo || b.round) {
             const sub = el('span', { class: 'pai-chasm-sub' });
             sub.textContent = [b.geo, b.round].filter(Boolean).join(' · ');
@@ -324,9 +534,18 @@
             const labelRight = cx < PAD_L + plotW - 110;
             const lx = labelRight ? cx + 12 : cx - 12;
             const anchor = labelRight ? 'start' : 'end';
-            root.appendChild(svg('text', {
+            const companyUrl = COMPANY_URLS[p.company];
+            const labelText = svg('text', {
                 x: lx, y: cy - 4, class: 'pai-point-label', 'text-anchor': anchor
-            }, p.company));
+            }, p.company);
+            if (companyUrl) {
+                const a = svg('a', { href: companyUrl, target: '_blank', rel: 'noopener', class: 'pai-svg-co-link' });
+                a.setAttributeNS('http://www.w3.org/1999/xlink', 'href', companyUrl);
+                a.appendChild(labelText);
+                root.appendChild(a);
+            } else {
+                root.appendChild(labelText);
+            }
             root.appendChild(svg('text', {
                 x: lx, y: cy + 9, class: 'pai-point-sub', 'text-anchor': anchor
             }, p.multiple + '×'));
@@ -339,9 +558,11 @@
         const sorted = [...points].sort((a, b) => b.multiple - a.multiple);
         sorted.forEach(p => {
             const cat = p.category === 'justified-by-revenue' ? 'justified' : p.category;
+            const nameEl = el('div', { class: 'pai-vf-name' });
+            nameEl.appendChild(companyLink(p.company));
             const row = el('div', { class: 'pai-vf-row' },
                 el('div', null,
-                    el('div', { class: 'pai-vf-name' }, p.company),
+                    nameEl,
                     el('div', { class: 'pai-vf-meta' }, fmtB(p.prev_val_m) + ' → ' + fmtB(p.new_val_m))
                 ),
                 el('div', { class: 'pai-vf-meta' }, p.months_between + 'mo'),
@@ -389,10 +610,18 @@
             }
         });
         const actorText = investors.join(' + ');
+        // Flow targets are company names — wrap in outbound link when known.
+        // Some entries have multiple companies separated by " · " (e.g. "EngineAI · LimX").
+        const targetEl = el('span', { class: 'pai-flow-target' });
+        const parts = company.split(' · ');
+        parts.forEach((p, i) => {
+            if (i > 0) targetEl.appendChild(document.createTextNode(' · '));
+            targetEl.appendChild(companyLink(p.trim()));
+        });
         const row = el('div', { class: 'pai-flow-row' },
             actor,
             el('span', { class: 'pai-flow-arrow' }, '→'),
-            el('span', { class: 'pai-flow-target' }, company)
+            targetEl
         );
         row.addEventListener('mousemove', (e) => {
             showTip(e, '<strong>' + company + '</strong>Backed by: ' + actorText +
@@ -483,10 +712,20 @@
             latestDot.addEventListener('mouseleave', hideTip);
             root.appendChild(latestDot);
 
-            // name label (just past first-cross dot)
-            root.appendChild(svg('text', {
+            // name label (just past first-cross dot) — wrap in SVG anchor for SEO crawler + click
+            const nameLabel = svg('text', {
                 x: xStart + 14, y: y - 5, class: 'pai-d-name'
-            }, u.name));
+            }, u.name);
+            const url = COMPANY_URLS[u.name];
+            if (url) {
+                const a = svg('a', { target: '_blank', rel: 'noopener' });
+                a.setAttributeNS('http://www.w3.org/1999/xlink', 'href', url);
+                a.setAttribute('href', url);
+                a.appendChild(nameLabel);
+                root.appendChild(a);
+            } else {
+                root.appendChild(nameLabel);
+            }
 
             // valuation label (right of latest dot)
             root.appendChild(svg('text', {
@@ -583,8 +822,12 @@
             buildStat('Deals', String(s.deals_count))
         );
 
-        const topNames = s.top_companies.slice(0, 5).map(c => c.name).join(' · ');
-        const companies = el('div', { class: 'pai-card-companies', html: 'Top: <em>' + topNames + '</em>' });
+        const topNames = s.top_companies.slice(0, 5).map(c => c.name);
+        const companies = el('div', { class: 'pai-card-companies' });
+        companies.appendChild(document.createTextNode('Top: '));
+        const emWrap = el('em');
+        emWrap.appendChild(companyListInline(topNames));
+        companies.appendChild(emWrap);
 
         const card = el('div', { class: 'pai-card' }, top, el('h3', null, s.name), stats, companies);
         card.dataset.id = s.id;
@@ -795,7 +1038,7 @@
         let anyLive = false;
         s.top_companies.forEach(c => {
             const nameCell = el('td');
-            nameCell.appendChild(document.createTextNode(c.name));
+            nameCell.appendChild(companyLink(c.name));
             if (c.flag) {
                 const flagEl = el('span', { class: 'pai-d-flag' + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
                 nameCell.appendChild(flagEl);
@@ -986,7 +1229,15 @@
             );
             const list = el('div', { class: 'pai-d-investors' });
             Array.from(entry.companies).forEach(c => {
-                list.appendChild(el('span', { class: 'pai-d-investor' }, c));
+                const url = COMPANY_URLS[c];
+                if (url) {
+                    list.appendChild(el('a', {
+                        class: 'pai-d-investor pai-d-investor-co',
+                        href: url, target: '_blank', rel: 'noopener'
+                    }, c));
+                } else {
+                    list.appendChild(el('span', { class: 'pai-d-investor' }, c));
+                }
             });
             compSec.appendChild(list);
             drawerInner.appendChild(compSec);

--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -12,7 +12,22 @@
     'use strict';
 
     let DATA = null;
+    let INVESTORS = null;  // Map<normalizedKey, { display, sectors: Set<id>, companies: Set<string>, annotations: Set<string> }>
+    let LIVE_QUOTES = null;  // ticker → { price, change_pct, date }. Populated from data.live_quotes if present.
     const tip = document.getElementById('pai-tip');
+
+    /* Investor name aliases — collapse known variants so a single click finds everything.
+       Keep the right-hand side as the canonical display form. */
+    const INVESTOR_ALIASES = {
+        'eclipse': 'Eclipse Ventures',
+        'khosla': 'Khosla Ventures',
+        'lux': 'Lux Capital',
+        'bezos': 'Bezos Expeditions',
+        'nvidia': 'Nvidia NVentures',
+        'a16z (18 deals)': 'a16z',
+        'blackstone (preferred)': 'Blackstone'
+    };
+    const BLACKLIST_INVESTORS = new Set(['state-backed china funds']);  // generic placeholder, not a focusable entity
 
     /* Static explanations for filter chips, TLDR stats, and key terms.
        Keep terse; the goal is to remove ambiguity, not to write paragraphs. */
@@ -106,6 +121,36 @@
         return sign + n + '%';
     }
 
+    function fmtPriceUSD(n) {
+        if (n == null || isNaN(n)) return '—';
+        return '$' + n.toFixed(2);
+    }
+
+    function fmtSignedPct1(n) {
+        if (n == null || isNaN(n)) return '—';
+        const sign = n > 0 ? '+' : '';
+        return sign + n.toFixed(2) + '%';
+    }
+
+    /* ---------- LIVE QUOTES ----------
+       Browser CORS blocks Stooq/Yahoo direct, so we don't fetch client-side.
+       Instead, a daily GitHub Action (see .github/workflows/refresh-quotes.yml)
+       fetches close prices server-side and commits them to data.json under
+       `live_quotes.quotes`. The JS here just reads what's there. */
+    function tickerExchangeUrl(ticker) {
+        if (!ticker) return null;
+        if (/\.HK$/i.test(ticker)) {
+            const num = ticker.replace(/\.HK$/i, '');
+            return 'https://www.google.com/finance/quote/' + num + ':HKG';
+        }
+        return 'https://www.google.com/finance/quote/' + encodeURIComponent(ticker) + ':NASDAQ';
+    }
+    function tickerExchangeLabel(ticker) {
+        if (!ticker) return '';
+        if (/\.HK$/i.test(ticker)) return 'HKEX: ' + ticker.replace(/\.HK$/i, '');
+        return 'NASDAQ: ' + ticker;
+    }
+
     /* ---------- Tooltip ---------- */
     function showTip(e, html) {
         tip.innerHTML = html;
@@ -137,7 +182,7 @@
 
         s.headline_bars.forEach(b => container.appendChild(buildChasmRow(b, false, maxVal)));
 
-        container.appendChild(el('div', { class: 'pai-chasm-divider' }, '— vs. six entire sub-sectors —'));
+        container.appendChild(el('div', { class: 'pai-chasm-divider' }, '— vs. 6 entire sub-sectors —'));
 
         s.tail_bars.forEach(b => container.appendChild(buildChasmRow({
             name: b.name,
@@ -328,14 +373,30 @@
     }
 
     function buildFlowRow(investors, company) {
+        const actor = el('span', { class: 'pai-flow-actor' });
+        investors.forEach((inv, i) => {
+            const norm = normalizeInvestorKey(inv);
+            if (norm) {
+                actor.appendChild(el('button', {
+                    class: 'pai-flow-actor-link',
+                    onclick: (e) => { e.stopPropagation(); openInvestor(norm.key); }
+                }, inv));
+            } else {
+                actor.appendChild(document.createTextNode(inv));
+            }
+            if (i < investors.length - 1) {
+                actor.appendChild(document.createTextNode(' + '));
+            }
+        });
         const actorText = investors.join(' + ');
         const row = el('div', { class: 'pai-flow-row' },
-            el('span', { class: 'pai-flow-actor' }, actorText),
+            actor,
             el('span', { class: 'pai-flow-arrow' }, '→'),
             el('span', { class: 'pai-flow-target' }, company)
         );
         row.addEventListener('mousemove', (e) => {
-            showTip(e, '<strong>' + company + '</strong>Backed by: <em>' + actorText + '</em>');
+            showTip(e, '<strong>' + company + '</strong>Backed by: ' + actorText +
+                '<br/><em>click any investor for their coverage</em>');
         });
         row.addEventListener('mouseleave', hideTip);
         return row;
@@ -449,7 +510,8 @@
             layer: p.get('layer') || 'all',
             geo: p.get('geo') || 'global',
             sort: p.get('sort') || 'capital',
-            sector: p.get('sector') || null
+            sector: p.get('sector') || null,
+            investor: p.get('investor') || null
         };
     }
 
@@ -459,6 +521,7 @@
         if (f.geo && f.geo !== 'global') p.set('geo', f.geo);
         if (f.sort && f.sort !== 'capital') p.set('sort', f.sort);
         if (f.sector) p.set('sector', f.sector);
+        if (f.investor) p.set('investor', f.investor);
         const qs = p.toString();
         const url = window.location.pathname + (qs ? '?' + qs : '') + window.location.hash;
         window.history.replaceState(null, '', url);
@@ -546,6 +609,60 @@
         );
     }
 
+    /* ---------- INVESTOR INDEX ---------- */
+    function normalizeInvestorKey(rawName) {
+        if (!rawName) return null;
+        // Strip parentheticals; lowercase; collapse whitespace
+        const stripped = rawName.replace(/\s*\([^)]*\)\s*$/, '').trim().toLowerCase();
+        if (!stripped) return null;
+        if (BLACKLIST_INVESTORS.has(stripped)) return null;
+        // Apply alias map (against full original lowercased form first, then stripped)
+        const fullLower = rawName.toLowerCase().trim();
+        const aliasFull = INVESTOR_ALIASES[fullLower];
+        const aliasStripped = INVESTOR_ALIASES[stripped];
+        const display = aliasFull || aliasStripped || rawName.replace(/\s*\([^)]*\)\s*$/, '').trim();
+        return { key: display.toLowerCase(), display };
+    }
+
+    function splitInvestorString(s) {
+        // Handle multi-investor entries like "Microsoft + Amazon + OpenAI" or "Alibaba, Geely"
+        return s.split(/\s*(?:\+|,|&)\s*/).map(x => x.trim()).filter(Boolean);
+    }
+
+    function buildInvestorIndex() {
+        const idx = new Map();
+        function add(rawName, sectorId, companyName) {
+            const norm = normalizeInvestorKey(rawName);
+            if (!norm) return;
+            if (!idx.has(norm.key)) {
+                idx.set(norm.key, {
+                    display: norm.display,
+                    sectors: new Set(),
+                    companies: new Set(),
+                    annotations: new Set()
+                });
+            }
+            const entry = idx.get(norm.key);
+            if (sectorId) entry.sectors.add(sectorId);
+            if (companyName) entry.companies.add(companyName);
+            // Pull annotation from parens if any
+            const annMatch = rawName.match(/\(([^)]+)\)\s*$/);
+            if (annMatch) entry.annotations.add(annMatch[1].trim());
+        }
+        DATA.subsectors.forEach(s => {
+            (s.top_investors || []).forEach(inv => {
+                splitInvestorString(inv).forEach(part => add(part, s.id, null));
+            });
+        });
+        const flows = DATA.scenes.us_china_flows;
+        if (flows) {
+            (flows.us_flows || []).concat(flows.china_flows || []).forEach(f => {
+                f.investors.forEach(inv => add(inv, null, f.company));
+            });
+        }
+        return idx;
+    }
+
     /* ---------- DRAWER ---------- */
     const drawer = document.getElementById('drawer');
     const drawerInner = document.getElementById('drawer-inner');
@@ -556,8 +673,25 @@
         if (!s) return;
         const f = readFilters();
         f.sector = id;
+        f.investor = null;
         writeFilters(f);
         renderDrawer(s);
+        drawer.classList.add('open');
+        drawer.setAttribute('aria-hidden', 'false');
+        drawerOverlay.classList.add('open');
+        document.body.style.overflow = 'hidden';
+    }
+
+    function openInvestor(key) {
+        if (!INVESTORS) return;
+        const lookupKey = key.toLowerCase();
+        const entry = INVESTORS.get(lookupKey);
+        if (!entry) return;
+        const f = readFilters();
+        f.investor = entry.display;
+        f.sector = null;
+        writeFilters(f);
+        renderInvestor(entry);
         drawer.classList.add('open');
         drawer.setAttribute('aria-hidden', 'false');
         drawerOverlay.classList.add('open');
@@ -571,6 +705,7 @@
         document.body.style.overflow = '';
         const f = readFilters();
         f.sector = null;
+        f.investor = null;
         writeFilters(f);
     }
 
@@ -657,12 +792,36 @@
         );
         table.appendChild(thead);
         const tbody = el('tbody');
+        let anyLive = false;
         s.top_companies.forEach(c => {
             const nameCell = el('td');
             nameCell.appendChild(document.createTextNode(c.name));
             if (c.flag) {
                 const flagEl = el('span', { class: 'pai-d-flag' + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
                 nameCell.appendChild(flagEl);
+            }
+            // Ticker row: always show for public-market-cap companies. Add live price if available.
+            if (c.ticker) {
+                const live = LIVE_QUOTES && LIVE_QUOTES[c.ticker];
+                const meta = el('div', { class: 'pai-live-meta' });
+                meta.appendChild(el('a', {
+                    class: 'pai-live-ticker',
+                    href: tickerExchangeUrl(c.ticker),
+                    target: '_blank',
+                    rel: 'noopener noreferrer',
+                    title: 'View ' + c.ticker + ' on Google Finance'
+                }, tickerExchangeLabel(c.ticker)));
+                if (live && live.price != null) {
+                    anyLive = true;
+                    meta.appendChild(el('span', { class: 'pai-live-dot', title: 'Daily close · ' + (live.date || '') }));
+                    meta.appendChild(el('span', { class: 'pai-live-price' }, fmtPriceUSD(live.price)));
+                    if (live.change_pct != null) {
+                        meta.appendChild(el('span', {
+                            class: 'pai-live-delta ' + (live.change_pct >= 0 ? 'pai-live-up' : 'pai-live-down')
+                        }, fmtSignedPct1(live.change_pct)));
+                    }
+                }
+                nameCell.appendChild(meta);
             }
             tbody.appendChild(el('tr', null,
                 nameCell,
@@ -673,6 +832,16 @@
         });
         table.appendChild(tbody);
         compSec.appendChild(table);
+        if (anyLive && DATA.live_quotes && DATA.live_quotes.updated) {
+            compSec.appendChild(el('div', { class: 'pai-live-footnote' },
+                'Daily-refreshed close prices via Stooq, last updated ' + DATA.live_quotes.updated +
+                '. Stored Val column is the point-in-time market cap from data.json (quarterly refresh).'
+            ));
+        } else if (s.top_companies.some(c => c.ticker)) {
+            compSec.appendChild(el('div', { class: 'pai-live-footnote pai-live-footnote-stale' },
+                'Live daily-refresh pending. Click any ticker symbol above for the current price on Google Finance.'
+            ));
+        }
         drawerInner.appendChild(compSec);
 
         // Investors
@@ -681,7 +850,25 @@
                 el('div', { class: 'pai-d-section-label' }, 'Active investors')
             );
             const invList = el('div', { class: 'pai-d-investors' });
-            s.top_investors.forEach(i => invList.appendChild(el('span', { class: 'pai-d-investor' }, i)));
+            s.top_investors.forEach(rawEntry => {
+                // Each top_investors entry might be a single name or a + separated group.
+                // Render each name as a clickable pill that opens that investor's coverage view.
+                const parts = splitInvestorString(rawEntry);
+                parts.forEach(part => {
+                    const norm = normalizeInvestorKey(part);
+                    if (!norm) {
+                        invList.appendChild(el('span', { class: 'pai-d-investor' }, part));
+                        return;
+                    }
+                    // Display: if the part has a parenthetical annotation, preserve it
+                    const annMatch = part.match(/\(([^)]+)\)\s*$/);
+                    const label = annMatch ? norm.display + ' (' + annMatch[1] + ')' : norm.display;
+                    invList.appendChild(el('button', {
+                        class: 'pai-d-investor pai-d-investor-btn',
+                        onclick: (e) => { e.stopPropagation(); openInvestor(norm.key); }
+                    }, label));
+                });
+            });
             invSec.appendChild(invList);
             drawerInner.appendChild(invSec);
         }
@@ -703,6 +890,113 @@
         drawerInner.appendChild(el('div', { class: 'pai-d-footer' },
             el('span', null, 'Last updated ' + updated + ' · v' + (DATA.meta && DATA.meta.version || '0.1')),
             el('a', { href: 'mailto:hello@canonical.cc?subject=' + sub }, 'Discuss this sub-sector →')
+        ));
+
+        drawer.scrollTop = 0;
+    }
+
+    function renderInvestor(entry) {
+        drawerInner.innerHTML = '';
+
+        drawerInner.appendChild(el('button', {
+            class: 'pai-drawer-close',
+            'aria-label': 'Close panel',
+            onclick: closeDrawer
+        }, '×'));
+
+        // Resolve sectors and aggregate
+        const sectors = Array.from(entry.sectors).map(id => DATA.subsectors.find(s => s.id === id)).filter(Boolean);
+        sectors.sort((a, b) => (b.capital_2024_25_m || 0) - (a.capital_2024_25_m || 0));
+
+        const totalCapital = sectors.reduce((sum, s) => sum + (s.capital_2024_25_m || 0), 0);
+        const layerBreakdown = { embodiment: 0, domain: 0, stack: 0 };
+        sectors.forEach(s => { layerBreakdown[s.layer] = (layerBreakdown[s.layer] || 0) + 1; });
+
+        // Header
+        const header = el('div', { class: 'pai-d-header' },
+            el('div', { class: 'pai-d-meta-row' },
+                el('span', { class: 'pai-card-layer pai-investor-label' }, 'INVESTOR'),
+                entry.annotations.size
+                    ? el('span', { class: 'pai-d-num pai-investor-ann' }, Array.from(entry.annotations).join(' · '))
+                    : null
+            ),
+            el('h2', { class: 'pai-d-title', id: 'drawer-title' }, entry.display)
+        );
+        drawerInner.appendChild(header);
+
+        // Stats: # sub-sectors, # named companies, layer breakdown
+        const stats = el('div', { class: 'pai-d-stats' });
+        stats.appendChild(el('div', null,
+            el('div', { class: 'pai-d-stat-k' }, 'Sub-sectors'),
+            el('div', { class: 'pai-d-stat-v' }, String(sectors.length))
+        ));
+        stats.appendChild(el('div', null,
+            el('div', { class: 'pai-d-stat-k' }, 'Sector capital total'),
+            el('div', { class: 'pai-d-stat-v' }, fmtB(totalCapital))
+        ));
+        stats.appendChild(el('div', null,
+            el('div', { class: 'pai-d-stat-k' }, 'Layer mix'),
+            el('div', { class: 'pai-d-stat-v pai-investor-layers' },
+                (layerBreakdown.embodiment ? layerBreakdown.embodiment + 'E ' : '') +
+                (layerBreakdown.domain ? layerBreakdown.domain + 'D ' : '') +
+                (layerBreakdown.stack ? layerBreakdown.stack + 'S' : '')
+            )
+        ));
+        drawerInner.appendChild(stats);
+
+        // Reading
+        drawerInner.appendChild(el('div', { class: 'pai-d-section' },
+            el('div', { class: 'pai-d-section-label' }, 'How to read this'),
+            el('div', { class: 'pai-d-pov-body' },
+                entry.display + ' shows up as a top-named investor in the sub-sectors below. ' +
+                'Sector capital total is the sum of all 2024–25 venture into those sub-sectors, not ' +
+                entry.display + '\'s own check size. Use it as a coverage map, not a deployment ledger.'
+            )
+        ));
+
+        // Sub-sectors list
+        if (sectors.length) {
+            const secList = el('div', { class: 'pai-d-section' },
+                el('div', { class: 'pai-d-section-label' }, 'Sub-sectors (' + sectors.length + ')')
+            );
+            const grid = el('div', { class: 'pai-investor-sector-grid' });
+            sectors.forEach(s => {
+                const card = el('div', { class: 'pai-investor-sector-card', onclick: () => openSector(s.id) },
+                    el('div', { class: 'pai-investor-sector-top' },
+                        el('span', { class: 'pai-card-num' }, s.number),
+                        el('span', { class: 'pai-card-layer' }, s.layer)
+                    ),
+                    el('div', { class: 'pai-investor-sector-name' }, s.name),
+                    el('div', { class: 'pai-investor-sector-stat' },
+                        fmtB(s.capital_2024_25_m) + ' · ' + s.deals_count + ' deals'
+                    )
+                );
+                grid.appendChild(card);
+            });
+            secList.appendChild(grid);
+            drawerInner.appendChild(secList);
+        }
+
+        // Named companies (from us_china_flows)
+        if (entry.companies.size) {
+            const compSec = el('div', { class: 'pai-d-section' },
+                el('div', { class: 'pai-d-section-label' }, 'Named portfolio companies (' + entry.companies.size + ')'),
+                el('div', { class: 'pai-d-section-note' },
+                    'Pulled from the US/China humanoid flows scene. Other portfolio investments live in the sub-sector cards.')
+            );
+            const list = el('div', { class: 'pai-d-investors' });
+            Array.from(entry.companies).forEach(c => {
+                list.appendChild(el('span', { class: 'pai-d-investor' }, c));
+            });
+            compSec.appendChild(list);
+            drawerInner.appendChild(compSec);
+        }
+
+        // Footer
+        const sub = encodeURIComponent('Physical AI Map — ' + entry.display);
+        drawerInner.appendChild(el('div', { class: 'pai-d-footer' },
+            el('span', null, 'Coverage view · v' + (DATA.meta && DATA.meta.version || '0.1')),
+            el('a', { href: 'mailto:hello@canonical.cc?subject=' + sub }, 'Discuss ' + entry.display + ' →')
         ));
 
         drawer.scrollTop = 0;
@@ -766,6 +1060,15 @@
             updatedEl.textContent = d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
         }
 
+        INVESTORS = buildInvestorIndex();
+
+        // Live quotes are populated server-side by a daily GitHub Action (see
+        // .github/workflows/refresh-quotes.yml) and committed to data.live_quotes.quotes.
+        // We just read what's in the file; no client-side fetching (browser CORS blocks Stooq/Yahoo).
+        if (DATA.live_quotes && DATA.live_quotes.quotes) {
+            LIVE_QUOTES = DATA.live_quotes.quotes;
+        }
+
         renderChasm();
         renderVelocity();
         renderFlows();
@@ -804,9 +1107,10 @@
         });
         document.addEventListener('focusout', hideTip);
 
-        // open sector from URL if present
+        // open sector or investor from URL if present (sector wins if both present)
         const f = readFilters();
         if (f.sector) openSector(f.sector);
+        else if (f.investor) openInvestor(f.investor);
 
         // close drawer interactions
         drawerOverlay.addEventListener('click', closeDrawer);

--- a/scripts/refresh-quotes.mjs
+++ b/scripts/refresh-quotes.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Refresh public market close prices for the Physical AI Map.
+ *
+ * Reads tickers from labs/physical-ai/data.json (each public company has a
+ * `ticker` field), fetches latest close prices from Stooq, and writes them
+ * back under `data.live_quotes.quotes`. Run by a daily GitHub Action (see
+ * .github/workflows/refresh-quotes.yml). Can also be run locally:
+ *
+ *   node scripts/refresh-quotes.mjs
+ *
+ * Browser CORS prevents doing this client-side, hence the server-side cron.
+ * Stooq is CORS-restricted but happily serves server-to-server requests with
+ * no auth and no rate limits worth worrying about for ~10 tickers/day.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA_PATH = resolve(__dirname, '..', 'labs', 'physical-ai', 'data.json');
+
+function tickerToStooq(ticker) {
+    if (/\.HK$/i.test(ticker)) return ticker.toLowerCase();
+    return ticker.toLowerCase() + '.us';
+}
+
+async function fetchOne(stooqSym) {
+    const url = `https://stooq.com/q/l/?s=${stooqSym}&f=sd2t2ohlcv&h&e=csv`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${stooqSym}`);
+    const csv = await res.text();
+    const lines = csv.trim().split(/\r?\n/);
+    if (lines.length < 2) throw new Error(`Empty CSV for ${stooqSym}`);
+    const cols = lines[1].split(',');
+    // Headers: Symbol, Date, Time, Open, High, Low, Close, Volume
+    if (cols.length < 7) throw new Error(`Bad CSV row for ${stooqSym}: ${lines[1]}`);
+    const date = cols[1];
+    const open = parseFloat(cols[3]);
+    const close = parseFloat(cols[6]);
+    if (!Number.isFinite(close) || close <= 0) {
+        throw new Error(`No close price for ${stooqSym} (row: ${lines[1]})`);
+    }
+    const changePct = Number.isFinite(open) && open > 0
+        ? Math.round(((close - open) / open) * 10000) / 100
+        : null;
+    return { price: close, open: Number.isFinite(open) ? open : null, change_pct: changePct, date };
+}
+
+async function main() {
+    const data = JSON.parse(readFileSync(DATA_PATH, 'utf8'));
+
+    // Collect unique tickers from public companies
+    const tickers = new Set();
+    for (const s of data.subsectors || []) {
+        for (const c of s.top_companies || []) {
+            if (c.ticker) tickers.add(c.ticker);
+        }
+    }
+
+    if (tickers.size === 0) {
+        console.log('No tickers found in data.json; nothing to refresh.');
+        return;
+    }
+
+    console.log(`Refreshing ${tickers.size} quotes:`, Array.from(tickers).join(', '));
+
+    const quotes = {};
+    const errors = [];
+    for (const ticker of tickers) {
+        const stooqSym = tickerToStooq(ticker);
+        try {
+            const quote = await fetchOne(stooqSym);
+            quotes[ticker] = quote;
+            console.log(`  ${ticker} → $${quote.price} (${quote.change_pct != null ? quote.change_pct + '%' : 'n/a'}) on ${quote.date}`);
+        } catch (err) {
+            errors.push({ ticker, error: err.message });
+            console.warn(`  ${ticker} failed: ${err.message}`);
+        }
+        // Be polite: small delay between requests
+        await new Promise(r => setTimeout(r, 200));
+    }
+
+    const updated = new Date().toISOString().split('T')[0];
+    data.live_quotes = {
+        updated,
+        source: 'Stooq',
+        quotes,
+        ...(errors.length ? { errors } : {})
+    };
+
+    writeFileSync(DATA_PATH, JSON.stringify(data, null, 2) + '\n');
+    console.log(`Wrote ${Object.keys(quotes).length} quotes to ${DATA_PATH} (${errors.length} errors)`);
+}
+
+main().catch(err => {
+    console.error('refresh-quotes failed:', err);
+    process.exit(1);
+});


### PR DESCRIPTION
Two follow-up commits on top of #16, which already shipped the v1 map. Both are additive; no behavior change to existing scenes.

## Commit 1 — Physical AI Map Phase 2: investor view, daily-refreshed quotes, copy polish

**Investor focus view.** Click any investor (drawer pill or US/China flow row) → coverage panel listing every physical-AI sub-sector that investor appears in, total sector capital, layer mix, and named portfolio companies from the humanoid flows scene. Name aliases collapse Eclipse / Eclipse Ventures, Khosla / Khosla Ventures, Lux / Lux Capital, Bezos / Bezos Expeditions, Nvidia / Nvidia NVentures, and a16z / a16z (18 deals). Deep-linkable: `?investor=Bezos+Expeditions` opens straight to coverage.

**Live public market quotes.** Browser CORS blocks Stooq/Yahoo from a static page, so quotes refresh server-side via a new daily GitHub Action (`.github/workflows/refresh-quotes.yml`, weekday 22:00 UTC) running `scripts/refresh-quotes.mjs`. Script pulls each ticker individually (Stooq's multi-symbol endpoint is broken), writes results under `data.live_quotes.quotes`, commits if the file changed. 7 of 8 tickers populated on first run (SYM, PONY, WRD, AUR, HSAI, 2498.HK, OUST); EKSO is too small for Stooq's free feed and is gracefully skipped. Drawer renders ticker, close price, and intraday change for public-cap companies with a Google Finance link on the symbol. Footnote shows source + last refresh date.

**Copy polish.** Written-out numbers converted to digits across HTML, data.json, lab.js ("Four" → 4, "six" → 6, "two" → 2, "twelve" → 12). LP CTA button removed. "Subscribe to quarterly updates" is now "Subscribe to updates".

## Commit 2 — Outbound company links across the map for SEO

Every company name on the page is wrapped in an outbound anchor to its official site when known. Single `COMPANY_URLS` dictionary in lab.js (~80 entries) is the source of truth. `companyLink()` helper produces real `<a target=_blank rel=noopener>` elements; `companyListInline()` builds the "Top: a · b · c" fragment for sector card previews.

Wired through every render path: chasm bar names, velocity scatter SVG labels (crawler-visible via SVG anchors), US/China flow targets, defense unicorn timeline SVG labels, drawer top-companies table, investor-view named portfolio pills, sector card "Top:" lines across all 22 cards, mobile velocity fallback list.

Aliases handled so the same dictionary covers "Figure" / "Figure AI", "Skild" / "Skild AI", "Anduril" / "Anduril Dive-LD/XL", "Ouster" / "Ouster (post-Stereolabs)", "Diligent Robotics" / "Diligent Robotics (Moxi)". Flow targets with " · " separators split correctly so each name links independently.

**Result**: 146 outbound links to 100 unique domains rendered on first load before any user interaction. SEO-clean — no `rel=nofollow`, real anchors with `target=_blank rel=noopener`.

## Test plan

- [ ] Click any sub-sector card → drawer opens. Company names in the top-companies table are linked to the company's site.
- [ ] Inside a drawer, click an investor pill (e.g. "a16z (18 deals)" in Defense) → investor coverage view opens. Title shows canonical form, annotation in orange.
- [ ] Bezos coverage view shows 3 named portfolio companies (Skild, Physical Intelligence, Project Prometheus), each linked.
- [ ] Open Sensors / Perception sector → 3 public-traded companies (Hesai, RoboSense, Ouster) show ticker, close price, intraday delta with color, footnote with refresh date.
- [ ] Deep link `?investor=a16z` restores the a16z coverage view; URL preserves both filters and current view.
- [ ] In US/China flows (Scene 3), investor names like "OpenAI" or "Microsoft + Amazon + OpenAI" are clickable per-investor.
- [ ] No console errors on load.
- [ ] Trigger the workflow manually once after merge: `gh workflow run "Refresh public market quotes"` — confirms the daily-refresh path works end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)