### PR TITLE
Make company links visibly clickable on the Physical AI Map

### DIFF
--- a/labs/physical-ai/lab.css
+++ b/labs/physical-ai/lab.css
@@ -1195,30 +1195,30 @@
 }
 
 /* ============ COMPANY OUTBOUND LINKS ============
-   Used everywhere a company name renders. Subtle by default (color inherits),
-   underline on hover. Keep these crawler-visible — no nofollow, real anchors. */
+   Used everywhere a company name renders. Real anchors, crawler-visible,
+   no nofollow. Visible underline cue so they read as clickable. */
 .pai-co-link {
-    color: inherit;
+    color: var(--pai-navy);
     text-decoration: none;
-    border-bottom: 1px dotted rgba(30, 58, 138, 0.35);
+    border-bottom: 1px solid rgba(30, 58, 138, 0.55);
     transition: border-bottom-color 0.15s, color 0.15s;
+    font-weight: 500;
 }
 .pai-co-link:hover {
-    border-bottom-color: var(--pai-navy);
-    color: var(--pai-navy);
+    border-bottom-color: var(--pai-accent);
+    color: var(--pai-accent);
 }
 .pai-co-link:focus { outline: 2px solid rgba(249, 115, 22, 0.55); outline-offset: 1px; }
 
-/* On the navy-gradient sections (cards on dark), tweak the underline tone */
-.pai-chasm-name .pai-co-link,
-.pai-flow-target .pai-co-link,
-.pai-card-companies .pai-co-link {
-    border-bottom-color: rgba(30, 58, 138, 0.25);
+/* Portfolio rows in the drawer table — extra-clear link styling on the company name */
+.pai-d-portfolio-row .pai-co-link {
+    color: var(--pai-navy);
+    border-bottom: 1px solid var(--pai-navy);
+    font-weight: 600;
 }
-.pai-chasm-name .pai-co-link:hover,
-.pai-flow-target .pai-co-link:hover,
-.pai-card-companies .pai-co-link:hover {
-    border-bottom-color: var(--pai-navy);
+.pai-d-portfolio-row .pai-co-link:hover {
+    color: var(--pai-accent);
+    border-bottom-color: var(--pai-accent);
 }
 
 /* Investor-view "named portfolio companies" pills become anchor tags */


### PR DESCRIPTION
## Problem

Reported: "there are no links to Robo.inc and Eastworlds." The anchors WERE rendered with correct hrefs, but the visual styling was so subtle that names read as plain text:

- `color: inherit` → black text, no color cue
- `border-bottom: 1px dotted rgba(30, 58, 138, 0.35)` → near-invisible underline, especially on the orange-tinted portfolio-row background

## Fix

```css
.pai-co-link {
  color: var(--pai-navy);
  border-bottom: 1px solid rgba(30, 58, 138, 0.55);
  font-weight: 500;
}
.pai-d-portfolio-row .pai-co-link {
  color: var(--pai-navy);
  border-bottom: 1px solid var(--pai-navy);
  font-weight: 600;
}
```

Navy text + solid underline + bold weight = clearly a link. Portfolio company names get full-opacity underline and 600 weight so they stand out more than peer companies. Hover transitions to accent orange for both color and underline.

Applies everywhere a company name renders: chasm bars, velocity scatter labels (SVG), US/China flow targets, defense unicorn timeline labels, drawer top-companies table (all rows including the portfolio rows for Eastworlds, Robo, Haptic, Nirvana AI), investor view portfolio pills, sector card "Top:" lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)