### PR TITLE
Add Semiconductor Stack Disruptors lab under /labs/semiconductor-silicon-stack/

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,6 +15,7 @@
                         <a href="https://canonical.cc/labs/fundmodeler/" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
                         <a href="https://canonical.cc/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
                         <a href="https://canonical.cc/labs/physical-ai/" class="nav-dropdown-item" role="menuitem">Physical AI Map</a>
+                        <a href="https://canonical.cc/labs/semiconductor-silicon-stack/" class="nav-dropdown-item" role="menuitem">Semiconductor Stack</a>
                     </div>
                 </div>
                 <a href="https://canonical.cc/#team" class="nav-link" data-canonical-anchor="team">TEAM</a>
@@ -34,6 +35,8 @@
         <a href="https://canonical.cc/labs/dilutionlab/" class="nav-mobile-sublink">Dilution Lab</a>
         <a href="https://canonical.cc/labs/fundmodeler/" class="nav-mobile-sublink">Fund Modeler</a>
         <a href="https://canonical.cc/labs/power-law/" class="nav-mobile-sublink">Power Law Lab</a>
+        <a href="https://canonical.cc/labs/physical-ai/" class="nav-mobile-sublink">Physical AI Map</a>
+        <a href="https://canonical.cc/labs/semiconductor-silicon-stack/" class="nav-mobile-sublink">Semiconductor Stack</a>
         <a href="https://canonical.cc/#team" class="nav-mobile-link" data-canonical-anchor="team">TEAM</a>
     </nav>
 </header>

