### PR TITLE
Add Eastworlds (Virtuals) to Physical AI Map

### DIFF
--- a/labs/physical-ai/data.json
+++ b/labs/physical-ai/data.json
@@ -1590,6 +1590,14 @@
       },
       "top_companies": [
         {
+          "name": "Eastworlds (Virtuals)",
+          "geo": "US",
+          "valuation_m": null,
+          "last_round_label": "Feb 2026 launch, 30+ humanoid fleet + 500K+ task dataset + VLA models",
+          "canonical_portfolio": true,
+          "portfolio_url": "https://canonical.cc/companies/virtuals.html"
+        },
+        {
           "name": "Robo",
           "geo": "US",
           "valuation_m": null,
@@ -1634,7 +1642,9 @@
         "state-backed China funds"
       ],
       "canonical_pov": "Data collection is the most under-tracked and arguably most important physical AI category. China is building national humanoid data farms (395 humanoids across 9 national training facilities with 300 companies sharing standardized data) while the US relies on private RaaS data plus Scale AI. This is where China's structural advantage is widest and least visible to LPs.",
-      "caveats": []
+      "caveats": [
+        "Eastworlds (Virtuals Protocol's embodied-AI initiative, launched Feb 2026) operates a 30+ humanoid teleop fleet with an Embodied AI Data Lake — a US-side answer to AgiBot Pudong and Beijing X-Humanoid NLJIC. Counted here as a teleop-data play."
+      ]
     },
     {
       "id": "safety-verification",

--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -37,10 +37,12 @@
        (for outbound SEO juice). The CANONICAL pill rendered next to the name
        links to the internal /companies/<slug>.html page for engagement. */
     const COMPANY_URLS = {
-        // Canonical portfolio (3)
+        // Canonical portfolio
         'Haptic': 'https://hapticlabs.ai',
         'Robo': 'https://robo.inc',
         'Nirvana AI': 'https://nrvana.ai',
+        'Eastworlds (Virtuals)': 'https://whitepaper.virtuals.io/',
+        'Eastworlds': 'https://whitepaper.virtuals.io/',
         // Humanoid robotics
         'Figure AI': 'https://www.figure.ai',
         'Figure': 'https://www.figure.ai',


### PR DESCRIPTION
## Summary

Eastworlds is Virtuals Protocol's embodied-AI initiative — a 30+ humanoid teleop fleet, 500K+ recorded-tasks dataset, VLA models, and the Embodied AI Data Lake. Launched Feb 2026 as a US-side counterpart to AgiBot Pudong and Beijing X-Humanoid (NLJIC).

## Placement

- Sub-sector: **Teleoperation & Data Collection** (the spine of the operation — teleop fleets + egocentric data engine + Embodied AI Data Lake)
- Pinned first in `top_companies`, `canonical_portfolio: true` (Virtuals is a Canonical portfolio company)
- External link: `whitepaper.virtuals.io` (Eastworlds has no dedicated domain; this is the most authoritative public landing)
- Internal "★ Canonical" pill: `/companies/virtuals.html`
- Sub-sector caveat updated with Eastworlds context

After merge the Teleop sector card carries the orange star badge (already there from the Robo addition) and the drawer shows two portfolio rows pinned at top: Eastworlds (Virtuals) and Robo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)