### PR TITLE
Fix Eastworlds external URL → eastworlds.io

### DIFF
--- a/labs/physical-ai/lab.js
+++ b/labs/physical-ai/lab.js
@@ -41,8 +41,8 @@
         'Haptic': 'https://hapticlabs.ai',
         'Robo': 'https://robo.inc',
         'Nirvana AI': 'https://nrvana.ai',
-        'Eastworlds (Virtuals)': 'https://whitepaper.virtuals.io/',
-        'Eastworlds': 'https://whitepaper.virtuals.io/',
+        'Eastworlds (Virtuals)': 'https://eastworlds.io',
+        'Eastworlds': 'https://eastworlds.io',
         // Humanoid robotics
         'Figure AI': 'https://www.figure.ai',
         'Figure': 'https://www.figure.ai',


### PR DESCRIPTION
Eastworlds now has its own domain. Previously pointed at whitepaper.virtuals.io which was the most authoritative landing we had at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)