--- a/labs/semiconductor-silicon-stack/index.html
+++ b/labs/semiconductor-silicon-stack/index.html
@@ -1,0 +1,775 @@
+---
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Semiconductor Stack Disruptors | Canonical Labs</title>
+    <meta name="description" content="The semiconductor stack, mapped. Who owns each layer of silicon today, and the 40+ startups credibly trying to take a piece of it. Built by Canonical." />
+    <meta name="author" content="Canonical" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://canonical.cc/labs/semiconductor-silicon-stack/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://canonical.cc/labs/semiconductor-silicon-stack/" />
+    <meta property="og:title" content="Semiconductor Stack Disruptors | Canonical Labs" />
+    <meta property="og:description" content="Who owns each layer of silicon today, and the 40+ startups credibly trying to take a piece of it." />
+    <meta property="og:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="og:site_name" content="Canonical" />
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://canonical.cc/labs/semiconductor-silicon-stack/" />
+    <meta property="twitter:title" content="Semiconductor Stack Disruptors | Canonical Labs" />
+    <meta property="twitter:description" content="The picks-and-shovels of silicon. Mapped. 7 stack layers, 40+ challengers, 20 incumbents." />
+    <meta property="twitter:image" content="https://canonical.cc/images/site-logo.png" />
+    <meta property="twitter:creator" content="@canonicalcc" />
+    <meta property="twitter:site" content="@canonicalcc" />
+
+    <meta name="theme-color" content="#1e3a8a" />
+    <link rel="icon" type="image/x-icon" href="https://www.canonical.cc/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://canonical.cc/css/style.css?v=20260514f">
+    <link rel="stylesheet" href="lab.css?v=1">
+</head>
+<body>
+    <div class="min-h-screen">
+        {% include header.html %}
+
+        <main>
+            <!-- HERO -->
+            <section class="sem-hero" id="top">
+                <div class="container mx-auto px-8">
+                    <div class="sem-hero-content">
+                        <span class="sem-eyebrow">[00] &nbsp; Canonical Labs &middot; Semiconductor Stack Disruptors</span>
+                        <h1 class="sem-title">The picks-and-shovels of silicon. <em>Mapped.</em></h1>
+                        <p class="sem-subtitle">
+                            Every AI chip in the world flows through the same dozen companies. ASML for lithography. TSMC for manufacturing. Synopsys, Cadence and Siemens for design. We mapped who owns each layer today &mdash; and the 40+ startups credibly trying to take a piece of it. Companion to the <a href="https://canonical.cc/labs/physical-ai/">Physical AI Capital Flow Map</a>.
+                        </p>
+                        <div class="sem-meta">
+                            <div class="sem-meta-item"><span class="sem-meta-key">Coverage</span><span class="sem-meta-val">7 stack layers + EDA</span></div>
+                            <div class="sem-meta-item"><span class="sem-meta-key">Companies tracked</span><span class="sem-meta-val">40+ challengers, 20 incumbents</span></div>
+                            <div class="sem-meta-item"><span class="sem-meta-key">Sources</span><span class="sem-meta-val">Primary filings &middot; PRs &middot; Crunchbase &middot; Pitchbook</span></div>
+                            <div class="sem-meta-item"><span class="sem-meta-key">Updated</span><span class="sem-meta-val">May 16, 2026</span></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- TL;DR STRIP -->
+            <section class="sem-tldr">
+                <div class="container mx-auto px-8">
+                    <div class="sem-tldr-intro">The state of the silicon stack in four numbers.</div>
+                    <div class="sem-tldr-grid">
+                        <div class="sem-tldr-item">
+                            <div class="sem-stat"><em>$4B</em></div>
+                            <div class="sem-tldr-label"><strong>Ricursive Intelligence</strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
+                        </div>
+                        <div class="sem-tldr-item">
+                            <div class="sem-stat">2</div>
+                            <div class="sem-tldr-label"><strong>Real chokepoints.</strong> ASML and TSMC. If either stops shipping, the industry stops. Everything else has competition.</div>
+                        </div>
+                        <div class="sem-tldr-item">
+                            <div class="sem-stat">$1<span class="sem-stat-unit">B</span></div>
+                            <div class="sem-tldr-label"><strong>Substrate's seed valuation.</strong> X-ray lithography from particle accelerators. Founders Fund led. Skepticism is warranted.</div>
+                        </div>
+                        <div class="sem-tldr-item">
+                            <div class="sem-stat">75<span class="sem-stat-unit">%</span></div>
+                            <div class="sem-tldr-label"><strong>EDA market share</strong> held by three companies. Cadence already acquired ChipStack. More consolidation coming.</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- SUB-NAV -->
+            <div class="sem-subnav" id="sem-subnav">
+                <div class="container mx-auto px-8">
+                    <ul class="sem-subnav-list">
+                        <li><a href="#stack">The Stack</a></li>
+                        <li><a href="#upstream">Upstream</a></li>
+                        <li><a href="#equipment">Equipment &amp; Fabs</a></li>
+                        <li><a href="#design">Design (EDA)</a></li>
+                        <li><a href="#tiers">What we're watching</a></li>
+                        <li><a href="#methodology">Methodology</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- [01] THE STACK -->
+            <section class="sem-scene" id="stack">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[01]</span> The Stack</div>
+                    <h2 class="sem-scene-h2">How a chip <em>actually</em> gets made.</h2>
+                    <p class="sem-lede">It starts as sand and ends as a die packaged with billions of transistors. There are six physical steps and one parallel software pipeline. Each step has one or two dominant incumbents. Each is being challenged.</p>
+
+                    <div class="sem-diagram-wrap">
+                        <svg viewBox="0 0 1080 720" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Semiconductor stack diagram showing six physical layers plus EDA design column, with incumbents and challengers in each layer">
+                            <defs>
+                                <linearGradient id="sem-lg-incumbent" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#1e3a8a"/>
+                                    <stop offset="100%" stop-color="#162456"/>
+                                </linearGradient>
+                                <linearGradient id="sem-lg-chal" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#f97316"/>
+                                    <stop offset="100%" stop-color="#c2410c"/>
+                                </linearGradient>
+                                <linearGradient id="sem-lg-star" x1="0" y1="0" x2="0" y2="1">
+                                    <stop offset="0%" stop-color="#fb923c"/>
+                                    <stop offset="100%" stop-color="#ea580c"/>
+                                </linearGradient>
+                            </defs>
+
+                            <!-- column headers -->
+                            <text x="160" y="38" fill="#475569" font-family="JetBrains Mono" font-size="11" letter-spacing="2">INCUMBENTS</text>
+                            <text x="540" y="38" fill="#f97316" font-family="JetBrains Mono" font-size="11" letter-spacing="2">CHALLENGERS</text>
+                            <text x="900" y="38" fill="#1e3a8a" font-family="JetBrains Mono" font-size="11" letter-spacing="2">DESIGN (EDA)</text>
+
+                            <!-- flow arrow -->
+                            <line x1="22" y1="670" x2="22" y2="80" stroke="#15803d" stroke-width="2"/>
+                            <polygon points="18,86 22,72 26,86" fill="#15803d"/>
+                            <text x="36" y="370" fill="#15803d" font-family="JetBrains Mono" font-size="9" letter-spacing="2" transform="rotate(-90 36 370)">MANUFACTURING FLOW</text>
+
+                            <!-- LAYER 1: Raw Materials -->
+                            <g>
+                                <rect x="60" y="620" width="780" height="60" rx="4" fill="#fef3c7" stroke="#d97706" stroke-opacity=".35"/>
+                                <text x="80" y="643" fill="#92400e" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">1. RAW MATERIALS</text>
+                                <text x="80" y="662" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">sand → ultra-pure silicon</text>
+
+                                <rect x="270" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="320" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Wacker</text>
+
+                                <rect x="382" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="432" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Hemlock</text>
+
+                                <line x1="510" y1="628" x2="510" y2="672" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="630" width="220" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="640" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Highland Materials</text>
+                            </g>
+
+                            <!-- LAYER 2: Wafers -->
+                            <g>
+                                <rect x="60" y="540" width="780" height="60" rx="4" fill="#f3e8ff" stroke="#a855f7" stroke-opacity=".35"/>
+                                <text x="80" y="563" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">2. WAFERS</text>
+                                <text x="80" y="582" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">silicon, GaN, diamond substrates</text>
+
+                                <rect x="270" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="320" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Shin-Etsu</text>
+
+                                <rect x="382" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="432" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SUMCO</text>
+
+                                <line x1="510" y1="548" x2="510" y2="592" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Vertical Semi</text>
+
+                                <rect x="645" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Diamond Foundry</text>
+                            </g>
+
+                            <!-- LAYER 3: Lithography -->
+                            <g>
+                                <rect x="60" y="460" width="780" height="60" rx="4" fill="#ede9fe" stroke="#7c3aed" stroke-opacity=".35"/>
+                                <text x="80" y="483" fill="#5b21b6" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">3. LITHOGRAPHY</text>
+                                <text x="80" y="502" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">EUV — the real bottleneck</text>
+
+                                <rect x="270" y="470" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <text x="376" y="495" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">ASML</text>
+
+                                <line x1="510" y1="468" x2="510" y2="512" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="564" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Substrate</text>
+
+                                <rect x="608" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="642" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">xLight</text>
+
+                                <rect x="686" y="470" width="64" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="718" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Canon NIL</text>
+                            </g>
+
+                            <!-- LAYER 4: Deposition & Etch -->
+                            <g>
+                                <rect x="60" y="380" width="780" height="60" rx="4" fill="#ccfbf1" stroke="#0d9488" stroke-opacity=".35"/>
+                                <text x="80" y="403" fill="#115e59" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">4. DEPOSITION &amp; ETCH</text>
+                                <text x="80" y="422" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">doping, layers, interconnects</text>
+
+                                <rect x="270" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="303" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AMAT</text>
+
+                                <rect x="344" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="377" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lam</text>
+
+                                <rect x="418" y="390" width="64" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="450" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">TEL</text>
+
+                                <line x1="510" y1="388" x2="510" y2="432" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AlixLabs</text>
+
+                                <rect x="645" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic Semi</text>
+                            </g>
+
+                            <!-- LAYER 5: Inspection -->
+                            <g>
+                                <rect x="60" y="300" width="780" height="60" rx="4" fill="#f3e8ff" stroke="#a855f7" stroke-opacity=".35"/>
+                                <text x="80" y="323" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">5. INSPECTION &amp; TEST</text>
+                                <text x="80" y="342" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">defect detection at every step</text>
+
+                                <rect x="270" y="310" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2"/>
+                                <text x="376" y="335" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">KLA</text>
+
+                                <line x1="510" y1="308" x2="510" y2="352" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Nearfield</text>
+
+                                <rect x="645" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SixSense</text>
+                            </g>
+
+                            <!-- LAYER 6: Fab / Tape Out -->
+                            <g>
+                                <rect x="60" y="220" width="780" height="60" rx="4" fill="#dcfce7" stroke="#16a34a" stroke-opacity=".35"/>
+                                <text x="80" y="243" fill="#14532d" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">6. FAB / TAPE OUT</text>
+                                <text x="80" y="262" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">manufacturing at scale</text>
+
+                                <rect x="270" y="230" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <text x="303" y="255" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="14" font-weight="600" text-anchor="middle">TSMC</text>
+
+                                <rect x="344" y="230" width="74" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="381" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Samsung</text>
+
+                                <rect x="426" y="230" width="56" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="454" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Intel</text>
+
+                                <line x1="510" y1="228" x2="510" y2="272" stroke="#94a3b8" stroke-dasharray="3 3"/>
+
+                                <rect x="530" y="230" width="68" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="564" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic</text>
+
+                                <text x="650" y="245" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">no startup credibly</text>
+                                <text x="650" y="257" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">challenges TSMC</text>
+                                <text x="650" y="269" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">at leading-edge</text>
+                            </g>
+
+                            <!-- ADJACENT: Novel Compute Substrates -->
+                            <g>
+                                <rect x="60" y="130" width="780" height="60" rx="4" fill="#f1f5f9" stroke="#64748b" stroke-opacity=".5" stroke-dasharray="4 3"/>
+                                <text x="80" y="152" fill="#475569" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">× ADJACENT</text>
+                                <text x="80" y="170" fill="#64748b" font-family="Aeonik Regular, system-ui" font-size="10">novel compute substrates</text>
+                                <text x="80" y="184" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">chip cos, not picks-and-shovels</text>
+
+                                <rect x="270" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="325" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">PsiQuantum</text>
+
+                                <rect x="388" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="443" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lightmatter</text>
+
+                                <rect x="506" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="561" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Ayar Labs</text>
+
+                                <rect x="624" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="679" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Snowcap</text>
+                            </g>
+
+                            <!-- EDA Column on the right -->
+                            <g>
+                                <rect x="860" y="60" width="210" height="620" rx="6" fill="#eff6ff" stroke="#1e3a8a" stroke-opacity=".5"/>
+                                <text x="880" y="86" fill="#1e3a8a" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">DESIGN (EDA)</text>
+                                <text x="880" y="104" fill="#64748b" font-family="Aeonik Regular, system-ui" font-size="11">the blueprint pipeline</text>
+
+                                <rect x="880" y="120" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="138" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">RTL &amp; Synthesis</text>
+                                <text x="965" y="151" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ Ricursive, Cognichip</text>
+
+                                <rect x="880" y="172" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="190" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Verification</text>
+                                <text x="965" y="203" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ ChipAgents, ChipStack*</text>
+
+                                <rect x="880" y="224" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="242" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Place &amp; Route</text>
+                                <text x="965" y="255" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ Ricursive (AlphaChip)</text>
+
+                                <rect x="880" y="276" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="294" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Signoff (DRC/LVS)</text>
+                                <text x="965" y="307" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ Silimate</text>
+
+                                <rect x="880" y="328" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="346" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Analog &amp; PCB</text>
+                                <text x="965" y="359" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ Quilter, Astrus, Diode</text>
+
+                                <rect x="880" y="380" width="170" height="36" rx="4" fill="#dbeafe" stroke="#1e3a8a"/>
+                                <text x="965" y="398" fill="#1e3a8a" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">IP Cores</text>
+                                <text x="965" y="411" fill="#c2410c" font-family="JetBrains Mono" font-size="9" text-anchor="middle">+ Tenstorrent, SiFive</text>
+
+                                <text x="880" y="442" fill="#94a3b8" font-family="JetBrains Mono" font-size="9">* acquired by Cadence Nov 2025</text>
+
+                                <!-- Arrow from EDA to Fab layer -->
+                                <line x1="855" y1="250" x2="755" y2="250" stroke="#1e3a8a" stroke-width="1.5"/>
+                                <polygon points="760,246 750,250 760,254" fill="#1e3a8a"/>
+                                <text x="780" y="244" fill="#1e3a8a" font-family="JetBrains Mono" font-size="9" text-anchor="middle">GDSII</text>
+                            </g>
+                        </svg>
+                        <div class="sem-diagram-legend">
+                            <span><span class="swatch" style="background:#1e3a8a"></span>Incumbents</span>
+                            <span><span class="swatch" style="background:#f97316"></span>Challengers</span>
+                            <span><span class="swatch" style="background:#dbeafe;border:1px solid #1e3a8a"></span>Design (EDA)</span>
+                            <span><span class="swatch" style="background:#e2e8f0;border:1px dashed #64748b"></span>Adjacent</span>
+                        </div>
+                    </div>
+
+                    <div class="sem-pov">
+                        <span class="sem-pov-label">Canonical POV</span>
+                        <p>Two layers drive everything. <strong>ASML</strong> in lithography. <strong>TSMC</strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- [02] UPSTREAM -->
+            <section class="sem-scene" id="upstream">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[02]</span> Upstream</div>
+                    <h2 class="sem-scene-h2">Materials, wafers, and the <em>real</em> chokepoint.</h2>
+                    <p class="sem-lede">Three upstream layers. Two are quietly competitive duopolies. The third is ASML &mdash; a single Dutch company every fab on earth depends on. Two well-funded startups are now trying to do something about it.</p>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Raw Materials</h3>
+                            <span class="sem-layer-tag">L1 &middot; sand → polysilicon</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Wacker Chemie</span>
+                                    <span class="sem-pill">Hemlock Semiconductor</span>
+                                </div>
+                                <p>Quartz sand gets purified into 99.9999999% pure polysilicon, then grown into single-crystal ingots. Two companies dominate, mostly because nobody else wants to operate billion-dollar chemical plants that need decade-long contracts to amortize.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Highland Materials</span>
+                                </div>
+                                <p><strong>Highland Materials</strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Wafers</h3>
+                            <span class="sem-layer-tag">L2 &middot; silicon, GaN, diamond</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Shin-Etsu</span>
+                                    <span class="sem-pill">SUMCO</span>
+                                    <span class="sem-pill">Wolfspeed (SiC)</span>
+                                </div>
+                                <p>Two Japanese companies make the silicon discs every chip is etched onto. For specialty wafers (SiC, GaN, diamond), the field opens up.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Vertical Semiconductor</span>
+                                    <span class="sem-pill"><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></span>
+                                    <span class="sem-pill">Orbray</span>
+                                    <span class="sem-pill">Innoscience</span>
+                                </div>
+                                <p><strong>Vertical Semiconductor</strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
+                                <p><strong><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Lithography</h3>
+                            <span class="sem-layer-tag">L3 &middot; EUV — the bottleneck</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbent</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star"><a href="https://www.asml.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ASML (only EUV maker)</a></span>
+                                </div>
+                                <p><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a> makes the only machines on earth capable of printing features small enough for modern chips. A single High-NA EUV machine costs $380M. Every advanced fab buys from them. There is no second source.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star">Substrate</span>
+                                    <span class="sem-pill star"><a href="https://xlight.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
+                                    <span class="sem-pill">Canon NIL</span>
+                                    <span class="sem-pill">Inversion Semi</span>
+                                </div>
+                                <p><strong>Substrate</strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
+                                <p><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
+                                <p><strong>Canon NIL</strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-pov">
+                        <span class="sem-pov-label">Canonical POV</span>
+                        <p>ASML is the highest-stakes target on the entire stack and the lowest-probability one to crack. The physics work in three or four credible directions (X-ray, FEL-EUV, nanoimprint, maskless e-beam), but the gap between a working demo and a production tool is measured in decades and tens of billions of dollars. The right exposure is one or two positions sized as moonshots, underwritten the way you'd underwrite fusion. <strong>xLight is the lower-risk version of this bet</strong>; Substrate is the higher-variance one.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- [03] EQUIPMENT & FABS -->
+            <section class="sem-scene" id="equipment">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[03]</span> Equipment &amp; Fabs</div>
+                    <h2 class="sem-scene-h2">The tools, the inspectors, and the place where it all <em>happens</em>.</h2>
+                    <p class="sem-lede">Below ASML in the stack are the equipment makers that handle every other physical step &mdash; deposition, etch, inspection &mdash; and above them are the foundries that put it all together. Most equipment vendors compete in three-horse races. The fabs are a near-monopoly held by TSMC.</p>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Deposition &amp; Etch</h3>
+                            <span class="sem-layer-tag">L4 &middot; doping, layers, interconnects</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Applied Materials</span>
+                                    <span class="sem-pill">Lam Research</span>
+                                    <span class="sem-pill">Tokyo Electron</span>
+                                </div>
+                                <p>Three companies make 80% of the tools that lay down metal layers, etch patterns, and dope silicon. Healthy three-way competition keeps prices roughly honest.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">AlixLabs</span>
+                                    <span class="sem-pill"><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                </div>
+                                <p><strong>AlixLabs</strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
+                                <p><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Inspection &amp; Test</h3>
+                            <span class="sem-layer-tag">L5 &middot; defect detection</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbent</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star">KLA</span>
+                                </div>
+                                <p>KLA owns wafer inspection. Lasertec owns EUV mask inspection. Both are near-monopolies in their slices.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Nearfield Instruments</span>
+                                    <span class="sem-pill">SixSense</span>
+                                    <span class="sem-pill">EuQlid</span>
+                                </div>
+                                <p><strong>Nearfield Instruments</strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
+                                <p><strong>SixSense</strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
+                                <p><strong>EuQlid</strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Fab / Tape Out</h3>
+                            <span class="sem-layer-tag">L6 &middot; manufacturing at scale</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star"><a href="https://www.tsmc.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
+                                    <span class="sem-pill">Samsung</span>
+                                    <span class="sem-pill">Intel</span>
+                                </div>
+                                <p><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a> manufactures everything at the leading edge. Samsung is a credible second on certain nodes. Intel is rebuilding. If TSMC stops, the AI industry stops.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill"><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                </div>
+                                <p><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; small-fab-as-a-service. The bet is that the future has many smaller specialized fabs, not three giant ones. Currently the only startup credibly working on the fab problem, and only at sub-300mm scale.</p>
+                                <div class="sem-layer-note">No startup is credibly challenging TSMC at leading-edge nodes. The fab layer remains the most monopolized and the most capital-intensive in the stack.</div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- ADJACENT: Novel Compute Substrates -->
+                    <div class="sem-adjacent">
+                        <div class="sem-adjacent-marker"><span class="num">×</span><span>Adjacent — not picks-and-shovels</span></div>
+                        <h3>Novel compute substrates sit <em>alongside</em> the fab layer, not inside it.</h3>
+                        <p>These four are chip companies, not foundry challengers. They design photonic, quantum-photonic, optical-I/O, or superconducting chips and have them manufactured by GlobalFoundries, TSMC, or others. They belong on the map because anyone studying silicon will ask where they fit &mdash; but they're customers of the fab layer, not competitors to it. (Cross-listed on the <a href="https://canonical.cc/labs/physical-ai/">Physical AI Capital Flow Map</a> under the broader compute thesis.)</p>
+
+                        <div class="sem-adjacent-grid">
+                            <div class="sem-adjacent-cell">
+                                <span class="sem-pill"><a href="https://psiquantum.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">PsiQuantum</a></span>
+                                <p><strong><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; photonic quantum chips manufactured at GlobalFoundries Fab 8 (Malta, NY). $1B Series E at $7B (Sep 2025). Customer of the fab layer.</p>
+                            </div>
+                            <div class="sem-adjacent-cell">
+                                <span class="sem-pill"><a href="https://lightmatter.co" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lightmatter</a></span>
+                                <p><strong><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> &mdash; photonic compute (Envise) and 3D photonic interposer (Passage L200, 200+ Tbps). ~$822M raised, $4.4B valuation. Fabless. Manufacturing at GlobalFoundries.</p>
+                            </div>
+                            <div class="sem-adjacent-cell">
+                                <span class="sem-pill"><a href="https://ayarlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ayar Labs</a></span>
+                                <p><strong><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
+                            </div>
+                            <div class="sem-adjacent-cell">
+                                <span class="sem-pill">Snowcap Compute</span>
+                                <p><strong>Snowcap Compute</strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-pov">
+                        <span class="sem-pov-label">Canonical POV</span>
+                        <p>The fab layer is structurally the hardest to disrupt and the most capital-intensive to attempt. We don't expect a credible TSMC challenger to emerge at the leading edge in the next decade &mdash; Atomic Semi at sub-300mm scale is as close as it gets, and that's a different market.</p>
+                        <p>The more investable thesis sits one layer up: <strong>Lightmatter</strong> and <strong>Ayar Labs</strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- [04] DESIGN (EDA) -->
+            <section class="sem-scene" id="design">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[04]</span> Design (EDA)</div>
+                    <h2 class="sem-scene-h2">The most fundable layer is <em>software</em>.</h2>
+                    <p class="sem-lede">Before any chip gets manufactured, it gets designed in software. Three companies &mdash; Synopsys, Cadence, Siemens &mdash; hold ~75% of that market. Their tools are 30 years old and run on Linux machines that smell faintly of the 1990s. This is the layer where AI is most likely to draw blood, and where 2026 funding has been most aggressive.</p>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Foundation-model AI for chip design</h3>
+                            <span class="sem-layer-tag">RTL &middot; Synthesis &middot; Place &amp; Route</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Synopsys</span>
+                                    <span class="sem-pill">Cadence</span>
+                                    <span class="sem-pill">Siemens EDA</span>
+                                </div>
+                                <p>The Big Three. ~75% market share. All three have launched in-house AI products (Synopsys.ai, Cadence Cerebrus, Calibre.AI) but their architecture is bolt-on, not native.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star">Ricursive Intelligence</span>
+                                    <span class="sem-pill star"><a href="https://cognichip.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
+                                </div>
+                                <p><strong>Ricursive Intelligence</strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
+                                <p><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Agentic verification</h3>
+                            <span class="sem-layer-tag">verification &middot; simulation &middot; formal</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Synopsys VCS</span>
+                                    <span class="sem-pill">Cadence Xcelium</span>
+                                    <span class="sem-pill">Siemens Questa</span>
+                                </div>
+                                <p>Verification is the most expensive and time-consuming part of chip design. Often 70% of total engineering hours. Ripe for automation.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star"><a href="https://chipagents.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
+                                    <span class="sem-pill">ChipStack (acq.)</span>
+                                    <span class="sem-pill">Silimate</span>
+                                </div>
+                                <p><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
+                                <p><strong>ChipStack</strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-layer">
+                        <div class="sem-layer-head">
+                            <h3>Analog, PCB &amp; IP Cores</h3>
+                            <span class="sem-layer-tag">layout &middot; routing &middot; cores</span>
+                        </div>
+                        <div class="sem-layer-body">
+                            <div class="sem-layer-col incumbent">
+                                <h4>Incumbents</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill">Cadence Virtuoso</span>
+                                    <span class="sem-pill">Arm</span>
+                                    <span class="sem-pill">Synopsys IP</span>
+                                </div>
+                                <p>Virtuoso has owned analog layout for 30 years with effectively no competition. Arm has owned mobile cores for nearly as long.</p>
+                            </div>
+                            <div class="sem-layer-col challenger">
+                                <h4>Challengers</h4>
+                                <div class="sem-pill-row">
+                                    <span class="sem-pill star"><a href="https://www.quilter.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
+                                    <span class="sem-pill">Astrus</span>
+                                    <span class="sem-pill">Diode</span>
+                                    <span class="sem-pill star"><a href="https://tenstorrent.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
+                                    <span class="sem-pill"><a href="https://sifive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
+                                </div>
+                                <p><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
+                                <p><strong>Astrus</strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
+                                <p><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="sem-pov">
+                        <span class="sem-pov-label">Canonical POV</span>
+                        <p>This is the most fundable layer of the entire stack, and also the layer where the consolidation clock is loudest. Cadence acquiring ChipStack at ~20 people validates the thesis and tells you the next dozen single-feature AI-verification copilots are exit targets, not platforms. The remaining standalone bets need to be platform-scale (Ricursive, Cognichip) or category-defining in a category the Big Three don't yet own (Quilter for PCB, Tenstorrent for IP).</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- [05] TIERS -->
+            <section class="sem-scene" id="tiers">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[05]</span> What we're watching</div>
+                    <h2 class="sem-scene-h2">The names <em>worth</em> tracking, sorted by conviction.</h2>
+                    <p class="sem-lede">Three tiers. The first is the highest-conviction picks-and-shovels positions, sized like normal venture bets. The second is capital-heavy moonshots that need staged diligence. The third is the watch list.</p>
+
+                    <div class="sem-tiers">
+                        <div class="sem-tier">
+                            <span class="sem-tier-num">Tier 1 &middot; High conviction</span>
+                            <h4>Software speed of light</h4>
+                            <ul>
+                                <li><strong>Ricursive Intelligence</strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
+                                <li><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
+                                <li><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
+                                <li><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
+                            </ul>
+                        </div>
+
+                        <div class="sem-tier">
+                            <span class="sem-tier-num">Tier 2 &middot; Capital-heavy moonshots</span>
+                            <h4>Underwrite like deep tech</h4>
+                            <ul>
+                                <li><strong>Substrate</strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
+                                <li><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
+                                <li><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
+                                <li><strong>Vertical Semi</strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
+                            </ul>
+                        </div>
+
+                        <div class="sem-tier">
+                            <span class="sem-tier-num">Tier 3 &middot; Watch list</span>
+                            <h4>Earlier, narrower, or both</h4>
+                            <ul>
+                                <li><strong>Astrus</strong> &mdash; analog layout RL.</li>
+                                <li><strong>Diode Computers</strong> &mdash; PCB-as-code.</li>
+                                <li><strong>Nearfield Instruments</strong> &mdash; late-stage metrology.</li>
+                                <li><strong>Snowcap Compute</strong> &mdash; superconducting compute.</li>
+                                <li><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
+                                <li><strong><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div class="sem-benchmarks">
+                        <h4>Benchmarks that would change the thesis</h4>
+                        <ul>
+                            <li>Synopsys or Siemens acquires <strong>ChipAgents</strong>, <strong>Silimate</strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
+                            <li>First full-stack chip tape-out designed end-to-end by <strong>Ricursive</strong> or <strong>Cognichip</strong> → re-rates the entire AI-EDA category upward.</li>
+                            <li><strong>Substrate</strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
+                            <li><strong>xLight</strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
+                            <li><strong>Atomic Semi</strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
+                        </ul>
+                    </div>
+
+                    <div class="sem-crosslink">
+                        <strong>Related</strong>
+                        See where these silicon bets sit in the broader picks-and-shovels thesis on the <a href="https://canonical.cc/labs/physical-ai/">Physical AI Capital Flow Map</a> &middot; tools for early-stage diligence in <a href="https://canonical.cc/labs/dilutionlab/">Dilution Lab</a>, <a href="https://canonical.cc/labs/fundmodeler/">Fund Modeler</a>, and <a href="https://canonical.cc/labs/power-law/">Power Law Lab</a>.
+                    </div>
+                </div>
+            </section>
+
+            <!-- [06] METHODOLOGY -->
+            <section class="sem-method-section" id="methodology">
+                <div class="container mx-auto px-8">
+                    <div class="sem-section-label"><span class="sem-section-num">[06]</span> Methodology</div>
+                    <h2 class="sem-scene-h2">How this <em>was built</em>, and where the data is weakest.</h2>
+
+                    <div class="sem-method-grid">
+                        <div class="sem-method-col">
+                            <h3>Sources &amp; approach</h3>
+                            <ul class="sem-method-list">
+                                <li><span class="sem-method-k">Sources</span><span class="sem-method-v">Primary company filings and press releases, Crunchbase, PitchBook Premium, Sequoia podcast appearances, EE Times, Business Wire, Tom's Hardware, Semiconductor Engineering, NIST and Department of Commerce announcements, founder X posts.</span></li>
+                                <li><span class="sem-method-k">Window</span><span class="sem-method-v">2023 through Q2 2026. Funding rounds are version-stamped at last public close.</span></li>
+                                <li><span class="sem-method-k">Coverage</span><span class="sem-method-v">Seven stack layers (six physical + EDA software). 40+ challenger companies surfaced. Not exhaustive &mdash; stealth companies are by definition absent.</span></li>
+                                <li><span class="sem-method-k">Refresh</span><span class="sem-method-v">Quarterly with running corrections. <a href="https://canonicalcc.substack.com">Subscribe</a> for the next update.</span></li>
+                            </ul>
+                        </div>
+                        <div class="sem-method-col">
+                            <h3>Known caveats</h3>
+                            <ul class="sem-method-list">
+                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong>Ricursive Intelligence</strong>, not "Recursive." The lithography company is <strong>Substrate</strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
+                                <li><span class="sem-method-k">Substrate</span><span class="sem-method-v">Technical claims (12nm contact arrays, $10K-per-wafer) come from the company itself. Independent analysts (Fox Chapel Research, summarized in Tom's Hardware) have publicly questioned founder pedigree and the credibility of the demonstrations. Treat accordingly.</span></li>
+                                <li><span class="sem-method-k">Atomic Semi</span><span class="sem-method-v">Valuation ($100M) and seed size (~$15M) come from a January 2023 TechCrunch report citing unnamed sources. The 60-engineer team count is current as of Nov 2025 (Berkeley BWRC). A follow-on round has likely closed but is not public.</span></li>
+                                <li><span class="sem-method-k">Tenstorrent</span><span class="sem-method-v">The reported $3.2B pre-money Fidelity round comes from The Information citing two people with knowledge of the talks. Confirm terms directly before underwriting.</span></li>
+                                <li><span class="sem-method-k">AI claims</span><span class="sem-method-v">"Designless," "recursive self-improvement," and "AI-native" are forward-looking marketing across the EDA-disruptor cohort. Real demonstrations to date are narrow proofs of concept, not full-SoC frontier-node tape-outs. Spot one missing? <a href="mailto:hello@canonical.cc?subject=Semiconductor%20Stack%20-%20coverage%20gap">Tell us.</a></span></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- [07] CTA -->
+            <section class="sem-cta">
+                <div class="container mx-auto px-8">
+                    <div class="sem-cta-grid">
+                        <div>
+                            <div class="sem-section-label sem-section-label-light"><span class="sem-section-num">[07]</span> Talk to Canonical</div>
+                            <h2 class="sem-cta-h2">If you're building or investing in the <em>picks-and-shovels</em> of silicon, we want to hear from you.</h2>
+                            <p class="sem-cta-p"><a href="https://canonical.cc/#about">Canonical</a> leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed, pre-product friendly. See our <a href="https://canonical.cc/portfolio">portfolio</a> and <a href="https://canonical.cc/#thesis">thesis</a>.</p>
+                        </div>
+                        <div class="sem-cta-actions">
+                            <a href="mailto:hello@canonical.cc?subject=Building%20in%20semiconductors" class="sem-btn"><span>I'm building &rarr; pitch us</span><span class="sem-btn-arrow">&rarr;</span></a>
+                            <a href="mailto:hello@canonical.cc?subject=LP%20-%20Canonical%20Fund%20II" class="sem-btn"><span>I'm an LP &rarr; let's talk Fund II</span><span class="sem-btn-arrow">&rarr;</span></a>
+                            <a href="https://canonical.cc/labs/physical-ai/" class="sem-btn"><span>See the Physical AI Capital Flow Map</span><span class="sem-btn-arrow">&rarr;</span></a>
+                            <a href="https://canonicalcc.substack.com" target="_blank" rel="noopener noreferrer" class="sem-btn"><span>Subscribe to quarterly updates</span><span class="sem-btn-arrow">&rarr;</span></a>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Footnote disclaimer -->
+            <div class="sem-disclaimer">
+                <div class="container mx-auto px-8">
+                    <p>Built by <a href="https://x.com/ai" target="_blank" rel="noopener noreferrer">Anand Iyer</a> at <a href="https://canonical.cc">Canonical</a> &middot; v0.1 &middot; Educational tool. Not investment advice. Data is point-in-time and not exhaustive.</p>
+                </div>
+            </div>
+        </main>
+
+        {% include footer.html %}
+    </div>
+</body>
+</html>

--- a/labs/semiconductor-silicon-stack/lab.css
+++ b/labs/semiconductor-silicon-stack/lab.css
@@ -1,0 +1,770 @@
+/* Semiconductor Stack Disruptors - lab-specific styles
+   Inherits /css/style.css (navy gradient body, fixed header, footer).
+   Adapts the editorial composition (numbered sections, stack diagram,
+   incumbent vs challenger layer panels, tiered conviction list) to the
+   canonical.cc system: navy gradient background, Aeonik display type,
+   white paper cards with slate ink, orange accents. */
+
+:root {
+    --sem-navy: #1e3a8a;
+    --sem-navy-deep: #162456;
+    --sem-accent: #f97316;        /* orange-500 */
+    --sem-accent-soft: #fdba74;
+    --sem-positive: #15803d;
+    --sem-on-navy-faint: rgba(255, 255, 255, 0.55);
+    --sem-on-navy-soft: rgba(255, 255, 255, 0.75);
+    --sem-on-navy-strong: rgba(255, 255, 255, 0.92);
+    --sem-card-bg: #ffffff;
+    --sem-card-bg-2: #fafafa;
+    --sem-ink: #0a0a0a;
+    --sem-ink-soft: #1f2937;
+    --sem-ink-muted: #475569;
+    --sem-ink-faint: #94a3b8;
+    --sem-rule: rgba(15, 23, 42, 0.08);
+    --sem-rule-strong: rgba(15, 23, 42, 0.16);
+    --sem-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ============ HERO ============ */
+.sem-hero {
+    padding: 8rem 0 3rem;
+    text-align: left;
+}
+
+.sem-hero-content {
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.sem-eyebrow {
+    display: inline-block;
+    font-family: var(--sem-mono);
+    font-size: 0.72rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    color: var(--sem-accent-soft);
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+}
+
+.sem-title {
+    font-size: clamp(2.5rem, 6.5vw, 5.2rem);
+    font-weight: 300;
+    line-height: 1.05;
+    letter-spacing: -0.025em;
+    color: #ffffff;
+    max-width: 22ch;
+    margin: 0 0 1.5rem;
+}
+.sem-title em {
+    font-style: normal;
+    color: var(--sem-accent-soft);
+    font-weight: 400;
+}
+
+.sem-subtitle {
+    font-size: clamp(1.05rem, 1.4vw, 1.25rem);
+    font-weight: 400;
+    line-height: 1.6;
+    color: var(--sem-on-navy-soft);
+    max-width: 64ch;
+    margin: 0 0 2.5rem;
+}
+.sem-subtitle a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-subtitle a:hover { color: #ffffff; }
+
+.sem-meta {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1.5rem 2.5rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.15);
+    max-width: 64rem;
+}
+.sem-meta-item { display: flex; flex-direction: column; gap: 0.25rem; }
+.sem-meta-key {
+    font-family: var(--sem-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
+    color: var(--sem-on-navy-faint);
+    text-transform: uppercase;
+}
+.sem-meta-val {
+    font-family: var(--sem-mono);
+    font-size: 0.78rem;
+    color: var(--sem-on-navy-strong);
+    line-height: 1.4;
+}
+
+/* ============ TL;DR STRIP ============ */
+.sem-tldr {
+    padding: 3.5rem 0;
+    background: rgba(255, 255, 255, 0.04);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    backdrop-filter: blur(4px);
+}
+.sem-tldr-intro {
+    font-family: var(--sem-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sem-on-navy-faint);
+    margin-bottom: 1.75rem;
+    text-align: center;
+}
+.sem-tldr-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 2.5rem;
+}
+.sem-tldr-item {
+    padding: 0.5rem 0.25rem;
+    border-radius: 0.4rem;
+    transition: transform 0.15s;
+}
+.sem-tldr-item:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.sem-stat {
+    font-size: 3rem;
+    font-weight: 300;
+    color: #ffffff;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    margin-bottom: 0.7rem;
+}
+.sem-stat em {
+    font-style: normal;
+    color: var(--sem-accent-soft);
+    font-weight: 400;
+}
+.sem-stat-unit {
+    font-size: 1.5rem;
+    color: var(--sem-on-navy-soft);
+    font-weight: 300;
+    margin-left: 0.1em;
+}
+
+.sem-tldr-label {
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--sem-on-navy-soft);
+}
+.sem-tldr-label strong { color: #ffffff; font-weight: 500; }
+
+/* ============ SUB-NAV ============ */
+.sem-subnav {
+    position: sticky;
+    top: 72px;
+    z-index: 40;
+    background: rgba(30, 58, 138, 0.85);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.65rem 0;
+}
+.sem-subnav-list {
+    list-style: none;
+    display: flex;
+    gap: 1.5rem;
+    margin: 0;
+    padding: 0;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+.sem-subnav-list::-webkit-scrollbar { display: none; }
+.sem-subnav-list li { flex: 0 0 auto; }
+.sem-subnav-list a {
+    display: inline-block;
+    font-family: var(--sem-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sem-on-navy-soft);
+    padding: 0.5rem 0.9rem;
+    border-radius: 999px;
+    transition: background 0.15s, color 0.15s;
+    text-decoration: none;
+    white-space: nowrap;
+}
+.sem-subnav-list a:hover { background: rgba(255, 255, 255, 0.08); color: #ffffff; }
+.sem-subnav-list a.active { background: rgba(255, 255, 255, 0.12); color: #ffffff; }
+
+/* ============ SCENE BASE ============ */
+.sem-scene {
+    padding: 5rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    scroll-margin-top: 130px;
+}
+#stack, #upstream, #equipment, #design, #tiers, #methodology { scroll-margin-top: 130px; }
+
+.sem-section-label {
+    font-family: var(--sem-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    color: var(--sem-accent-soft);
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 1.25rem;
+}
+.sem-section-num { color: var(--sem-on-navy-faint); margin-right: 0.4rem; }
+
+.sem-scene-h2 {
+    font-size: clamp(1.85rem, 3.4vw, 2.85rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 300;
+    color: #ffffff;
+    margin: 0 0 1.4rem;
+    max-width: 30ch;
+}
+.sem-scene-h2 em {
+    font-style: normal;
+    color: var(--sem-accent-soft);
+    font-weight: 400;
+}
+
+.sem-lede {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    color: var(--sem-on-navy-soft);
+    margin: 0 0 1.5rem;
+    max-width: 72ch;
+}
+.sem-lede a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-lede a:hover { color: #ffffff; }
+
+/* ============ DIAGRAM CARD ============ */
+.sem-diagram-wrap {
+    margin-top: 2.5rem;
+    padding: 2rem;
+    background: var(--sem-card-bg);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.1);
+    overflow-x: auto;
+}
+.sem-diagram-wrap svg {
+    display: block;
+    margin: 0 auto;
+    width: 100%;
+    max-width: 1080px;
+    height: auto;
+}
+.sem-diagram-legend {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    margin-top: 1.5rem;
+    flex-wrap: wrap;
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-ink-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+.sem-diagram-legend .swatch {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    vertical-align: middle;
+    margin-right: 0.4rem;
+}
+
+/* ============ POV BLOCK (on navy) ============ */
+.sem-pov {
+    margin: 2rem 0 0;
+    padding: 1.5rem 1.6rem;
+    border-left: 3px solid var(--sem-accent);
+    background: linear-gradient(90deg, rgba(249, 115, 22, 0.06), transparent 80%);
+    border-radius: 0 0.5rem 0.5rem 0;
+}
+.sem-pov-label {
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    margin-bottom: 0.7rem;
+    display: block;
+    font-weight: 500;
+}
+.sem-pov p {
+    color: var(--sem-on-navy-strong);
+    font-size: 0.98rem;
+    line-height: 1.6;
+    margin: 0;
+}
+.sem-pov p + p { margin-top: 0.65rem; }
+.sem-pov p strong { color: #ffffff; font-weight: 600; }
+.sem-pov a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-pov a:hover { color: #ffffff; }
+
+/* ============ LAYER PANELS (incumbent vs challenger) ============ */
+.sem-layer {
+    margin-top: 2rem;
+    padding: 1.75rem;
+    background: var(--sem-card-bg);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.1);
+    color: var(--sem-ink);
+    transition: transform 0.18s, box-shadow 0.18s;
+}
+.sem-layer:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px -12px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+.sem-layer-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1.25rem;
+    margin-bottom: 1.1rem;
+    padding-bottom: 0.9rem;
+    border-bottom: 1px solid var(--sem-rule);
+}
+.sem-layer-head h3 {
+    font-size: 1.35rem;
+    font-weight: 500;
+    color: var(--sem-ink);
+    margin: 0;
+    letter-spacing: -0.01em;
+}
+.sem-layer-tag {
+    font-family: var(--sem-mono);
+    font-size: 0.68rem;
+    color: var(--sem-ink-faint);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+.sem-layer-body {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+.sem-layer-col h4 {
+    font-family: var(--sem-mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--sem-ink-faint);
+    margin: 0 0 0.85rem;
+    font-weight: 500;
+}
+.sem-layer-col.challenger h4 { color: var(--sem-accent); }
+.sem-layer-col p {
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--sem-ink-muted);
+    margin: 0 0 0.7rem;
+}
+.sem-layer-col p:last-child { margin-bottom: 0; }
+.sem-layer-col p strong { color: var(--sem-ink); font-weight: 600; }
+.sem-layer-col p a {
+    color: var(--sem-navy);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(30, 58, 138, 0.35);
+    transition: color 0.15s, text-decoration-color 0.15s;
+}
+.sem-layer-col p a:hover { color: var(--sem-accent); text-decoration-color: var(--sem-accent); }
+
+.sem-pill-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.9rem;
+}
+.sem-pill {
+    font-family: var(--sem-mono);
+    font-size: 0.72rem;
+    padding: 0.25rem 0.65rem;
+    border: 1px solid var(--sem-rule-strong);
+    border-radius: 999px;
+    color: var(--sem-ink-soft);
+    background: rgba(15, 23, 42, 0.02);
+    letter-spacing: 0.02em;
+}
+.sem-layer-col.challenger .sem-pill {
+    border-color: rgba(249, 115, 22, 0.4);
+    background: rgba(249, 115, 22, 0.06);
+    color: #b45309;
+}
+.sem-pill.star {
+    background: rgba(249, 115, 22, 0.18);
+    border-color: var(--sem-accent);
+    color: #9a3412;
+    font-weight: 600;
+}
+.sem-layer-col.incumbent .sem-pill.star {
+    background: rgba(30, 58, 138, 0.12);
+    border-color: var(--sem-navy);
+    color: var(--sem-navy);
+}
+
+.sem-layer-note {
+    margin-top: 0.9rem;
+    padding-top: 0.8rem;
+    border-top: 1px dashed var(--sem-rule);
+    font-size: 0.82rem;
+    color: var(--sem-ink-faint);
+    font-style: italic;
+    line-height: 1.5;
+}
+
+/* ============ ADJACENT BLOCK ============ */
+.sem-adjacent {
+    margin-top: 2rem;
+    padding: 1.75rem;
+    background: var(--sem-card-bg);
+    border: 1px dashed var(--sem-rule-strong);
+    border-radius: 0.75rem;
+    color: var(--sem-ink);
+    position: relative;
+}
+.sem-adjacent::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 1.75rem;
+    width: 60px;
+    height: 2px;
+    background: var(--sem-ink-faint);
+    border-radius: 0 0 4px 4px;
+}
+.sem-adjacent-marker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-family: var(--sem-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    color: var(--sem-ink-faint);
+    text-transform: uppercase;
+    margin-bottom: 0.9rem;
+}
+.sem-adjacent-marker .num { color: var(--sem-ink-muted); font-size: 0.9rem; }
+.sem-adjacent h3 {
+    font-size: 1.4rem;
+    font-weight: 500;
+    color: var(--sem-ink);
+    margin: 0 0 0.7rem;
+    letter-spacing: -0.01em;
+    line-height: 1.2;
+}
+.sem-adjacent h3 em { font-style: italic; color: var(--sem-ink-muted); font-weight: 400; }
+.sem-adjacent > p {
+    font-size: 0.92rem;
+    line-height: 1.55;
+    color: var(--sem-ink-muted);
+    margin-bottom: 1.25rem;
+    max-width: 76ch;
+}
+.sem-adjacent > p a { color: var(--sem-navy); text-decoration: underline; text-underline-offset: 2px; }
+.sem-adjacent-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.2rem;
+    margin-top: 0.5rem;
+}
+.sem-adjacent-cell {
+    padding: 1rem 1.1rem;
+    background: var(--sem-card-bg-2);
+    border-radius: 0.5rem;
+    border: 1px solid var(--sem-rule);
+}
+.sem-adjacent-cell .sem-pill {
+    border-color: var(--sem-rule-strong);
+    background: rgba(148, 163, 184, 0.1);
+    color: var(--sem-ink-soft);
+}
+.sem-adjacent-cell p {
+    font-size: 0.88rem;
+    line-height: 1.55;
+    color: var(--sem-ink-muted);
+    margin: 0.6rem 0 0;
+}
+.sem-adjacent-cell p strong { color: var(--sem-ink); font-weight: 600; }
+.sem-adjacent-cell p a { color: var(--sem-navy); text-decoration: underline; text-underline-offset: 2px; }
+
+/* ============ TIER GRID ============ */
+.sem-tiers {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.2rem;
+    margin-top: 2.5rem;
+}
+.sem-tier {
+    background: var(--sem-card-bg);
+    border-radius: 0.75rem;
+    padding: 1.6rem 1.5rem;
+    box-shadow: 0 10px 30px -10px rgba(0, 0, 0, 0.35), 0 2px 6px rgba(0, 0, 0, 0.1);
+    color: var(--sem-ink);
+    transition: transform 0.18s;
+}
+.sem-tier:hover { transform: translateY(-3px); }
+.sem-tier-num {
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-accent);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    display: block;
+    margin-bottom: 0.4rem;
+    font-weight: 500;
+}
+.sem-tier h4 {
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: var(--sem-ink);
+    margin: 0 0 1rem;
+    letter-spacing: -0.01em;
+}
+.sem-tier ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.sem-tier li {
+    font-size: 0.88rem;
+    color: var(--sem-ink-muted);
+    line-height: 1.5;
+    padding: 0.55rem 0;
+    border-bottom: 1px dashed var(--sem-rule);
+}
+.sem-tier li:last-child { border-bottom: none; }
+.sem-tier li strong { color: var(--sem-ink); font-weight: 600; }
+.sem-tier li a {
+    color: var(--sem-navy);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    text-decoration-color: rgba(30, 58, 138, 0.35);
+}
+.sem-tier li a:hover { color: var(--sem-accent); text-decoration-color: var(--sem-accent); }
+
+/* ============ BENCHMARKS ============ */
+.sem-benchmarks {
+    margin-top: 2rem;
+    padding: 1.6rem 1.75rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px dashed rgba(255, 255, 255, 0.18);
+    border-radius: 0.75rem;
+}
+.sem-benchmarks h4 {
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-accent-soft);
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    margin: 0 0 1rem;
+    font-weight: 500;
+}
+.sem-benchmarks ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.sem-benchmarks li {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    font-size: 0.92rem;
+    color: var(--sem-on-navy-soft);
+    line-height: 1.55;
+    position: relative;
+    padding-left: 1.4rem;
+}
+.sem-benchmarks li:last-child { border-bottom: none; }
+.sem-benchmarks li::before {
+    content: "→";
+    position: absolute;
+    left: 0;
+    color: var(--sem-accent);
+    font-family: var(--sem-mono);
+}
+.sem-benchmarks li strong { color: #ffffff; font-weight: 500; }
+.sem-benchmarks li a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-benchmarks li a:hover { color: #ffffff; }
+
+/* ============ METHODOLOGY ============ */
+.sem-method-section { padding: 5rem 0; }
+.sem-method-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    margin-top: 2rem;
+}
+.sem-method-col h3 {
+    font-size: 1.3rem;
+    font-weight: 500;
+    color: #ffffff;
+    margin: 0 0 1rem;
+    letter-spacing: -0.01em;
+}
+.sem-method-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+.sem-method-list li {
+    padding: 0.85rem 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    display: flex;
+    gap: 1.2rem;
+}
+.sem-method-list li:first-child { border-top: none; }
+.sem-method-k {
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-on-navy-faint);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    min-width: 8rem;
+    padding-top: 0.2rem;
+    flex-shrink: 0;
+}
+.sem-method-v {
+    color: var(--sem-on-navy-soft);
+    font-size: 0.92rem;
+    line-height: 1.55;
+}
+.sem-method-v a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-method-v a:hover { color: #ffffff; }
+.sem-method-v strong { color: #ffffff; font-weight: 500; }
+
+/* ============ CTA ============ */
+.sem-cta {
+    padding: 4.5rem 0;
+    background: rgba(0, 0, 0, 0.18);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+.sem-cta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4rem;
+    align-items: center;
+}
+.sem-section-label-light { color: rgba(255, 255, 255, 0.55) !important; }
+.sem-section-label-light .sem-section-num { color: rgba(255, 255, 255, 0.3); }
+.sem-cta-h2 {
+    font-size: clamp(1.8rem, 3vw, 2.6rem);
+    line-height: 1.1;
+    letter-spacing: -0.02em;
+    font-weight: 300;
+    color: #ffffff;
+    margin: 0 0 1.25rem;
+}
+.sem-cta-h2 em { font-style: normal; color: var(--sem-accent-soft); font-weight: 400; }
+.sem-cta-p {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--sem-on-navy-soft);
+    margin: 0;
+}
+.sem-cta-p a { color: var(--sem-accent-soft); text-decoration: underline; text-underline-offset: 3px; }
+.sem-cta-p a:hover { color: #ffffff; }
+.sem-cta-actions { display: flex; flex-direction: column; gap: 0.7rem; }
+.sem-btn {
+    display: inline-flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1.05rem 1.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: #ffffff;
+    font-family: var(--sem-mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    transition: all 0.15s;
+    border-radius: 0.5rem;
+    text-decoration: none;
+    background: rgba(255, 255, 255, 0.02);
+}
+.sem-btn:hover {
+    background: #ffffff;
+    color: var(--sem-navy);
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+.sem-btn-arrow {
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 1.15rem;
+    transition: transform 0.2s;
+}
+.sem-btn:hover .sem-btn-arrow { transform: translateX(4px); }
+
+/* ============ CROSS-LAB LINK STRIP ============ */
+.sem-crosslink {
+    margin-top: 1.5rem;
+    padding: 0.9rem 1.25rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0.5rem;
+    font-family: var(--sem-mono);
+    font-size: 0.78rem;
+    color: var(--sem-on-navy-soft);
+    line-height: 1.5;
+}
+.sem-crosslink strong {
+    color: var(--sem-accent-soft);
+    font-weight: 500;
+    margin-right: 0.4rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.68rem;
+}
+.sem-crosslink a {
+    color: #ffffff;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-color: rgba(255, 255, 255, 0.4);
+}
+.sem-crosslink a:hover { color: var(--sem-accent-soft); text-decoration-color: var(--sem-accent-soft); }
+
+/* ============ DISCLAIMER ============ */
+.sem-disclaimer { padding: 1.5rem 0 0.5rem; }
+.sem-disclaimer p {
+    font-family: var(--sem-mono);
+    font-size: 0.7rem;
+    color: var(--sem-on-navy-faint);
+    text-align: center;
+    margin: 0;
+    letter-spacing: 0.05em;
+}
+.sem-disclaimer a {
+    color: var(--sem-accent-soft);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+}
+.sem-disclaimer a:hover { color: #ffffff; }
+
+/* ============ RESPONSIVE ============ */
+@media (max-width: 960px) {
+    .sem-tldr-grid { grid-template-columns: repeat(2, 1fr); }
+    .sem-meta { grid-template-columns: repeat(2, 1fr); }
+    .sem-tiers { grid-template-columns: 1fr; }
+    .sem-method-grid, .sem-cta-grid { grid-template-columns: 1fr; gap: 2rem; }
+    .sem-scene, .sem-method-section { padding: 3.5rem 0; }
+    .sem-hero { padding: 6rem 0 2rem; }
+    .sem-layer-body { grid-template-columns: 1fr; gap: 1.4rem; }
+    .sem-adjacent-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+    .sem-tldr-grid { grid-template-columns: 1fr; gap: 1.5rem; }
+    .sem-meta { grid-template-columns: 1fr; gap: 1rem; }
+    .sem-stat { font-size: 2.4rem; }
+    .sem-subnav { top: 60px; }
+    .sem-layer { padding: 1.4rem; }
+    .sem-tier { padding: 1.25rem; }
+    .sem-diagram-wrap { padding: 1rem; }
+    .sem-layer-head { flex-direction: column; align-items: flex-start; gap: 0.4rem; }
+}
+
+#header.scrolled ~ main .sem-subnav { background: rgba(30, 58, 138, 0.95); }


### PR DESCRIPTION
## Summary

- New lab page mapping the seven-layer silicon stack (raw materials → wafers → litho → depo/etch → inspection → fab + parallel EDA pipeline), naming incumbents and 40+ credible challengers per layer
- Translates the strawman dark/amber design into the canonical.cc navy/orange aesthetic (Aeonik display, JetBrains Mono labels, white card panels with slate ink) — matches the [Physical AI Capital Flow Map](https://canonical.cc/labs/physical-ai/) treatment
- Adds the lab to the Labs dropdown (desktop + mobile) in `_includes/header.html`
- Backlinks throughout: cross-references to the Physical AI map and sibling labs, external links to named companies (ASML, TSMC, xLight, Atomic Semi, Cognichip, ChipAgents, Quilter, Tenstorrent, Lightmatter, Ayar Labs, etc.), and the standard portfolio/thesis/substack CTAs

## Files

- `labs/semiconductor-silicon-stack/index.html` — page with Jekyll frontmatter, six layer scenes + EDA scene + tiers + methodology + CTA
- `labs/semiconductor-silicon-stack/lab.css` — `sem-` prefixed styles inheriting `/css/style.css`
- `_includes/header.html` — new nav entry in both desktop dropdown and mobile menu

## Test plan

- [ ] `bundle exec jekyll serve` and visit `/labs/semiconductor-silicon-stack/`
- [ ] Verify the Labs dropdown shows "Semiconductor Stack" on desktop and the mobile menu
- [ ] Confirm the stack diagram renders cleanly on the white card (incumbents = navy, challengers = orange, EDA column = light navy, ASML/TSMC/KLA stars)
- [ ] Sticky sub-nav (Stack / Upstream / Equipment / Design / Tiers / Methodology) sits correctly under the fixed canonical header
- [ ] Spot-check external company links and the cross-link strip to the Physical AI map

🤖 Generated with [Claude Code](https://claude.com/claude-code)