### PR TITLE
Surface 3 Canonical portfolio companies on the Physical AI Map

### DIFF
--- a/labs/physical-ai/data.json
+++ b/labs/physical-ai/data.json
@@ -806,6 +806,14 @@
       },
       "top_companies": [
         {
+          "name": "Nirvana AI",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "early stage",
+          "canonical_portfolio": true,
+          "portfolio_url": "https://canonical.cc/companies/nirvana-ai.html"
+        },
+        {
           "name": "Mind Robotics",
           "geo": "US",
           "valuation_m": 3400,
@@ -1527,6 +1535,14 @@
       },
       "top_companies": [
         {
+          "name": "Haptic",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "early stage",
+          "canonical_portfolio": true,
+          "portfolio_url": "https://canonical.cc/companies/haptic.html"
+        },
+        {
           "name": "Foxglove",
           "geo": "US",
           "valuation_m": null,
@@ -1573,6 +1589,14 @@
         "RoW": 0
       },
       "top_companies": [
+        {
+          "name": "Robo",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "early stage, ROBO-1 arm + LeRobot-compatible stack",
+          "canonical_portfolio": true,
+          "portfolio_url": "https://canonical.cc/companies/robo.html"
+        },
         {
           "name": "Dexterity",
           "geo": "US",

--- a/labs/physical-ai/lab.css
+++ b/labs/physical-ai/lab.css
@@ -1126,6 +1126,74 @@
 }
 .pai-d-table .pai-d-flag.public { background: rgba(30, 58, 138, 0.1); color: var(--pai-navy); }
 
+/* ============ CANONICAL PORTFOLIO ============ */
+/* Drawer table — orange pill linked to internal portfolio page */
+.pai-d-flag-canonical {
+    background: var(--pai-accent) !important;
+    color: #ffffff !important;
+    border: none;
+    text-decoration: none;
+    cursor: pointer;
+    transition: filter 0.15s, transform 0.15s;
+    letter-spacing: 0.06em !important;
+    font-weight: 600 !important;
+}
+.pai-d-flag-canonical:hover { filter: brightness(1.1); transform: translateY(-1px); }
+.pai-d-flag-canonical:focus { outline: 2px solid rgba(255, 255, 255, 0.6); outline-offset: 2px; }
+
+/* Subtle row highlight in the drawer table for Canonical portfolio rows */
+.pai-d-portfolio-row {
+    background: rgba(249, 115, 22, 0.04);
+    border-left: 2px solid var(--pai-accent);
+    padding-left: 0.5rem !important;
+}
+
+/* Card preview — star prefix on portfolio company names in "Top: ..." line */
+.pai-card-portfolio-name {
+    display: inline;
+    color: var(--pai-accent);
+    font-weight: 500;
+    white-space: nowrap;
+}
+.pai-card-portfolio-name .pai-co-link {
+    color: var(--pai-accent);
+    border-bottom-color: rgba(249, 115, 22, 0.4);
+}
+.pai-card-portfolio-name .pai-co-link:hover {
+    color: var(--pai-accent);
+    border-bottom-color: var(--pai-accent);
+}
+
+/* Sector card — small corner badge if the card holds a Canonical portfolio company */
+.pai-card { position: relative; }
+.pai-card-portfolio-badge {
+    position: absolute;
+    top: 0.55rem;
+    right: 0.55rem;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--pai-accent);
+    color: #ffffff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    line-height: 1;
+    box-shadow: 0 2px 6px rgba(249, 115, 22, 0.4);
+    cursor: help;
+}
+.pai-card-has-portfolio {
+    border-color: rgba(249, 115, 22, 0.25);
+}
+.pai-card-has-portfolio:hover {
+    border-color: var(--pai-accent);
+}
+/* Push the layer pill left so it doesn't collide with the corner badge */
+.pai-card-has-portfolio .pai-card-layer {
+    margin-right: 1.6rem;
+}
+
 /* ============ COMPANY OUTBOUND LINKS ============
    Used everywhere a company name renders. Subtle by default (color inherits),
    underline on hover. Keep these crawler-visible — no nofollow, real anchors. */

--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -31,8 +31,16 @@
 
     /* Company → official corporate URL. Source of truth for outbound links.
        Keep aligned with names in data.json scenes + subsectors[].top_companies.
-       Used by companyLink() everywhere a company is rendered. */
+       Used by companyLink() everywhere a company is rendered.
+
+       Canonical portfolio companies are linked to their corporate domains here
+       (for outbound SEO juice). The CANONICAL pill rendered next to the name
+       links to the internal /companies/<slug>.html page for engagement. */
     const COMPANY_URLS = {
+        // Canonical portfolio (3)
+        'Haptic': 'https://hapticlabs.ai',
+        'Robo': 'https://robo.inc',
+        'Nirvana AI': 'https://nrvana.ai',
         // Humanoid robotics
         'Figure AI': 'https://www.figure.ai',
         'Figure': 'https://www.figure.ai',
@@ -809,6 +817,9 @@
     }
 
     function buildCard(s) {
+        const portfolioCompanies = (s.top_companies || []).filter(c => c.canonical_portfolio);
+        const hasPortfolio = portfolioCompanies.length > 0;
+
         const top = el('div', { class: 'pai-card-top' },
             el('span', { class: 'pai-card-num' }, s.number),
             el('span', { class: 'pai-card-layer' }, s.layer)
@@ -822,14 +833,38 @@
             buildStat('Deals', String(s.deals_count))
         );
 
-        const topNames = s.top_companies.slice(0, 5).map(c => c.name);
+        // For the card preview, surface our portfolio companies first regardless of valuation rank,
+        // then fill with the next 4 (or however many) non-portfolio names.
+        const portfolioNames = portfolioCompanies.map(c => c.name);
+        const nonPortfolio = (s.top_companies || []).filter(c => !c.canonical_portfolio).slice(0, 5 - portfolioNames.length).map(c => c.name);
+        const topNames = portfolioNames.concat(nonPortfolio);
+
         const companies = el('div', { class: 'pai-card-companies' });
         companies.appendChild(document.createTextNode('Top: '));
         const emWrap = el('em');
-        emWrap.appendChild(companyListInline(topNames));
+        // Inline rendering with star prefix for portfolio company names
+        topNames.forEach((name, i) => {
+            if (i > 0) emWrap.appendChild(document.createTextNode(' · '));
+            const isPortfolio = portfolioNames.includes(name);
+            if (isPortfolio) {
+                const wrap = el('span', { class: 'pai-card-portfolio-name' });
+                wrap.appendChild(document.createTextNode('★ '));
+                wrap.appendChild(companyLink(name));
+                emWrap.appendChild(wrap);
+            } else {
+                emWrap.appendChild(companyLink(name));
+            }
+        });
         companies.appendChild(emWrap);
 
-        const card = el('div', { class: 'pai-card' }, top, el('h3', null, s.name), stats, companies);
+        const card = el('div', { class: 'pai-card' + (hasPortfolio ? ' pai-card-has-portfolio' : '') }, top, el('h3', null, s.name), stats, companies);
+        if (hasPortfolio) {
+            // Floating corner indicator for sectors with Canonical portfolio coverage
+            card.appendChild(el('span', {
+                class: 'pai-card-portfolio-badge',
+                title: portfolioCompanies.map(c => c.name).join(', ') + ' — Canonical portfolio'
+            }, '★'));
+        }
         card.dataset.id = s.id;
         card.addEventListener('click', () => openSector(s.id));
 
@@ -1038,10 +1073,19 @@
         let anyLive = false;
         s.top_companies.forEach(c => {
             const nameCell = el('td');
+            if (c.canonical_portfolio) nameCell.classList.add('pai-d-portfolio-row');
             nameCell.appendChild(companyLink(c.name));
             if (c.flag) {
                 const flagEl = el('span', { class: 'pai-d-flag' + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
                 nameCell.appendChild(flagEl);
+            }
+            // Canonical portfolio pill — links to the internal /companies/<slug>.html page
+            if (c.canonical_portfolio && c.portfolio_url) {
+                nameCell.appendChild(el('a', {
+                    class: 'pai-d-flag pai-d-flag-canonical',
+                    href: c.portfolio_url,
+                    title: 'A Canonical portfolio company'
+                }, '★ Canonical'));
             }
             // Ticker row: always show for public-market-cap companies. Add live price if available.
             if (c.ticker) {


### PR DESCRIPTION
## Summary

Three Canonical portfolio companies are now first-class citizens on https://canonical.cc/labs/physical-ai/:

| Company | Site | Sub-sector |
|--|--|--|
| **Haptic** | [hapticlabs.ai](https://hapticlabs.ai) | Fleet Ops / Robotics Middleware |
| **Robo** | [robo.inc](https://robo.inc) | Teleoperation & Data Collection |
| **Nirvana AI** | [nrvna.ai](https://nrvna.ai) | Industrial / Manufacturing Automation |

Each is added to its sub-sector's `top_companies` array (pinned first) with `canonical_portfolio: true` and a `portfolio_url` pointing to the internal `/companies/<slug>.html` page.

## Treatment

**Dual-link strategy** — the company name links outbound to the corporate site (for SEO backlink juice), and a separate orange "★ Canonical" pill next to the name links inbound to `canonical.cc/companies/<slug>.html` (for portfolio engagement).

**Drawer table** — portfolio row has a subtle orange left border + tinted background. The orange pill is clearly clickable.

**Sector cards** — cards holding a portfolio company get a floating orange star badge in the top-right corner. The portfolio company name is pinned first in the card's "Top:" preview line with a star prefix in accent color.

**Editorial integrity preserved** — existing `canonical_pov` blurbs unchanged. The badge does the disclosure; the POV stays opinionated about the macro picture, not promotional.

## Test plan

- [ ] Explorer grid: cards 8 (Industrial), 20 (Fleet Ops), 21 (Teleop) each show an orange star badge in the corner and "★ Haptic / Robo / Nirvana AI" in the Top: line.
- [ ] Open Fleet Ops drawer → Haptic is row 1, has orange row highlight, name links to hapticlabs.ai (external), "★ Canonical" pill links to /companies/haptic.html (internal).
- [ ] Same pattern for Industrial → Nirvana AI and Teleop → Robo.
- [ ] No regression on existing rows; other sub-sectors render unchanged.
- [ ] No console errors on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)