### PR TITLE
Semiconductor Stack: complete backlinks, hover tooltips, clickable SVG with ?ref=canonicalcc

### DIFF
--- a/labs/semiconductor-silicon-stack/index.html
+++ b/labs/semiconductor-silicon-stack/index.html
@@ -30,10 +30,10 @@
 
     <meta name="theme-color" content="#1e3a8a" />
     <link rel="icon" type="image/x-icon" href="https://www.canonical.cc/favicon.ico" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com?ref=canonicalcc">
+    <link rel="preconnect" href="https://fonts.gstatic.com?ref=canonicalcc" crossorigin>
+    <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular&ref=canonicalcc" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap&ref=canonicalcc" rel="stylesheet">
     <link rel="stylesheet" href="https://canonical.cc/css/style.css?v=20260514f">
     <link rel="stylesheet" href="lab.css?v=1">
 </head>
@@ -68,7 +68,7 @@
                     <div class="sem-tldr-grid">
                         <div class="sem-tldr-item">
                             <div class="sem-stat"><em>$4B</em></div>
-                            <div class="sem-tldr-label"><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
+                            <div class="sem-tldr-label"><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
                         </div>
                         <div class="sem-tldr-item">
                             <div class="sem-stat">2</div>
@@ -140,16 +140,16 @@
                                 <text x="80" y="643" fill="#92400e" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">1. RAW MATERIALS</text>
                                 <text x="80" y="662" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">sand → ultra-pure silicon</text>
 
-                                <rect x="270" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Wacker Chemie — German polysilicon producer; one of two majors.</title></rect>
-                                <text x="320" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Wacker</text>
+                                <a href="https://www.wacker.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Wacker Chemie — German polysilicon producer; one of two majors."><title>Wacker Chemie — German polysilicon producer; one of two majors.</title><rect x="270" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="320" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Wacker</text></a>
 
-                                <rect x="382" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Hemlock Semiconductor — US polysilicon producer; co-monopolist with Wacker.</title></rect>
-                                <text x="432" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Hemlock</text>
+                                <a href="https://www.hscpoly.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Hemlock Semiconductor — US polysilicon producer; co-monopolist with Wacker."><title>Hemlock Semiconductor — US polysilicon producer; co-monopolist with Wacker.</title><rect x="382" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="432" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Hemlock</text></a>
 
                                 <line x1="510" y1="628" x2="510" y2="672" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="630" width="220" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>First new commercial US polysilicon greenfield since the IRA. ~$1B, 16,000 MT/year.</title></rect>
-                                <text x="640" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Highland Materials</text>
+                                <a href="https://highlandmaterials.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="First new commercial US polysilicon greenfield since the IRA. ~$1B, 16,000 MT/year."><title>First new commercial US polysilicon greenfield since the IRA. ~$1B, 16,000 MT/year.</title><rect x="530" y="630" width="220" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="640" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Highland Materials</text></a>
                             </g>
 
                             <!-- LAYER 2: Wafers -->
@@ -158,19 +158,19 @@
                                 <text x="80" y="563" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">2. WAFERS</text>
                                 <text x="80" y="582" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">silicon, GaN, diamond substrates</text>
 
-                                <rect x="270" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Japanese silicon wafer producer; one of two majors.</title></rect>
-                                <text x="320" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Shin-Etsu</text>
+                                <a href="https://www.shinetsu.co.jp/en/?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Japanese silicon wafer producer; one of two majors."><title>Japanese silicon wafer producer; one of two majors.</title><rect x="270" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="320" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Shin-Etsu</text></a>
 
-                                <rect x="382" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Japanese silicon wafer producer; co-monopolist with Shin-Etsu.</title></rect>
-                                <text x="432" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SUMCO</text>
+                                <a href="https://www.sumcosi.com/english/?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Japanese silicon wafer producer; co-monopolist with Shin-Etsu."><title>Japanese silicon wafer producer; co-monopolist with Shin-Etsu.</title><rect x="382" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="432" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SUMCO</text></a>
 
                                 <line x1="510" y1="548" x2="510" y2="592" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>MIT spinout (Palacios). Vertical GaN FinFETs on 200mm. $11M seed Oct 2025.</title></rect>
-                                <text x="582" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Vertical Semi</text>
+                                <a href="https://verticalsemi.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm. $11M seed Oct 2025."><title>MIT spinout (Palacios). Vertical GaN FinFETs on 200mm. $11M seed Oct 2025.</title><rect x="530" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Vertical Semi</text></a>
 
-                                <rect x="645" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Single-crystal CVD diamond substrate maker. ~$315M raised, €675M Spain plant.</title></rect>
-                                <text x="697" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Diamond Foundry</text>
+                                <a href="https://diamondfoundry.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M Spain plant."><title>Single-crystal CVD diamond substrate maker. ~$315M raised, €675M Spain plant.</title><rect x="645" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Diamond Foundry</text></a>
                             </g>
 
                             <!-- LAYER 3: Lithography -->
@@ -179,19 +179,19 @@
                                 <text x="80" y="483" fill="#5b21b6" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">3. LITHOGRAPHY</text>
                                 <text x="80" y="502" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">EUV — the real bottleneck</text>
 
-                                <rect x="270" y="470" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"><title>Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool.</title></rect>
-                                <text x="376" y="495" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">ASML</text>
+                                <a href="https://www.asml.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><title>Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool.</title><rect x="270" y="470" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <text x="376" y="495" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">ASML</text></a>
 
                                 <line x1="510" y1="468" x2="510" y2="512" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"><title>James Proud's SF startup. X-ray lithography from custom particle accelerators. $100M at $1B.</title></rect>
-                                <text x="564" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Substrate</text>
+                                <a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="James Proud's SF startup. X-ray lithography from custom particle accelerators. $100M at $1B."><title>James Proud's SF startup. X-ray lithography from custom particle accelerators. $100M at $1B.</title><rect x="530" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="564" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Substrate</text></a>
 
-                                <rect x="608" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"><title>Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B + $150M CHIPS LOI.</title></rect>
-                                <text x="642" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">xLight</text>
+                                <a href="https://xlight.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B + $150M CHIPS LOI."><title>Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B + $150M CHIPS LOI.</title><rect x="608" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="642" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">xLight</text></a>
 
-                                <rect x="686" y="470" width="64" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Canon's nanoimprint lithography. Only credible non-EUV alternative shipping today.</title></rect>
-                                <text x="718" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Canon NIL</text>
+                                <a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Canon's nanoimprint lithography. Only credible non-EUV alternative shipping today."><title>Canon's nanoimprint lithography. Only credible non-EUV alternative shipping today.</title><rect x="686" y="470" width="64" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="718" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Canon NIL</text></a>
                             </g>
 
                             <!-- LAYER 4: Deposition & Etch -->
@@ -200,22 +200,22 @@
                                 <text x="80" y="403" fill="#115e59" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">4. DEPOSITION &amp; ETCH</text>
                                 <text x="80" y="422" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">doping, layers, interconnects</text>
 
-                                <rect x="270" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Applied Materials — world's largest semi equipment maker.</title></rect>
-                                <text x="303" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AMAT</text>
+                                <a href="https://www.appliedmaterials.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Applied Materials — world's largest semi equipment maker."><title>Applied Materials — world's largest semi equipment maker.</title><rect x="270" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="303" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AMAT</text></a>
 
-                                <rect x="344" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Lam Research — etch and deposition leader.</title></rect>
-                                <text x="377" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lam</text>
+                                <a href="https://www.lamresearch.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Lam Research — etch and deposition leader."><title>Lam Research — etch and deposition leader.</title><rect x="344" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="377" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lam</text></a>
 
-                                <rect x="418" y="390" width="64" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Tokyo Electron — coater/developer and etch leader.</title></rect>
-                                <text x="450" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">TEL</text>
+                                <a href="https://www.tel.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Tokyo Electron — coater/developer and etch leader."><title>Tokyo Electron — coater/developer and etch leader.</title><rect x="418" y="390" width="64" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="450" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">TEL</text></a>
 
                                 <line x1="510" y1="388" x2="510" y2="432" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A.</title></rect>
-                                <text x="582" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AlixLabs</text>
+                                <a href="https://www.alixlabs.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A."><title>Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A.</title><rect x="530" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AlixLabs</text></a>
 
-                                <rect x="645" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Sam Zeloof + Jim Keller. Small fast fabs + tools inside them. ~$15M seed from OpenAI Startup Fund.</title></rect>
-                                <text x="697" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic Semi</text>
+                                <a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Sam Zeloof + Jim Keller. Small fast fabs + tools inside them. ~$15M seed from OpenAI Startup Fund."><title>Sam Zeloof + Jim Keller. Small fast fabs + tools inside them. ~$15M seed from OpenAI Startup Fund.</title><rect x="645" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic Semi</text></a>
                             </g>
 
                             <!-- LAYER 5: Inspection -->
@@ -224,16 +224,16 @@
                                 <text x="80" y="323" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">5. INSPECTION &amp; TEST</text>
                                 <text x="80" y="342" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">defect detection at every step</text>
 
-                                <rect x="270" y="310" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2"><title>Near-monopoly in wafer defect inspection.</title></rect>
-                                <text x="376" y="335" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">KLA</text>
+                                <a href="https://www.kla.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Near-monopoly in wafer defect inspection."><title>Near-monopoly in wafer defect inspection.</title><rect x="270" y="310" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2"/>
+                                <text x="376" y="335" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">KLA</text></a>
 
                                 <line x1="510" y1="308" x2="510" y2="352" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Dutch non-destructive 3D AFM metrology. €135M Series C.</title></rect>
-                                <text x="582" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Nearfield</text>
+                                <a href="https://www.nearfieldinstruments.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Dutch non-destructive 3D AFM metrology. €135M Series C."><title>Dutch non-destructive 3D AFM metrology. €135M Series C.</title><rect x="530" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="582" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Nearfield</text></a>
 
-                                <rect x="645" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Singapore AI overlay on existing fab inspection hardware. At GlobalFoundries + JCET.</title></rect>
-                                <text x="697" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SixSense</text>
+                                <a href="https://www.sixsense.ai?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Singapore AI overlay on existing fab inspection hardware. At GlobalFoundries + JCET."><title>Singapore AI overlay on existing fab inspection hardware. At GlobalFoundries + JCET.</title><rect x="645" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <text x="697" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SixSense</text></a>
                             </g>
 
                             <!-- LAYER 6: Fab / Tape Out -->
@@ -242,19 +242,19 @@
                                 <text x="80" y="243" fill="#14532d" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">6. FAB / TAPE OUT</text>
                                 <text x="80" y="262" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">manufacturing at scale</text>
 
-                                <rect x="270" y="230" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"><title>Taiwan Semi Manufacturing Co. Manufactures everything at the leading edge.</title></rect>
-                                <text x="303" y="255" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="14" font-weight="600" text-anchor="middle">TSMC</text>
+                                <a href="https://www.tsmc.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Taiwan Semi Manufacturing Co. Manufactures everything at the leading edge."><title>Taiwan Semi Manufacturing Co. Manufactures everything at the leading edge.</title><rect x="270" y="230" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <text x="303" y="255" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="14" font-weight="600" text-anchor="middle">TSMC</text></a>
 
-                                <rect x="344" y="230" width="74" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Samsung Foundry. Credible second to TSMC on certain nodes.</title></rect>
-                                <text x="381" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Samsung</text>
+                                <a href="https://semiconductor.samsung.com/foundry/?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Samsung Foundry. Credible second to TSMC on certain nodes."><title>Samsung Foundry. Credible second to TSMC on certain nodes.</title><rect x="344" y="230" width="74" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="381" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Samsung</text></a>
 
-                                <rect x="426" y="230" width="56" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Intel Foundry. Rebuilding US leading-edge fab capacity.</title></rect>
-                                <text x="454" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Intel</text>
+                                <a href="https://www.intel.com/content/www/us/en/foundry/overview.html?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Intel Foundry. Rebuilding US leading-edge fab capacity."><title>Intel Foundry. Rebuilding US leading-edge fab capacity.</title><rect x="426" y="230" width="56" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <text x="454" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Intel</text></a>
 
                                 <line x1="510" y1="228" x2="510" y2="272" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="230" width="68" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c" stroke-width="2"><title>Atomic Semi — Sam Zeloof + Jim Keller. Small-fab-as-a-service.</title></rect>
-                                <text x="564" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic</text>
+                                <a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Atomic Semi — Sam Zeloof + Jim Keller. Small-fab-as-a-service."><title>Atomic Semi — Sam Zeloof + Jim Keller. Small-fab-as-a-service.</title><rect x="530" y="230" width="68" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c" stroke-width="2"/>
+                                <text x="564" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic</text></a>
 
                                 <text x="650" y="245" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">no startup credibly</text>
                                 <text x="650" y="257" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">challenges TSMC</text>
@@ -268,17 +268,17 @@
                                 <text x="80" y="170" fill="#64748b" font-family="Aeonik Regular, system-ui" font-size="10">novel compute substrates</text>
                                 <text x="80" y="184" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">chip cos, not picks-and-shovels</text>
 
-                                <rect x="270" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Photonic quantum chips at GlobalFoundries Fab 8. $1B Series E at $7B.</title></rect>
-                                <text x="325" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">PsiQuantum</text>
+                                <a href="https://psiquantum.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Photonic quantum chips at GlobalFoundries Fab 8. $1B Series E at $7B."><title>Photonic quantum chips at GlobalFoundries Fab 8. $1B Series E at $7B.</title><rect x="270" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="325" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">PsiQuantum</text></a>
 
-                                <rect x="388" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Photonic compute + 3D photonic interposer. ~$822M raised, $4.4B valuation.</title></rect>
-                                <text x="443" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lightmatter</text>
+                                <a href="https://lightmatter.co?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Photonic compute + 3D photonic interposer. ~$822M raised, $4.4B valuation."><title>Photonic compute + 3D photonic interposer. ~$822M raised, $4.4B valuation.</title><rect x="388" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="443" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lightmatter</text></a>
 
-                                <rect x="506" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised.</title></rect>
-                                <text x="561" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Ayar Labs</text>
+                                <a href="https://ayarlabs.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><title>Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised.</title><rect x="506" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="561" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Ayar Labs</text></a>
 
-                                <rect x="624" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Snowcap Compute — superconducting digital compute on NbTiN at 4.5K. $23M seed.</title></rect>
-                                <text x="679" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Snowcap</text>
+                                <a href="https://www.snowcapcompute.com?ref=canonicalcc" target="_blank" rel="noopener" class="sem-svg-link" data-tip="Snowcap Compute — superconducting digital compute on NbTiN at 4.5K. $23M seed."><title>Snowcap Compute — superconducting digital compute on NbTiN at 4.5K. $23M seed.</title><rect x="624" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <text x="679" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Snowcap</text></a>
                             </g>
 
                             <!-- EDA Column on the right -->
@@ -329,7 +329,7 @@
 
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
-                        <p>Two layers drive everything. <strong title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a></strong> in lithography. <strong title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a></strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
+                        <p>Two layers drive everything. <strong title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool." data-tip="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com?ref=canonicalcc" target="_blank" rel="noopener">ASML</a></strong> in lithography. <strong title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge." data-tip="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com?ref=canonicalcc" target="_blank" rel="noopener">TSMC</a></strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
                     </div>
                 </div>
             </section>
@@ -350,17 +350,17 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="German polysilicon producer. One of two majors purifying quartz sand to 99.9999999% pure silicon."><a href="https://www.wacker.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wacker Chemie</a></span>
-                                    <span class="sem-pill" title="US polysilicon producer. Co-monopolist with Wacker on ultra-pure silicon."><a href="https://www.hscpoly.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Hemlock Semiconductor</a></span>
+                                    <span class="sem-pill" title="German polysilicon producer. One of two majors purifying quartz sand to 99.9999999% pure silicon." data-tip="German polysilicon producer. One of two majors purifying quartz sand to 99.9999999% pure silicon."><a href="https://www.wacker.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wacker Chemie</a></span>
+                                    <span class="sem-pill" title="US polysilicon producer. Co-monopolist with Wacker on ultra-pure silicon." data-tip="US polysilicon producer. Co-monopolist with Wacker on ultra-pure silicon."><a href="https://www.hscpoly.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Hemlock Semiconductor</a></span>
                                 </div>
                                 <p>Quartz sand gets purified into 99.9999999% pure polysilicon, then grown into single-crystal ingots. Two companies dominate, mostly because nobody else wants to operate billion-dollar chemical plants that need decade-long contracts to amortize.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Highland Materials</a></span>
+                                    <span class="sem-pill" title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year." data-tip="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Highland Materials</a></span>
                                 </div>
-                                <p><strong title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com" target="_blank" rel="noopener">Highland Materials</a></strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
+                                <p><strong title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year." data-tip="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com?ref=canonicalcc" target="_blank" rel="noopener">Highland Materials</a></strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
                             </div>
                         </div>
                     </div>
@@ -374,22 +374,22 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Japanese silicon wafer producer. One of two majors supplying the discs every chip is etched onto."><a href="https://www.shinetsu.co.jp/en/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Shin-Etsu</a></span>
-                                    <span class="sem-pill" title="Japanese silicon wafer producer. Co-monopolist with Shin-Etsu on 300mm prime wafers."><a href="https://www.sumcosi.com/english/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SUMCO</a></span>
-                                    <span class="sem-pill" title="US silicon carbide wafer maker for power semis. Formerly Cree."><a href="https://www.wolfspeed.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wolfspeed (SiC)</a></span>
+                                    <span class="sem-pill" title="Japanese silicon wafer producer. One of two majors supplying the discs every chip is etched onto." data-tip="Japanese silicon wafer producer. One of two majors supplying the discs every chip is etched onto."><a href="https://www.shinetsu.co.jp/en/?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Shin-Etsu</a></span>
+                                    <span class="sem-pill" title="Japanese silicon wafer producer. Co-monopolist with Shin-Etsu on 300mm prime wafers." data-tip="Japanese silicon wafer producer. Co-monopolist with Shin-Etsu on 300mm prime wafers."><a href="https://www.sumcosi.com/english/?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SUMCO</a></span>
+                                    <span class="sem-pill" title="US silicon carbide wafer maker for power semis. Formerly Cree." data-tip="US silicon carbide wafer maker for power semis. Formerly Cree."><a href="https://www.wolfspeed.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wolfspeed (SiC)</a></span>
                                 </div>
                                 <p>Two Japanese companies make the silicon discs every chip is etched onto. For specialty wafers (SiC, GaN, diamond), the field opens up.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Vertical Semiconductor</a></span>
-                                    <span class="sem-pill" title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diamond Foundry</a></span>
-                                    <span class="sem-pill" title="Japanese specialty wafer and diamond substrate maker."><a href="https://orbray.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Orbray</a></span>
-                                    <span class="sem-pill" title="Chinese GaN power semiconductor company. IPO&#x27;d on HKEX."><a href="https://www.innoscience.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Innoscience</a></span>
+                                    <span class="sem-pill" title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led." data-tip="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Vertical Semiconductor</a></span>
+                                    <span class="sem-pill" title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain." data-tip="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diamond Foundry</a></span>
+                                    <span class="sem-pill" title="Japanese specialty wafer and diamond substrate maker." data-tip="Japanese specialty wafer and diamond substrate maker."><a href="https://orbray.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Orbray</a></span>
+                                    <span class="sem-pill" title="Chinese GaN power semiconductor company. IPO&#x27;d on HKEX." data-tip="Chinese GaN power semiconductor company. IPO&#x27;d on HKEX."><a href="https://www.innoscience.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Innoscience</a></span>
                                 </div>
-                                <p><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semiconductor</a></strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
-                                <p><strong title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
+                                <p><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led." data-tip="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Vertical Semiconductor</a></strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
+                                <p><strong title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain." data-tip="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com?ref=canonicalcc" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
                             </div>
                         </div>
                     </div>
@@ -403,21 +403,21 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbent</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ASML (only EUV maker)</a></span>
+                                    <span class="sem-pill star" title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool." data-tip="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ASML (only EUV maker)</a></span>
                                 </div>
-                                <p><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a> makes the only machines on earth capable of printing features small enough for modern chips. A single High-NA EUV machine costs $380M. Every advanced fab buys from them. There is no second source.</p>
+                                <p><a href="https://www.asml.com?ref=canonicalcc" target="_blank" rel="noopener">ASML</a> makes the only machines on earth capable of printing features small enough for modern chips. A single High-NA EUV machine costs $380M. Every advanced fab buys from them. There is no second source.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Substrate</a></span>
-                                    <span class="sem-pill star" title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
-                                    <span class="sem-pill" title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Canon NIL</a></span>
-                                    <span class="sem-pill" title="Lithography-adjacent semiconductor startup."><a href="https://www.inversionsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Inversion Semi</a></span>
+                                    <span class="sem-pill star" title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led." data-tip="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Substrate</a></span>
+                                    <span class="sem-pill star" title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI." data-tip="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
+                                    <span class="sem-pill" title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum." data-tip="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Canon NIL</a></span>
+                                    <span class="sem-pill" title="Lithography-adjacent semiconductor startup." data-tip="Lithography-adjacent semiconductor startup."><a href="https://www.inversionsemi.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Inversion Semi</a></span>
                                 </div>
-                                <p><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
-                                <p><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
-                                <p><strong title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener">Canon NIL</a></strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
+                                <p><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led." data-tip="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener">Substrate</a></strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
+                                <p><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI." data-tip="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com?ref=canonicalcc" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
+                                <p><strong title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum." data-tip="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html?ref=canonicalcc" target="_blank" rel="noopener">Canon NIL</a></strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
                             </div>
                         </div>
                     </div>
@@ -445,20 +445,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="World&#x27;s largest semiconductor equipment maker. Deposition, etch, doping tools."><a href="https://www.appliedmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Applied Materials</a></span>
-                                    <span class="sem-pill" title="US semiconductor equipment maker. Etch and deposition leader."><a href="https://www.lamresearch.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lam Research</a></span>
-                                    <span class="sem-pill" title="Japanese semiconductor equipment maker. Coater/developer and etch leader."><a href="https://www.tel.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tokyo Electron</a></span>
+                                    <span class="sem-pill" title="World&#x27;s largest semiconductor equipment maker. Deposition, etch, doping tools." data-tip="World&#x27;s largest semiconductor equipment maker. Deposition, etch, doping tools."><a href="https://www.appliedmaterials.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Applied Materials</a></span>
+                                    <span class="sem-pill" title="US semiconductor equipment maker. Etch and deposition leader." data-tip="US semiconductor equipment maker. Etch and deposition leader."><a href="https://www.lamresearch.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lam Research</a></span>
+                                    <span class="sem-pill" title="Japanese semiconductor equipment maker. Coater/developer and etch leader." data-tip="Japanese semiconductor equipment maker. Coater/developer and etch leader."><a href="https://www.tel.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tokyo Electron</a></span>
                                 </div>
                                 <p>Three companies make 80% of the tools that lay down metal layers, etch patterns, and dope silicon. Healthy three-way competition keeps prices roughly honest.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">AlixLabs</a></span>
-                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                    <span class="sem-pill" title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG." data-tip="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">AlixLabs</a></span>
+                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
                                 </div>
-                                <p><strong title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com" target="_blank" rel="noopener">AlixLabs</a></strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
-                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
+                                <p><strong title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG." data-tip="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com?ref=canonicalcc" target="_blank" rel="noopener">AlixLabs</a></strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
+                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
                             </div>
                         </div>
                     </div>
@@ -472,20 +472,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbent</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="Near-monopoly in wafer defect inspection."><a href="https://www.kla.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">KLA</a></span>
+                                    <span class="sem-pill star" title="Near-monopoly in wafer defect inspection." data-tip="Near-monopoly in wafer defect inspection."><a href="https://www.kla.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">KLA</a></span>
                                 </div>
                                 <p>KLA owns wafer inspection. Lasertec owns EUV mask inspection. Both are near-monopolies in their slices.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Nearfield Instruments</a></span>
-                                    <span class="sem-pill" title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SixSense</a></span>
-                                    <span class="sem-pill" title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">EuQlid</a></span>
+                                    <span class="sem-pill" title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek." data-tip="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Nearfield Instruments</a></span>
+                                    <span class="sem-pill" title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET." data-tip="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SixSense</a></span>
+                                    <span class="sem-pill" title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM." data-tip="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">EuQlid</a></span>
                                 </div>
-                                <p><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
-                                <p><strong title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai" target="_blank" rel="noopener">SixSense</a></strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
-                                <p><strong title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io" target="_blank" rel="noopener">EuQlid</a></strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
+                                <p><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek." data-tip="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com?ref=canonicalcc" target="_blank" rel="noopener">Nearfield Instruments</a></strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
+                                <p><strong title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET." data-tip="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai?ref=canonicalcc" target="_blank" rel="noopener">SixSense</a></strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
+                                <p><strong title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM." data-tip="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io?ref=canonicalcc" target="_blank" rel="noopener">EuQlid</a></strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
                             </div>
                         </div>
                     </div>
@@ -499,18 +499,18 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
-                                    <span class="sem-pill" title="Samsung Foundry. Credible second to TSMC on certain nodes."><a href="https://semiconductor.samsung.com/foundry/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Samsung</a></span>
-                                    <span class="sem-pill" title="Intel Foundry. Rebuilding US leading-edge fab capacity."><a href="https://www.intel.com/content/www/us/en/foundry/overview.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Intel</a></span>
+                                    <span class="sem-pill star" title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge." data-tip="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
+                                    <span class="sem-pill" title="Samsung Foundry. Credible second to TSMC on certain nodes." data-tip="Samsung Foundry. Credible second to TSMC on certain nodes."><a href="https://semiconductor.samsung.com/foundry/?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Samsung</a></span>
+                                    <span class="sem-pill" title="Intel Foundry. Rebuilding US leading-edge fab capacity." data-tip="Intel Foundry. Rebuilding US leading-edge fab capacity."><a href="https://www.intel.com/content/www/us/en/foundry/overview.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Intel</a></span>
                                 </div>
-                                <p><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a> manufactures everything at the leading edge. Samsung is a credible second on certain nodes. Intel is rebuilding. If TSMC stops, the AI industry stops.</p>
+                                <p><a href="https://www.tsmc.com?ref=canonicalcc" target="_blank" rel="noopener">TSMC</a> manufactures everything at the leading edge. Samsung is a credible second on certain nodes. Intel is rebuilding. If TSMC stops, the AI industry stops.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
                                 </div>
-                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; small-fab-as-a-service. The bet is that the future has many smaller specialized fabs, not three giant ones. Currently the only startup credibly working on the fab problem, and only at sub-300mm scale.</p>
+                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; small-fab-as-a-service. The bet is that the future has many smaller specialized fabs, not three giant ones. Currently the only startup credibly working on the fab problem, and only at sub-300mm scale.</p>
                                 <div class="sem-layer-note">No startup is credibly challenging TSMC at leading-edge nodes. The fab layer remains the most monopolized and the most capital-intensive in the stack.</div>
                             </div>
                         </div>
@@ -524,20 +524,20 @@
 
                         <div class="sem-adjacent-grid">
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill" title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">PsiQuantum</a></span>
-                                <p><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; photonic quantum chips manufactured at GlobalFoundries Fab 8 (Malta, NY). $1B Series E at $7B (Sep 2025). Customer of the fab layer.</p>
+                                <span class="sem-pill" title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B." data-tip="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">PsiQuantum</a></span>
+                                <p><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B." data-tip="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com?ref=canonicalcc" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; photonic quantum chips manufactured at GlobalFoundries Fab 8 (Malta, NY). $1B Series E at $7B (Sep 2025). Customer of the fab layer.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill" title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lightmatter</a></span>
-                                <p><strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> &mdash; photonic compute (Envise) and 3D photonic interposer (Passage L200, 200+ Tbps). ~$822M raised, $4.4B valuation. Fabless. Manufacturing at GlobalFoundries.</p>
+                                <span class="sem-pill" title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation." data-tip="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lightmatter</a></span>
+                                <p><strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation." data-tip="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co?ref=canonicalcc" target="_blank" rel="noopener">Lightmatter</a></strong> &mdash; photonic compute (Envise) and 3D photonic interposer (Passage L200, 200+ Tbps). ~$822M raised, $4.4B valuation. Fabless. Manufacturing at GlobalFoundries.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill" title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ayar Labs</a></span>
-                                <p><strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
+                                <span class="sem-pill" title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised." data-tip="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ayar Labs</a></span>
+                                <p><strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised." data-tip="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com?ref=canonicalcc" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill" title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Snowcap Compute</a></span>
-                                <p><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
+                                <span class="sem-pill" title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed." data-tip="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Snowcap Compute</a></span>
+                                <p><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed." data-tip="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com?ref=canonicalcc" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
                             </div>
                         </div>
                     </div>
@@ -545,7 +545,7 @@
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
                         <p>The fab layer is structurally the hardest to disrupt and the most capital-intensive to attempt. We don't expect a credible TSMC challenger to emerge at the leading edge in the next decade &mdash; Atomic Semi at sub-300mm scale is as close as it gets, and that's a different market.</p>
-                        <p>The more investable thesis sits one layer up: <strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> and <strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
+                        <p>The more investable thesis sits one layer up: <strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation." data-tip="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co?ref=canonicalcc" target="_blank" rel="noopener">Lightmatter</a></strong> and <strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised." data-tip="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com?ref=canonicalcc" target="_blank" rel="noopener">Ayar Labs</a></strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
                     </div>
                 </div>
             </section>
@@ -566,20 +566,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Big-Three EDA incumbent. Largest by revenue."><a href="https://www.synopsys.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys</a></span>
-                                    <span class="sem-pill" title="Big-Three EDA incumbent. Acquired ChipStack Nov 2025."><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence</a></span>
-                                    <span class="sem-pill" title="Big-Three EDA incumbent. Formerly Mentor Graphics."><a href="https://eda.sw.siemens.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens EDA</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Largest by revenue." data-tip="Big-Three EDA incumbent. Largest by revenue."><a href="https://www.synopsys.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Acquired ChipStack Nov 2025." data-tip="Big-Three EDA incumbent. Acquired ChipStack Nov 2025."><a href="https://www.cadence.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Formerly Mentor Graphics." data-tip="Big-Three EDA incumbent. Formerly Mentor Graphics."><a href="https://eda.sw.siemens.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens EDA</a></span>
                                 </div>
                                 <p>The Big Three. ~75% market share. All three have launched in-house AI products (Synopsys.ai, Cadence Cerebrus, Calibre.AI) but their architecture is bolt-on, not native.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ricursive Intelligence</a></span>
-                                    <span class="sem-pill star" title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
+                                    <span class="sem-pill star" title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ricursive Intelligence</a></span>
+                                    <span class="sem-pill star" title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board." data-tip="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
                                 </div>
-                                <p><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
-                                <p><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
+                                <p><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
+                                <p><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board." data-tip="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai?ref=canonicalcc" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
                             </div>
                         </div>
                     </div>
@@ -593,21 +593,21 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Synopsys&#x27;s verification simulator. One of the big-three sim platforms."><a href="https://www.synopsys.com/verification/simulation/vcs.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys VCS</a></span>
-                                    <span class="sem-pill" title="Cadence&#x27;s verification simulator."><a href="https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Xcelium</a></span>
-                                    <span class="sem-pill" title="Siemens&#x27;s verification platform. Formerly Mentor."><a href="https://eda.sw.siemens.com/en-US/ic/questa/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens Questa</a></span>
+                                    <span class="sem-pill" title="Synopsys&#x27;s verification simulator. One of the big-three sim platforms." data-tip="Synopsys&#x27;s verification simulator. One of the big-three sim platforms."><a href="https://www.synopsys.com/verification/simulation/vcs.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys VCS</a></span>
+                                    <span class="sem-pill" title="Cadence&#x27;s verification simulator." data-tip="Cadence&#x27;s verification simulator."><a href="https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Xcelium</a></span>
+                                    <span class="sem-pill" title="Siemens&#x27;s verification platform. Formerly Mentor." data-tip="Siemens&#x27;s verification platform. Formerly Mentor."><a href="https://eda.sw.siemens.com/en-US/ic/questa/?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens Questa</a></span>
                                 </div>
                                 <p>Verification is the most expensive and time-consuming part of chip design. Often 70% of total engineering hours. Ripe for automation.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
-                                    <span class="sem-pill" title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipStack (acq.)</a></span>
-                                    <span class="sem-pill" title="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Silimate</a></span>
+                                    <span class="sem-pill star" title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies." data-tip="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
+                                    <span class="sem-pill" title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent." data-tip="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipStack (acq.)</a></span>
+                                    <span class="sem-pill" title="AI for EDA signoff (DRC/LVS)." data-tip="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Silimate</a></span>
                                 </div>
-                                <p><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
-                                <p><strong title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com" target="_blank" rel="noopener">ChipStack</a></strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
+                                <p><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies." data-tip="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai?ref=canonicalcc" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
+                                <p><strong title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent." data-tip="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com?ref=canonicalcc" target="_blank" rel="noopener">ChipStack</a></strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
                             </div>
                         </div>
                     </div>
@@ -621,24 +621,24 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill" title="Cadence&#x27;s 30-year-old analog layout tool. Near-monopoly."><a href="https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Virtuoso</a></span>
-                                    <span class="sem-pill" title="Mobile and embedded CPU IP licensing."><a href="https://www.arm.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Arm</a></span>
-                                    <span class="sem-pill" title="Synopsys&#x27;s IP licensing business. Formerly DesignWare."><a href="https://www.synopsys.com/designware-ip.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys IP</a></span>
+                                    <span class="sem-pill" title="Cadence&#x27;s 30-year-old analog layout tool. Near-monopoly." data-tip="Cadence&#x27;s 30-year-old analog layout tool. Near-monopoly."><a href="https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Virtuoso</a></span>
+                                    <span class="sem-pill" title="Mobile and embedded CPU IP licensing." data-tip="Mobile and embedded CPU IP licensing."><a href="https://www.arm.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Arm</a></span>
+                                    <span class="sem-pill" title="Synopsys&#x27;s IP licensing business. Formerly DesignWare." data-tip="Synopsys&#x27;s IP licensing business. Formerly DesignWare."><a href="https://www.synopsys.com/designware-ip.html?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys IP</a></span>
                                 </div>
                                 <p>Virtuoso has owned analog layout for 30 years with effectively no competition. Arm has owned mobile cores for nearly as long.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star" title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
-                                    <span class="sem-pill" title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Astrus</a></span>
-                                    <span class="sem-pill" title="PCB-as-code."><a href="https://www.diode.computer" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diode</a></span>
-                                    <span class="sem-pill star" title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
-                                    <span class="sem-pill" title="RISC-V CPU IP cores."><a href="https://sifive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
+                                    <span class="sem-pill star" title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal." data-tip="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
+                                    <span class="sem-pill" title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla." data-tip="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Astrus</a></span>
+                                    <span class="sem-pill" title="PCB-as-code." data-tip="PCB-as-code."><a href="https://www.diode.computer?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diode</a></span>
+                                    <span class="sem-pill star" title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money." data-tip="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
+                                    <span class="sem-pill" title="RISC-V CPU IP cores." data-tip="RISC-V CPU IP cores."><a href="https://sifive.com?ref=canonicalcc" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
                                 </div>
-                                <p><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
-                                <p><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
-                                <p><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
+                                <p><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal." data-tip="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai?ref=canonicalcc" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
+                                <p><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla." data-tip="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai?ref=canonicalcc" target="_blank" rel="noopener">Astrus</a></strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
+                                <p><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money." data-tip="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com?ref=canonicalcc" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
                             </div>
                         </div>
                     </div>
@@ -662,10 +662,10 @@
                             <span class="sem-tier-num">Tier 1 &middot; High conviction</span>
                             <h4>Software speed of light</h4>
                             <ul>
-                                <li><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
-                                <li><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
-                                <li><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
-                                <li><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
+                                <li><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
+                                <li><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board." data-tip="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai?ref=canonicalcc" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
+                                <li><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies." data-tip="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai?ref=canonicalcc" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
+                                <li><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal." data-tip="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai?ref=canonicalcc" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
                             </ul>
                         </div>
 
@@ -673,10 +673,10 @@
                             <span class="sem-tier-num">Tier 2 &middot; Capital-heavy moonshots</span>
                             <h4>Underwrite like deep tech</h4>
                             <ul>
-                                <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
-                                <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
-                                <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
-                                <li><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semi</a></strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
+                                <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led." data-tip="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener">Substrate</a></strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
+                                <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI." data-tip="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com?ref=canonicalcc" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
+                                <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
+                                <li><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led." data-tip="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Vertical Semi</a></strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
                             </ul>
                         </div>
 
@@ -684,12 +684,12 @@
                             <span class="sem-tier-num">Tier 3 &middot; Watch list</span>
                             <h4>Earlier, narrower, or both</h4>
                             <ul>
-                                <li><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> &mdash; analog layout RL.</li>
-                                <li><strong title="PCB-as-code."><a href="https://www.diode.computer" target="_blank" rel="noopener">Diode Computers</a></strong> &mdash; PCB-as-code.</li>
-                                <li><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> &mdash; late-stage metrology.</li>
-                                <li><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting compute.</li>
-                                <li><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
-                                <li><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
+                                <li><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla." data-tip="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai?ref=canonicalcc" target="_blank" rel="noopener">Astrus</a></strong> &mdash; analog layout RL.</li>
+                                <li><strong title="PCB-as-code." data-tip="PCB-as-code."><a href="https://www.diode.computer?ref=canonicalcc" target="_blank" rel="noopener">Diode Computers</a></strong> &mdash; PCB-as-code.</li>
+                                <li><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek." data-tip="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com?ref=canonicalcc" target="_blank" rel="noopener">Nearfield Instruments</a></strong> &mdash; late-stage metrology.</li>
+                                <li><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed." data-tip="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com?ref=canonicalcc" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting compute.</li>
+                                <li><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money." data-tip="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com?ref=canonicalcc" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
+                                <li><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B." data-tip="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com?ref=canonicalcc" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
                             </ul>
                         </div>
                     </div>
@@ -697,11 +697,11 @@
                     <div class="sem-benchmarks">
                         <h4>Benchmarks that would change the thesis</h4>
                         <ul>
-                            <li>Synopsys or Siemens acquires <strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong>, <strong title="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com" target="_blank" rel="noopener">Silimate</a></strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
-                            <li>First full-stack chip tape-out designed end-to-end by <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive</a></strong> or <strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> → re-rates the entire AI-EDA category upward.</li>
-                            <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
-                            <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
-                            <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
+                            <li>Synopsys or Siemens acquires <strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies." data-tip="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai?ref=canonicalcc" target="_blank" rel="noopener">ChipAgents</a></strong>, <strong title="AI for EDA signoff (DRC/LVS)." data-tip="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com?ref=canonicalcc" target="_blank" rel="noopener">Silimate</a></strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
+                            <li>First full-stack chip tape-out designed end-to-end by <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener">Ricursive</a></strong> or <strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board." data-tip="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai?ref=canonicalcc" target="_blank" rel="noopener">Cognichip</a></strong> → re-rates the entire AI-EDA category upward.</li>
+                            <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led." data-tip="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener">Substrate</a></strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
+                            <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI." data-tip="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com?ref=canonicalcc" target="_blank" rel="noopener">xLight</a></strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
+                            <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund." data-tip="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com?ref=canonicalcc" target="_blank" rel="noopener">Atomic Semi</a></strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
                         </ul>
                     </div>
 
@@ -731,7 +731,7 @@
                         <div class="sem-method-col">
                             <h3>Known caveats</h3>
                             <ul class="sem-method-list">
-                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong>, not "Recursive." The lithography company is <strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
+                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led." data-tip="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com?ref=canonicalcc" target="_blank" rel="noopener">Ricursive Intelligence</a></strong>, not "Recursive." The lithography company is <strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led." data-tip="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com?ref=canonicalcc" target="_blank" rel="noopener">Substrate</a></strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
                                 <li><span class="sem-method-k">Substrate</span><span class="sem-method-v">Technical claims (12nm contact arrays, $10K-per-wafer) come from the company itself. Independent analysts (Fox Chapel Research, summarized in Tom's Hardware) have publicly questioned founder pedigree and the credibility of the demonstrations. Treat accordingly.</span></li>
                                 <li><span class="sem-method-k">Atomic Semi</span><span class="sem-method-v">Valuation ($100M) and seed size (~$15M) come from a January 2023 TechCrunch report citing unnamed sources. The 60-engineer team count is current as of Nov 2025 (Berkeley BWRC). A follow-on round has likely closed but is not public.</span></li>
                                 <li><span class="sem-method-k">Tenstorrent</span><span class="sem-method-v">The reported $3.2B pre-money Fidelity round comes from The Information citing two people with knowledge of the talks. Confirm terms directly before underwriting.</span></li>
@@ -771,5 +771,90 @@
 
         {% include footer.html %}
     </div>
+
+    <script>
+    (function () {
+        // Custom tooltip overlay for [data-tip] elements (HTML pills, strong tags, SVG company boxes).
+        // Native title attribute remains as an accessibility fallback.
+        var tip = document.createElement('div');
+        tip.className = 'sem-tooltip';
+        tip.setAttribute('role', 'tooltip');
+        tip.setAttribute('aria-hidden', 'true');
+        document.body.appendChild(tip);
+
+        var current = null;
+        var hideTimer = null;
+
+        function show(el, evt) {
+            var text = el.getAttribute('data-tip');
+            if (!text) return;
+            var isLink = el.tagName === 'A' || (el.querySelector && el.querySelector('a'));
+            tip.textContent = text;
+            if (isLink) {
+                var hint = document.createElement('span');
+                hint.className = 'sem-tooltip-hint';
+                hint.textContent = 'click → opens site';
+                tip.appendChild(hint);
+            }
+            tip.classList.add('show');
+            tip.setAttribute('aria-hidden', 'false');
+            current = el;
+            position(evt);
+        }
+
+        function position(evt) {
+            if (!current) return;
+            var pad = 14;
+            var w = tip.offsetWidth;
+            var h = tip.offsetHeight;
+            var x = evt.clientX + pad;
+            var y = evt.clientY + pad;
+            if (x + w > window.innerWidth - 8) x = evt.clientX - w - pad;
+            if (y + h > window.innerHeight - 8) y = evt.clientY - h - pad;
+            if (x < 8) x = 8;
+            if (y < 8) y = 8;
+            tip.style.left = x + 'px';
+            tip.style.top = y + 'px';
+        }
+
+        function hide() {
+            tip.classList.remove('show');
+            tip.setAttribute('aria-hidden', 'true');
+            current = null;
+        }
+
+        document.addEventListener('mouseover', function (e) {
+            var el = e.target.closest ? e.target.closest('[data-tip]') : null;
+            if (!el || el === current) return;
+            if (hideTimer) { clearTimeout(hideTimer); hideTimer = null; }
+            show(el, e);
+        }, true);
+
+        document.addEventListener('mousemove', function (e) {
+            if (!current) return;
+            var el = e.target.closest ? e.target.closest('[data-tip]') : null;
+            if (el && el !== current) {
+                show(el, e);
+            } else if (!el) {
+                hide();
+            } else {
+                position(e);
+            }
+        }, true);
+
+        document.addEventListener('mouseout', function (e) {
+            if (!current) return;
+            var related = e.relatedTarget;
+            var stillIn = related && related.closest && related.closest('[data-tip]');
+            if (!stillIn) {
+                hideTimer = setTimeout(hide, 60);
+            }
+        }, true);
+
+        // Hide on scroll or window blur for safety.
+        window.addEventListener('scroll', hide, { passive: true });
+        window.addEventListener('blur', hide);
+    })();
+    </script>
 </body>
 </html>

--- a/labs/semiconductor-silicon-stack/index.html
+++ b/labs/semiconductor-silicon-stack/index.html
@@ -68,7 +68,7 @@
                     <div class="sem-tldr-grid">
                         <div class="sem-tldr-item">
                             <div class="sem-stat"><em>$4B</em></div>
-                            <div class="sem-tldr-label"><strong>Ricursive Intelligence</strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
+                            <div class="sem-tldr-label"><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
                         </div>
                         <div class="sem-tldr-item">
                             <div class="sem-stat">2</div>
@@ -329,7 +329,7 @@
 
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
-                        <p>Two layers drive everything. <strong>ASML</strong> in lithography. <strong>TSMC</strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
+                        <p>Two layers drive everything. <strong><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a></strong> in lithography. <strong><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a></strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
                     </div>
                 </div>
             </section>
@@ -350,17 +350,17 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Wacker Chemie</span>
-                                    <span class="sem-pill">Hemlock Semiconductor</span>
+                                    <span class="sem-pill"><a href="https://www.wacker.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wacker Chemie</a></span>
+                                    <span class="sem-pill"><a href="https://www.hscpoly.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Hemlock Semiconductor</a></span>
                                 </div>
                                 <p>Quartz sand gets purified into 99.9999999% pure polysilicon, then grown into single-crystal ingots. Two companies dominate, mostly because nobody else wants to operate billion-dollar chemical plants that need decade-long contracts to amortize.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Highland Materials</span>
+                                    <span class="sem-pill"><a href="https://highlandmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Highland Materials</a></span>
                                 </div>
-                                <p><strong>Highland Materials</strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
+                                <p><strong><a href="https://highlandmaterials.com" target="_blank" rel="noopener">Highland Materials</a></strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
                             </div>
                         </div>
                     </div>
@@ -374,21 +374,21 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Shin-Etsu</span>
-                                    <span class="sem-pill">SUMCO</span>
-                                    <span class="sem-pill">Wolfspeed (SiC)</span>
+                                    <span class="sem-pill"><a href="https://www.shinetsu.co.jp/en/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Shin-Etsu</a></span>
+                                    <span class="sem-pill"><a href="https://www.sumcosi.com/english/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SUMCO</a></span>
+                                    <span class="sem-pill"><a href="https://www.wolfspeed.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wolfspeed (SiC)</a></span>
                                 </div>
                                 <p>Two Japanese companies make the silicon discs every chip is etched onto. For specialty wafers (SiC, GaN, diamond), the field opens up.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Vertical Semiconductor</span>
-                                    <span class="sem-pill"><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></span>
-                                    <span class="sem-pill">Orbray</span>
-                                    <span class="sem-pill">Innoscience</span>
+                                    <span class="sem-pill"><a href="https://verticalsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Vertical Semiconductor</a></span>
+                                    <span class="sem-pill"><a href="https://diamondfoundry.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diamond Foundry</a></span>
+                                    <span class="sem-pill"><a href="https://orbray.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Orbray</a></span>
+                                    <span class="sem-pill"><a href="https://www.innoscience.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Innoscience</a></span>
                                 </div>
-                                <p><strong>Vertical Semiconductor</strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
+                                <p><strong><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semiconductor</a></strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
                                 <p><strong><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
                             </div>
                         </div>
@@ -410,14 +410,14 @@
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star">Substrate</span>
+                                    <span class="sem-pill star"><a href="https://www.substrate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Substrate</a></span>
                                     <span class="sem-pill star"><a href="https://xlight.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
-                                    <span class="sem-pill">Canon NIL</span>
-                                    <span class="sem-pill">Inversion Semi</span>
+                                    <span class="sem-pill"><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Canon NIL</a></span>
+                                    <span class="sem-pill"><a href="https://www.inversionsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Inversion Semi</a></span>
                                 </div>
-                                <p><strong>Substrate</strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
+                                <p><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
                                 <p><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
-                                <p><strong>Canon NIL</strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
+                                <p><strong><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener">Canon NIL</a></strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
                             </div>
                         </div>
                     </div>
@@ -445,19 +445,19 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Applied Materials</span>
-                                    <span class="sem-pill">Lam Research</span>
-                                    <span class="sem-pill">Tokyo Electron</span>
+                                    <span class="sem-pill"><a href="https://www.appliedmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Applied Materials</a></span>
+                                    <span class="sem-pill"><a href="https://www.lamresearch.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lam Research</a></span>
+                                    <span class="sem-pill"><a href="https://www.tel.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tokyo Electron</a></span>
                                 </div>
                                 <p>Three companies make 80% of the tools that lay down metal layers, etch patterns, and dope silicon. Healthy three-way competition keeps prices roughly honest.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">AlixLabs</span>
+                                    <span class="sem-pill"><a href="https://www.alixlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">AlixLabs</a></span>
                                     <span class="sem-pill"><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
                                 </div>
-                                <p><strong>AlixLabs</strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
+                                <p><strong><a href="https://www.alixlabs.com" target="_blank" rel="noopener">AlixLabs</a></strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
                                 <p><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
                             </div>
                         </div>
@@ -472,20 +472,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbent</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star">KLA</span>
+                                    <span class="sem-pill star"><a href="https://www.kla.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">KLA</a></span>
                                 </div>
                                 <p>KLA owns wafer inspection. Lasertec owns EUV mask inspection. Both are near-monopolies in their slices.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Nearfield Instruments</span>
-                                    <span class="sem-pill">SixSense</span>
-                                    <span class="sem-pill">EuQlid</span>
+                                    <span class="sem-pill"><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Nearfield Instruments</a></span>
+                                    <span class="sem-pill"><a href="https://www.sixsense.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SixSense</a></span>
+                                    <span class="sem-pill"><a href="https://euqlid.io" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">EuQlid</a></span>
                                 </div>
-                                <p><strong>Nearfield Instruments</strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
-                                <p><strong>SixSense</strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
-                                <p><strong>EuQlid</strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
+                                <p><strong><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
+                                <p><strong><a href="https://www.sixsense.ai" target="_blank" rel="noopener">SixSense</a></strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
+                                <p><strong><a href="https://euqlid.io" target="_blank" rel="noopener">EuQlid</a></strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
                             </div>
                         </div>
                     </div>
@@ -500,8 +500,8 @@
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
                                     <span class="sem-pill star"><a href="https://www.tsmc.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
-                                    <span class="sem-pill">Samsung</span>
-                                    <span class="sem-pill">Intel</span>
+                                    <span class="sem-pill"><a href="https://semiconductor.samsung.com/foundry/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Samsung</a></span>
+                                    <span class="sem-pill"><a href="https://www.intel.com/content/www/us/en/foundry/overview.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Intel</a></span>
                                 </div>
                                 <p><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a> manufactures everything at the leading edge. Samsung is a credible second on certain nodes. Intel is rebuilding. If TSMC stops, the AI industry stops.</p>
                             </div>
@@ -536,8 +536,8 @@
                                 <p><strong><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill">Snowcap Compute</span>
-                                <p><strong>Snowcap Compute</strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
+                                <span class="sem-pill"><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Snowcap Compute</a></span>
+                                <p><strong><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
                             </div>
                         </div>
                     </div>
@@ -545,7 +545,7 @@
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
                         <p>The fab layer is structurally the hardest to disrupt and the most capital-intensive to attempt. We don't expect a credible TSMC challenger to emerge at the leading edge in the next decade &mdash; Atomic Semi at sub-300mm scale is as close as it gets, and that's a different market.</p>
-                        <p>The more investable thesis sits one layer up: <strong>Lightmatter</strong> and <strong>Ayar Labs</strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
+                        <p>The more investable thesis sits one layer up: <strong><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> and <strong><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
                     </div>
                 </div>
             </section>
@@ -566,19 +566,19 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Synopsys</span>
-                                    <span class="sem-pill">Cadence</span>
-                                    <span class="sem-pill">Siemens EDA</span>
+                                    <span class="sem-pill"><a href="https://www.synopsys.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys</a></span>
+                                    <span class="sem-pill"><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence</a></span>
+                                    <span class="sem-pill"><a href="https://eda.sw.siemens.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens EDA</a></span>
                                 </div>
                                 <p>The Big Three. ~75% market share. All three have launched in-house AI products (Synopsys.ai, Cadence Cerebrus, Calibre.AI) but their architecture is bolt-on, not native.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star">Ricursive Intelligence</span>
+                                    <span class="sem-pill star"><a href="https://www.ricursive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ricursive Intelligence</a></span>
                                     <span class="sem-pill star"><a href="https://cognichip.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
                                 </div>
-                                <p><strong>Ricursive Intelligence</strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
+                                <p><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
                                 <p><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
                             </div>
                         </div>
@@ -593,9 +593,9 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Synopsys VCS</span>
-                                    <span class="sem-pill">Cadence Xcelium</span>
-                                    <span class="sem-pill">Siemens Questa</span>
+                                    <span class="sem-pill"><a href="https://www.synopsys.com/verification/simulation/vcs.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys VCS</a></span>
+                                    <span class="sem-pill"><a href="https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Xcelium</a></span>
+                                    <span class="sem-pill"><a href="https://eda.sw.siemens.com/en-US/ic/questa/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens Questa</a></span>
                                 </div>
                                 <p>Verification is the most expensive and time-consuming part of chip design. Often 70% of total engineering hours. Ripe for automation.</p>
                             </div>
@@ -603,11 +603,11 @@
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
                                     <span class="sem-pill star"><a href="https://chipagents.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
-                                    <span class="sem-pill">ChipStack (acq.)</span>
-                                    <span class="sem-pill">Silimate</span>
+                                    <span class="sem-pill"><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipStack (acq.)</a></span>
+                                    <span class="sem-pill"><a href="https://www.silimate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Silimate</a></span>
                                 </div>
                                 <p><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
-                                <p><strong>ChipStack</strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
+                                <p><strong><a href="https://www.cadence.com" target="_blank" rel="noopener">ChipStack</a></strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
                             </div>
                         </div>
                     </div>
@@ -621,9 +621,9 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill">Cadence Virtuoso</span>
-                                    <span class="sem-pill">Arm</span>
-                                    <span class="sem-pill">Synopsys IP</span>
+                                    <span class="sem-pill"><a href="https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Virtuoso</a></span>
+                                    <span class="sem-pill"><a href="https://www.arm.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Arm</a></span>
+                                    <span class="sem-pill"><a href="https://www.synopsys.com/designware-ip.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys IP</a></span>
                                 </div>
                                 <p>Virtuoso has owned analog layout for 30 years with effectively no competition. Arm has owned mobile cores for nearly as long.</p>
                             </div>
@@ -631,13 +631,13 @@
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
                                     <span class="sem-pill star"><a href="https://www.quilter.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
-                                    <span class="sem-pill">Astrus</span>
-                                    <span class="sem-pill">Diode</span>
+                                    <span class="sem-pill"><a href="https://www.astrus.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Astrus</a></span>
+                                    <span class="sem-pill"><a href="https://www.diode.computer" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diode</a></span>
                                     <span class="sem-pill star"><a href="https://tenstorrent.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
                                     <span class="sem-pill"><a href="https://sifive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
                                 </div>
                                 <p><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
-                                <p><strong>Astrus</strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
+                                <p><strong><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
                                 <p><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
                             </div>
                         </div>
@@ -662,7 +662,7 @@
                             <span class="sem-tier-num">Tier 1 &middot; High conviction</span>
                             <h4>Software speed of light</h4>
                             <ul>
-                                <li><strong>Ricursive Intelligence</strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
+                                <li><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
                                 <li><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
                                 <li><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
                                 <li><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
@@ -673,10 +673,10 @@
                             <span class="sem-tier-num">Tier 2 &middot; Capital-heavy moonshots</span>
                             <h4>Underwrite like deep tech</h4>
                             <ul>
-                                <li><strong>Substrate</strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
+                                <li><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
                                 <li><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
                                 <li><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
-                                <li><strong>Vertical Semi</strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
+                                <li><strong><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semi</a></strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
                             </ul>
                         </div>
 
@@ -684,10 +684,10 @@
                             <span class="sem-tier-num">Tier 3 &middot; Watch list</span>
                             <h4>Earlier, narrower, or both</h4>
                             <ul>
-                                <li><strong>Astrus</strong> &mdash; analog layout RL.</li>
-                                <li><strong>Diode Computers</strong> &mdash; PCB-as-code.</li>
-                                <li><strong>Nearfield Instruments</strong> &mdash; late-stage metrology.</li>
-                                <li><strong>Snowcap Compute</strong> &mdash; superconducting compute.</li>
+                                <li><strong><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> &mdash; analog layout RL.</li>
+                                <li><strong><a href="https://www.diode.computer" target="_blank" rel="noopener">Diode Computers</a></strong> &mdash; PCB-as-code.</li>
+                                <li><strong><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> &mdash; late-stage metrology.</li>
+                                <li><strong><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting compute.</li>
                                 <li><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
                                 <li><strong><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
                             </ul>
@@ -697,11 +697,11 @@
                     <div class="sem-benchmarks">
                         <h4>Benchmarks that would change the thesis</h4>
                         <ul>
-                            <li>Synopsys or Siemens acquires <strong>ChipAgents</strong>, <strong>Silimate</strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
-                            <li>First full-stack chip tape-out designed end-to-end by <strong>Ricursive</strong> or <strong>Cognichip</strong> → re-rates the entire AI-EDA category upward.</li>
-                            <li><strong>Substrate</strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
-                            <li><strong>xLight</strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
-                            <li><strong>Atomic Semi</strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
+                            <li>Synopsys or Siemens acquires <strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong>, <strong><a href="https://www.silimate.com" target="_blank" rel="noopener">Silimate</a></strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
+                            <li>First full-stack chip tape-out designed end-to-end by <strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive</a></strong> or <strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> → re-rates the entire AI-EDA category upward.</li>
+                            <li><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
+                            <li><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
+                            <li><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
                         </ul>
                     </div>
 
@@ -731,7 +731,7 @@
                         <div class="sem-method-col">
                             <h3>Known caveats</h3>
                             <ul class="sem-method-list">
-                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong>Ricursive Intelligence</strong>, not "Recursive." The lithography company is <strong>Substrate</strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
+                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong>, not "Recursive." The lithography company is <strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
                                 <li><span class="sem-method-k">Substrate</span><span class="sem-method-v">Technical claims (12nm contact arrays, $10K-per-wafer) come from the company itself. Independent analysts (Fox Chapel Research, summarized in Tom's Hardware) have publicly questioned founder pedigree and the credibility of the demonstrations. Treat accordingly.</span></li>
                                 <li><span class="sem-method-k">Atomic Semi</span><span class="sem-method-v">Valuation ($100M) and seed size (~$15M) come from a January 2023 TechCrunch report citing unnamed sources. The 60-engineer team count is current as of Nov 2025 (Berkeley BWRC). A follow-on round has likely closed but is not public.</span></li>
                                 <li><span class="sem-method-k">Tenstorrent</span><span class="sem-method-v">The reported $3.2B pre-money Fidelity round comes from The Information citing two people with knowledge of the talks. Confirm terms directly before underwriting.</span></li>

--- a/labs/semiconductor-silicon-stack/index.html
+++ b/labs/semiconductor-silicon-stack/index.html
@@ -68,7 +68,7 @@
                     <div class="sem-tldr-grid">
                         <div class="sem-tldr-item">
                             <div class="sem-stat"><em>$4B</em></div>
-                            <div class="sem-tldr-label"><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
+                            <div class="sem-tldr-label"><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> Series A post-money. The AlphaChip founders priced AI-for-EDA at a software multiple.</div>
                         </div>
                         <div class="sem-tldr-item">
                             <div class="sem-stat">2</div>
@@ -140,15 +140,15 @@
                                 <text x="80" y="643" fill="#92400e" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">1. RAW MATERIALS</text>
                                 <text x="80" y="662" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">sand → ultra-pure silicon</text>
 
-                                <rect x="270" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="270" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Wacker Chemie — German polysilicon producer; one of two majors.</title></rect>
                                 <text x="320" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Wacker</text>
 
-                                <rect x="382" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="382" y="630" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Hemlock Semiconductor — US polysilicon producer; co-monopolist with Wacker.</title></rect>
                                 <text x="432" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Hemlock</text>
 
                                 <line x1="510" y1="628" x2="510" y2="672" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="630" width="220" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="530" y="630" width="220" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>First new commercial US polysilicon greenfield since the IRA. ~$1B, 16,000 MT/year.</title></rect>
                                 <text x="640" y="654" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Highland Materials</text>
                             </g>
 
@@ -158,18 +158,18 @@
                                 <text x="80" y="563" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">2. WAFERS</text>
                                 <text x="80" y="582" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">silicon, GaN, diamond substrates</text>
 
-                                <rect x="270" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="270" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Japanese silicon wafer producer; one of two majors.</title></rect>
                                 <text x="320" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Shin-Etsu</text>
 
-                                <rect x="382" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="382" y="550" width="100" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Japanese silicon wafer producer; co-monopolist with Shin-Etsu.</title></rect>
                                 <text x="432" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SUMCO</text>
 
                                 <line x1="510" y1="548" x2="510" y2="592" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="530" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>MIT spinout (Palacios). Vertical GaN FinFETs on 200mm. $11M seed Oct 2025.</title></rect>
                                 <text x="582" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Vertical Semi</text>
 
-                                <rect x="645" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="645" y="550" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Single-crystal CVD diamond substrate maker. ~$315M raised, €675M Spain plant.</title></rect>
                                 <text x="697" y="574" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Diamond Foundry</text>
                             </g>
 
@@ -179,18 +179,18 @@
                                 <text x="80" y="483" fill="#5b21b6" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">3. LITHOGRAPHY</text>
                                 <text x="80" y="502" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">EUV — the real bottleneck</text>
 
-                                <rect x="270" y="470" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <rect x="270" y="470" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"><title>Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool.</title></rect>
                                 <text x="376" y="495" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">ASML</text>
 
                                 <line x1="510" y1="468" x2="510" y2="512" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <rect x="530" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"><title>James Proud's SF startup. X-ray lithography from custom particle accelerators. $100M at $1B.</title></rect>
                                 <text x="564" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Substrate</text>
 
-                                <rect x="608" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"/>
+                                <rect x="608" y="470" width="68" height="40" rx="4" fill="url(#sem-lg-star)" stroke="#c2410c" stroke-width="2"><title>Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B + $150M CHIPS LOI.</title></rect>
                                 <text x="642" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">xLight</text>
 
-                                <rect x="686" y="470" width="64" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="686" y="470" width="64" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Canon's nanoimprint lithography. Only credible non-EUV alternative shipping today.</title></rect>
                                 <text x="718" y="494" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Canon NIL</text>
                             </g>
 
@@ -200,21 +200,21 @@
                                 <text x="80" y="403" fill="#115e59" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">4. DEPOSITION &amp; ETCH</text>
                                 <text x="80" y="422" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">doping, layers, interconnects</text>
 
-                                <rect x="270" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="270" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Applied Materials — world's largest semi equipment maker.</title></rect>
                                 <text x="303" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AMAT</text>
 
-                                <rect x="344" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="344" y="390" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Lam Research — etch and deposition leader.</title></rect>
                                 <text x="377" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lam</text>
 
-                                <rect x="418" y="390" width="64" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="418" y="390" width="64" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Tokyo Electron — coater/developer and etch leader.</title></rect>
                                 <text x="450" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">TEL</text>
 
                                 <line x1="510" y1="388" x2="510" y2="432" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="530" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A.</title></rect>
                                 <text x="582" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">AlixLabs</text>
 
-                                <rect x="645" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="645" y="390" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Sam Zeloof + Jim Keller. Small fast fabs + tools inside them. ~$15M seed from OpenAI Startup Fund.</title></rect>
                                 <text x="697" y="414" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic Semi</text>
                             </g>
 
@@ -224,15 +224,15 @@
                                 <text x="80" y="323" fill="#6b21a8" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">5. INSPECTION &amp; TEST</text>
                                 <text x="80" y="342" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">defect detection at every step</text>
 
-                                <rect x="270" y="310" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2"/>
+                                <rect x="270" y="310" width="212" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2"><title>Near-monopoly in wafer defect inspection.</title></rect>
                                 <text x="376" y="335" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="16" font-weight="600" text-anchor="middle">KLA</text>
 
                                 <line x1="510" y1="308" x2="510" y2="352" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="530" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Dutch non-destructive 3D AFM metrology. €135M Series C.</title></rect>
                                 <text x="582" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Nearfield</text>
 
-                                <rect x="645" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"/>
+                                <rect x="645" y="310" width="105" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c"><title>Singapore AI overlay on existing fab inspection hardware. At GlobalFoundries + JCET.</title></rect>
                                 <text x="697" y="334" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">SixSense</text>
                             </g>
 
@@ -242,18 +242,18 @@
                                 <text x="80" y="243" fill="#14532d" font-family="JetBrains Mono" font-size="11" letter-spacing="1.5">6. FAB / TAPE OUT</text>
                                 <text x="80" y="262" fill="#78716c" font-family="Aeonik Regular, system-ui" font-size="11">manufacturing at scale</text>
 
-                                <rect x="270" y="230" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"/>
+                                <rect x="270" y="230" width="66" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#fb923c" stroke-width="2.5"><title>Taiwan Semi Manufacturing Co. Manufactures everything at the leading edge.</title></rect>
                                 <text x="303" y="255" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="14" font-weight="600" text-anchor="middle">TSMC</text>
 
-                                <rect x="344" y="230" width="74" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="344" y="230" width="74" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Samsung Foundry. Credible second to TSMC on certain nodes.</title></rect>
                                 <text x="381" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="12" text-anchor="middle">Samsung</text>
 
-                                <rect x="426" y="230" width="56" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"/>
+                                <rect x="426" y="230" width="56" height="40" rx="4" fill="url(#sem-lg-incumbent)" stroke="#162456"><title>Intel Foundry. Rebuilding US leading-edge fab capacity.</title></rect>
                                 <text x="454" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Intel</text>
 
                                 <line x1="510" y1="228" x2="510" y2="272" stroke="#94a3b8" stroke-dasharray="3 3"/>
 
-                                <rect x="530" y="230" width="68" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c" stroke-width="2"/>
+                                <rect x="530" y="230" width="68" height="40" rx="4" fill="url(#sem-lg-chal)" stroke="#c2410c" stroke-width="2"><title>Atomic Semi — Sam Zeloof + Jim Keller. Small-fab-as-a-service.</title></rect>
                                 <text x="564" y="254" fill="#ffffff" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Atomic</text>
 
                                 <text x="650" y="245" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">no startup credibly</text>
@@ -268,16 +268,16 @@
                                 <text x="80" y="170" fill="#64748b" font-family="Aeonik Regular, system-ui" font-size="10">novel compute substrates</text>
                                 <text x="80" y="184" fill="#94a3b8" font-family="Aeonik Regular, system-ui" font-size="9" font-style="italic">chip cos, not picks-and-shovels</text>
 
-                                <rect x="270" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <rect x="270" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Photonic quantum chips at GlobalFoundries Fab 8. $1B Series E at $7B.</title></rect>
                                 <text x="325" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">PsiQuantum</text>
 
-                                <rect x="388" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <rect x="388" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Photonic compute + 3D photonic interposer. ~$822M raised, $4.4B valuation.</title></rect>
                                 <text x="443" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Lightmatter</text>
 
-                                <rect x="506" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <rect x="506" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised.</title></rect>
                                 <text x="561" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Ayar Labs</text>
 
-                                <rect x="624" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"/>
+                                <rect x="624" y="140" width="110" height="40" rx="4" fill="#e2e8f0" stroke="#64748b" stroke-dasharray="3 3"><title>Snowcap Compute — superconducting digital compute on NbTiN at 4.5K. $23M seed.</title></rect>
                                 <text x="679" y="164" fill="#334155" font-family="Aeonik Regular, system-ui" font-size="13" text-anchor="middle">Snowcap</text>
                             </g>
 
@@ -329,7 +329,7 @@
 
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
-                        <p>Two layers drive everything. <strong><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a></strong> in lithography. <strong><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a></strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
+                        <p>Two layers drive everything. <strong title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a></strong> in lithography. <strong title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a></strong> in manufacturing. The other layers have at least two viable competitors. The startup map mirrors that: most challengers cluster around the chokepoints (Substrate and xLight on ASML, Atomic Semi on TSMC at small scale) or attack the EDA software layer, where AI-native design tools can finally close a 30-year-old monopoly.</p>
                     </div>
                 </div>
             </section>
@@ -350,17 +350,17 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.wacker.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wacker Chemie</a></span>
-                                    <span class="sem-pill"><a href="https://www.hscpoly.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Hemlock Semiconductor</a></span>
+                                    <span class="sem-pill" title="German polysilicon producer. One of two majors purifying quartz sand to 99.9999999% pure silicon."><a href="https://www.wacker.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wacker Chemie</a></span>
+                                    <span class="sem-pill" title="US polysilicon producer. Co-monopolist with Wacker on ultra-pure silicon."><a href="https://www.hscpoly.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Hemlock Semiconductor</a></span>
                                 </div>
                                 <p>Quartz sand gets purified into 99.9999999% pure polysilicon, then grown into single-crystal ingots. Two companies dominate, mostly because nobody else wants to operate billion-dollar chemical plants that need decade-long contracts to amortize.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://highlandmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Highland Materials</a></span>
+                                    <span class="sem-pill" title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Highland Materials</a></span>
                                 </div>
-                                <p><strong><a href="https://highlandmaterials.com" target="_blank" rel="noopener">Highland Materials</a></strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
+                                <p><strong title="First new commercial US polysilicon greenfield since the IRA. ~$1B project, 16,000 MT/year."><a href="https://highlandmaterials.com" target="_blank" rel="noopener">Highland Materials</a></strong> (TN) &mdash; first new commercial US polysilicon greenfield since the IRA. $255.6M Section 48C tax credit, ~$1B total project cost, 16,000 MT/year initial capacity targeted for late-2027 operation. Industrial play, not venture-backed.</p>
                             </div>
                         </div>
                     </div>
@@ -374,22 +374,22 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.shinetsu.co.jp/en/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Shin-Etsu</a></span>
-                                    <span class="sem-pill"><a href="https://www.sumcosi.com/english/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SUMCO</a></span>
-                                    <span class="sem-pill"><a href="https://www.wolfspeed.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wolfspeed (SiC)</a></span>
+                                    <span class="sem-pill" title="Japanese silicon wafer producer. One of two majors supplying the discs every chip is etched onto."><a href="https://www.shinetsu.co.jp/en/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Shin-Etsu</a></span>
+                                    <span class="sem-pill" title="Japanese silicon wafer producer. Co-monopolist with Shin-Etsu on 300mm prime wafers."><a href="https://www.sumcosi.com/english/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SUMCO</a></span>
+                                    <span class="sem-pill" title="US silicon carbide wafer maker for power semis. Formerly Cree."><a href="https://www.wolfspeed.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Wolfspeed (SiC)</a></span>
                                 </div>
                                 <p>Two Japanese companies make the silicon discs every chip is etched onto. For specialty wafers (SiC, GaN, diamond), the field opens up.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://verticalsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Vertical Semiconductor</a></span>
-                                    <span class="sem-pill"><a href="https://diamondfoundry.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diamond Foundry</a></span>
-                                    <span class="sem-pill"><a href="https://orbray.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Orbray</a></span>
-                                    <span class="sem-pill"><a href="https://www.innoscience.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Innoscience</a></span>
+                                    <span class="sem-pill" title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Vertical Semiconductor</a></span>
+                                    <span class="sem-pill" title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diamond Foundry</a></span>
+                                    <span class="sem-pill" title="Japanese specialty wafer and diamond substrate maker."><a href="https://orbray.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Orbray</a></span>
+                                    <span class="sem-pill" title="Chinese GaN power semiconductor company. IPO&#x27;d on HKEX."><a href="https://www.innoscience.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Innoscience</a></span>
                                 </div>
-                                <p><strong><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semiconductor</a></strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
-                                <p><strong><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
+                                <p><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semiconductor</a></strong> &mdash; MIT spinout (Tomás Palacios) making vertical GaN FinFETs on 200mm engineered wafers for AI data center power delivery. $11M seed Oct 2025, Playground Global led, Shin-Etsu participated (a notable signal from the incumbent).</p>
+                                <p><strong title="Single-crystal CVD diamond substrate maker. ~$315M raised, €675M plant in Spain."><a href="https://diamondfoundry.com" target="_blank" rel="noopener">Diamond Foundry</a></strong> &mdash; single-crystal CVD diamond substrates; ~$315M total raised, EU-funded €675M plant in Spain. Demonstrated 100mm monocrystalline diamond wafer in 2023.</p>
                             </div>
                         </div>
                     </div>
@@ -403,21 +403,21 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbent</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.asml.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ASML (only EUV maker)</a></span>
+                                    <span class="sem-pill star" title="Dutch company. Makes the only EUV lithography machines on earth. $380M per High-NA tool."><a href="https://www.asml.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ASML (only EUV maker)</a></span>
                                 </div>
                                 <p><a href="https://www.asml.com" target="_blank" rel="noopener">ASML</a> makes the only machines on earth capable of printing features small enough for modern chips. A single High-NA EUV machine costs $380M. Every advanced fab buys from them. There is no second source.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.substrate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Substrate</a></span>
-                                    <span class="sem-pill star"><a href="https://xlight.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
-                                    <span class="sem-pill"><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Canon NIL</a></span>
-                                    <span class="sem-pill"><a href="https://www.inversionsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Inversion Semi</a></span>
+                                    <span class="sem-pill star" title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Substrate</a></span>
+                                    <span class="sem-pill star" title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">xLight</a></span>
+                                    <span class="sem-pill" title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Canon NIL</a></span>
+                                    <span class="sem-pill" title="Lithography-adjacent semiconductor startup."><a href="https://www.inversionsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Inversion Semi</a></span>
                                 </div>
-                                <p><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
-                                <p><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
-                                <p><strong><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener">Canon NIL</a></strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
+                                <p><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; James Proud's SF company; $100M at $1B led by Founders Fund (with General Catalyst, In-Q-Tel). X-ray lithography from custom particle accelerators. Claims 12nm contact arrays demonstrated. First fab targeted 2028. Public skepticism about founder pedigree is real &mdash; price accordingly.</p>
+                                <p><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; Free-electron-laser EUV source. $40M Series B (Playground) plus $150M CHIPS Act LOI signed Dec 2025 &mdash; first Trump-era CRDO award. Pat Gelsinger is executive chairman. CEO Nicholas Kelez is ex-chief engineer of SLAC's LCLS. Lower beta than Substrate; longer timeline.</p>
+                                <p><strong title="Canon&#x27;s nanoimprint lithography. Only credible non-EUV alternative shipping today. 14nm minimum."><a href="https://global.canon/en/product/indtech/semicon/fpa1200nz2c.html" target="_blank" rel="noopener">Canon NIL</a></strong> &mdash; Nanoimprint lithography (not a startup, but the only credible non-EUV alternative shipping today). 14nm minimum linewidth.</p>
                             </div>
                         </div>
                     </div>
@@ -445,20 +445,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.appliedmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Applied Materials</a></span>
-                                    <span class="sem-pill"><a href="https://www.lamresearch.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lam Research</a></span>
-                                    <span class="sem-pill"><a href="https://www.tel.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tokyo Electron</a></span>
+                                    <span class="sem-pill" title="World&#x27;s largest semiconductor equipment maker. Deposition, etch, doping tools."><a href="https://www.appliedmaterials.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Applied Materials</a></span>
+                                    <span class="sem-pill" title="US semiconductor equipment maker. Etch and deposition leader."><a href="https://www.lamresearch.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lam Research</a></span>
+                                    <span class="sem-pill" title="Japanese semiconductor equipment maker. Coater/developer and etch leader."><a href="https://www.tel.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tokyo Electron</a></span>
                                 </div>
                                 <p>Three companies make 80% of the tools that lay down metal layers, etch patterns, and dope silicon. Healthy three-way competition keeps prices roughly honest.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.alixlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">AlixLabs</a></span>
-                                    <span class="sem-pill"><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                    <span class="sem-pill" title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">AlixLabs</a></span>
+                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
                                 </div>
-                                <p><strong><a href="https://www.alixlabs.com" target="_blank" rel="noopener">AlixLabs</a></strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
-                                <p><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
+                                <p><strong title="Swedish startup. Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG."><a href="https://www.alixlabs.com" target="_blank" rel="noopener">AlixLabs</a></strong> (Sweden) &mdash; Atomic Layer Etching Pitch Splitting. €15M Series A. MoU with VDL ETG for industrialization. Lets fabs hit advanced nodes without exclusive reliance on EUV.</p>
+                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Sam Zeloof + Jim Keller, ~60 engineers in SF building small, fast fabs and the tools inside them. OpenAI Startup Fund led a ~$15M seed at $100M valuation. Berkeley BWRC talk Nov 2025 signals they're emerging from stealth.</p>
                             </div>
                         </div>
                     </div>
@@ -472,20 +472,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbent</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.kla.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">KLA</a></span>
+                                    <span class="sem-pill star" title="Near-monopoly in wafer defect inspection."><a href="https://www.kla.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">KLA</a></span>
                                 </div>
                                 <p>KLA owns wafer inspection. Lasertec owns EUV mask inspection. Both are near-monopolies in their slices.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Nearfield Instruments</a></span>
-                                    <span class="sem-pill"><a href="https://www.sixsense.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SixSense</a></span>
-                                    <span class="sem-pill"><a href="https://euqlid.io" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">EuQlid</a></span>
+                                    <span class="sem-pill" title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Nearfield Instruments</a></span>
+                                    <span class="sem-pill" title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SixSense</a></span>
+                                    <span class="sem-pill" title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">EuQlid</a></span>
                                 </div>
-                                <p><strong><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
-                                <p><strong><a href="https://www.sixsense.ai" target="_blank" rel="noopener">SixSense</a></strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
-                                <p><strong><a href="https://euqlid.io" target="_blank" rel="noopener">EuQlid</a></strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
+                                <p><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> (NL) &mdash; non-destructive 3D AFM metrology. €135M Series C led by Walden Catalyst + Temasek. In HVM at a top-5 fab.</p>
+                                <p><strong title="Singapore AI overlay on existing fab inspection hardware. Deployed at GlobalFoundries and JCET."><a href="https://www.sixsense.ai" target="_blank" rel="noopener">SixSense</a></strong> (SG) &mdash; AI software overlay on existing AOI hardware. $8.5M Series A. Deployed at GlobalFoundries and JCET. Customer-reported 30% cycle time improvement.</p>
+                                <p><strong title="Quantum diamond magnetometry for current-flow mapping inside CPUs, GPUs, and HBM."><a href="https://euqlid.io" target="_blank" rel="noopener">EuQlid</a></strong> &mdash; quantum diamond magnetometry for current-flow mapping inside CPUs/GPUs/HBM. Emerged Q4 2025.</p>
                             </div>
                         </div>
                     </div>
@@ -499,18 +499,18 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.tsmc.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
-                                    <span class="sem-pill"><a href="https://semiconductor.samsung.com/foundry/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Samsung</a></span>
-                                    <span class="sem-pill"><a href="https://www.intel.com/content/www/us/en/foundry/overview.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Intel</a></span>
+                                    <span class="sem-pill star" title="Taiwan Semiconductor Manufacturing Company. Manufactures everything at the leading edge."><a href="https://www.tsmc.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">TSMC</a></span>
+                                    <span class="sem-pill" title="Samsung Foundry. Credible second to TSMC on certain nodes."><a href="https://semiconductor.samsung.com/foundry/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Samsung</a></span>
+                                    <span class="sem-pill" title="Intel Foundry. Rebuilding US leading-edge fab capacity."><a href="https://www.intel.com/content/www/us/en/foundry/overview.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Intel</a></span>
                                 </div>
                                 <p><a href="https://www.tsmc.com" target="_blank" rel="noopener">TSMC</a> manufactures everything at the leading edge. Samsung is a credible second on certain nodes. Intel is rebuilding. If TSMC stops, the AI industry stops.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
+                                    <span class="sem-pill" title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Atomic Semi</a></span>
                                 </div>
-                                <p><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; small-fab-as-a-service. The bet is that the future has many smaller specialized fabs, not three giant ones. Currently the only startup credibly working on the fab problem, and only at sub-300mm scale.</p>
+                                <p><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; small-fab-as-a-service. The bet is that the future has many smaller specialized fabs, not three giant ones. Currently the only startup credibly working on the fab problem, and only at sub-300mm scale.</p>
                                 <div class="sem-layer-note">No startup is credibly challenging TSMC at leading-edge nodes. The fab layer remains the most monopolized and the most capital-intensive in the stack.</div>
                             </div>
                         </div>
@@ -524,20 +524,20 @@
 
                         <div class="sem-adjacent-grid">
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill"><a href="https://psiquantum.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">PsiQuantum</a></span>
-                                <p><strong><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; photonic quantum chips manufactured at GlobalFoundries Fab 8 (Malta, NY). $1B Series E at $7B (Sep 2025). Customer of the fab layer.</p>
+                                <span class="sem-pill" title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">PsiQuantum</a></span>
+                                <p><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; photonic quantum chips manufactured at GlobalFoundries Fab 8 (Malta, NY). $1B Series E at $7B (Sep 2025). Customer of the fab layer.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill"><a href="https://lightmatter.co" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lightmatter</a></span>
-                                <p><strong><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> &mdash; photonic compute (Envise) and 3D photonic interposer (Passage L200, 200+ Tbps). ~$822M raised, $4.4B valuation. Fabless. Manufacturing at GlobalFoundries.</p>
+                                <span class="sem-pill" title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Lightmatter</a></span>
+                                <p><strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> &mdash; photonic compute (Envise) and 3D photonic interposer (Passage L200, 200+ Tbps). ~$822M raised, $4.4B valuation. Fabless. Manufacturing at GlobalFoundries.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill"><a href="https://ayarlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ayar Labs</a></span>
-                                <p><strong><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
+                                <span class="sem-pill" title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ayar Labs</a></span>
+                                <p><strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> &mdash; optical I/O chiplets (TeraPHY, SuperNova). ~$500M raised. Fabless. The packaging story for GPU clusters with more I/O than copper can support.</p>
                             </div>
                             <div class="sem-adjacent-cell">
-                                <span class="sem-pill"><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Snowcap Compute</a></span>
-                                <p><strong><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
+                                <span class="sem-pill" title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Snowcap Compute</a></span>
+                                <p><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting digital compute (Josephson junctions at 4.5K, niobium titanium nitride on 300mm). $23M seed Jun 2025, Playground Global led. Pat Gelsinger as board chair. First chip end of 2026.</p>
                             </div>
                         </div>
                     </div>
@@ -545,7 +545,7 @@
                     <div class="sem-pov">
                         <span class="sem-pov-label">Canonical POV</span>
                         <p>The fab layer is structurally the hardest to disrupt and the most capital-intensive to attempt. We don't expect a credible TSMC challenger to emerge at the leading edge in the next decade &mdash; Atomic Semi at sub-300mm scale is as close as it gets, and that's a different market.</p>
-                        <p>The more investable thesis sits one layer up: <strong><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> and <strong><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
+                        <p>The more investable thesis sits one layer up: <strong title="Photonic compute (Envise) plus 3D photonic interposer (Passage L200). ~$822M raised, $4.4B valuation."><a href="https://lightmatter.co" target="_blank" rel="noopener">Lightmatter</a></strong> and <strong title="Optical I/O chiplets (TeraPHY, SuperNova) for GPU clusters. ~$500M raised."><a href="https://ayarlabs.com" target="_blank" rel="noopener">Ayar Labs</a></strong> are moving the unit of computation from the chip to the package. If "the chip" becomes "the interposer," advanced packaging &mdash; CoWoS, photonic, optical I/O &mdash; becomes the new bottleneck, and the picks-and-shovels opportunity moves with it. These are adjacent bets, not stack-layer bets, but they're some of the most interesting ones we're tracking.</p>
                     </div>
                 </div>
             </section>
@@ -566,20 +566,20 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.synopsys.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys</a></span>
-                                    <span class="sem-pill"><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence</a></span>
-                                    <span class="sem-pill"><a href="https://eda.sw.siemens.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens EDA</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Largest by revenue."><a href="https://www.synopsys.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Acquired ChipStack Nov 2025."><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence</a></span>
+                                    <span class="sem-pill" title="Big-Three EDA incumbent. Formerly Mentor Graphics."><a href="https://eda.sw.siemens.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens EDA</a></span>
                                 </div>
                                 <p>The Big Three. ~75% market share. All three have launched in-house AI products (Synopsys.ai, Cadence Cerebrus, Calibre.AI) but their architecture is bolt-on, not native.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.ricursive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ricursive Intelligence</a></span>
-                                    <span class="sem-pill star"><a href="https://cognichip.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
+                                    <span class="sem-pill star" title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Ricursive Intelligence</a></span>
+                                    <span class="sem-pill star" title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cognichip</a></span>
                                 </div>
-                                <p><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
-                                <p><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
+                                <p><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; co-founded by Anna Goldie and Azalia Mirhoseini, the AlphaChip authors. $300M Series A at <strong>$4B post-money</strong>, Lightspeed led, with Sequoia, DST, NVentures. $335M total. Highest-priced startup in the entire EDA-disruptor cohort.</p>
+                                <p><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; $93M total ($60M Series A Apr 2026, $33M seed May 2025). Lip-Bu Tan on the board. Physics-informed foundation model branded ACI®. 30+ semiconductor customers engaged, claims ~75% cost reduction in chip development.</p>
                             </div>
                         </div>
                     </div>
@@ -593,21 +593,21 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.synopsys.com/verification/simulation/vcs.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys VCS</a></span>
-                                    <span class="sem-pill"><a href="https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Xcelium</a></span>
-                                    <span class="sem-pill"><a href="https://eda.sw.siemens.com/en-US/ic/questa/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens Questa</a></span>
+                                    <span class="sem-pill" title="Synopsys&#x27;s verification simulator. One of the big-three sim platforms."><a href="https://www.synopsys.com/verification/simulation/vcs.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys VCS</a></span>
+                                    <span class="sem-pill" title="Cadence&#x27;s verification simulator."><a href="https://www.cadence.com/en_US/home/tools/system-design-and-verification/simulation-and-testbench-verification/xcelium-simulator.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Xcelium</a></span>
+                                    <span class="sem-pill" title="Siemens&#x27;s verification platform. Formerly Mentor."><a href="https://eda.sw.siemens.com/en-US/ic/questa/" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Siemens Questa</a></span>
                                 </div>
                                 <p>Verification is the most expensive and time-consuming part of chip design. Often 70% of total engineering hours. Ripe for automation.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://chipagents.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
-                                    <span class="sem-pill"><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipStack (acq.)</a></span>
-                                    <span class="sem-pill"><a href="https://www.silimate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Silimate</a></span>
+                                    <span class="sem-pill star" title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipAgents</a></span>
+                                    <span class="sem-pill" title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">ChipStack (acq.)</a></span>
+                                    <span class="sem-pill" title="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Silimate</a></span>
                                 </div>
-                                <p><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
-                                <p><strong><a href="https://www.cadence.com" target="_blank" rel="noopener">ChipStack</a></strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
+                                <p><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; UCSB professor William Wang, founded June 2024. $74M total ($50M Series A1 led by Matter Venture Partners, TSMC-backed). 140x YoY ARR growth, deployed at 80 semiconductor companies. Advisory board includes ex-CEOs of Mentor, Cadence, and the former Synopsys CTO.</p>
+                                <p><strong title="Acquired by Cadence Nov 2025, relaunched as Cadence ChipStack AI Super Agent."><a href="https://www.cadence.com" target="_blank" rel="noopener">ChipStack</a></strong> &mdash; acquired by Cadence in November 2025, relaunched as the "Cadence ChipStack AI Super Agent." The canary. More acquisitions coming.</p>
                             </div>
                         </div>
                     </div>
@@ -621,24 +621,24 @@
                             <div class="sem-layer-col incumbent">
                                 <h4>Incumbents</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill"><a href="https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Virtuoso</a></span>
-                                    <span class="sem-pill"><a href="https://www.arm.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Arm</a></span>
-                                    <span class="sem-pill"><a href="https://www.synopsys.com/designware-ip.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys IP</a></span>
+                                    <span class="sem-pill" title="Cadence&#x27;s 30-year-old analog layout tool. Near-monopoly."><a href="https://www.cadence.com/en_US/home/tools/custom-ic-analog-rf-design.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Cadence Virtuoso</a></span>
+                                    <span class="sem-pill" title="Mobile and embedded CPU IP licensing."><a href="https://www.arm.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Arm</a></span>
+                                    <span class="sem-pill" title="Synopsys&#x27;s IP licensing business. Formerly DesignWare."><a href="https://www.synopsys.com/designware-ip.html" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Synopsys IP</a></span>
                                 </div>
                                 <p>Virtuoso has owned analog layout for 30 years with effectively no competition. Arm has owned mobile cores for nearly as long.</p>
                             </div>
                             <div class="sem-layer-col challenger">
                                 <h4>Challengers</h4>
                                 <div class="sem-pill-row">
-                                    <span class="sem-pill star"><a href="https://www.quilter.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
-                                    <span class="sem-pill"><a href="https://www.astrus.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Astrus</a></span>
-                                    <span class="sem-pill"><a href="https://www.diode.computer" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diode</a></span>
-                                    <span class="sem-pill star"><a href="https://tenstorrent.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
-                                    <span class="sem-pill"><a href="https://sifive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
+                                    <span class="sem-pill star" title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Quilter</a></span>
+                                    <span class="sem-pill" title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Astrus</a></span>
+                                    <span class="sem-pill" title="PCB-as-code."><a href="https://www.diode.computer" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Diode</a></span>
+                                    <span class="sem-pill star" title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">Tenstorrent</a></span>
+                                    <span class="sem-pill" title="RISC-V CPU IP cores."><a href="https://sifive.com" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">SiFive</a></span>
                                 </div>
-                                <p><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
-                                <p><strong><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
-                                <p><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
+                                <p><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; physics-driven RL for PCB layout. $40M raised (Benchmark + Index). "Project Speedrun" booted an 843-component Linux computer on first try after one week of AI-driven design.</p>
+                                <p><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> (Toronto) &mdash; AlphaZero-style RL for analog SerDes layout. $8M USD seed led by Khosla. Founders trained by an AlphaGo advisor.</p>
+                                <p><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Jim Keller. Raising at a reported $3.2B pre-money (Fidelity-led, per The Information Nov 2025). RISC-V CPU IP with full RTL source-code access &mdash; a direct Arm challenge.</p>
                             </div>
                         </div>
                     </div>
@@ -662,10 +662,10 @@
                             <span class="sem-tier-num">Tier 1 &middot; High conviction</span>
                             <h4>Software speed of light</h4>
                             <ul>
-                                <li><strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
-                                <li><strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
-                                <li><strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
-                                <li><strong><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
+                                <li><strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong> &mdash; AlphaChip team, $4B mark, hard to access.</li>
+                                <li><strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> &mdash; credible alternative at a fraction of the price. Lip-Bu Tan on board.</li>
+                                <li><strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong> &mdash; clearest revenue traction in agentic verification.</li>
+                                <li><strong title="Physics-driven RL for PCB layout. $40M raised (Benchmark + Index). Tony Fadell signal."><a href="https://www.quilter.ai" target="_blank" rel="noopener">Quilter</a></strong> &mdash; Tony Fadell signal, Benchmark/Index/Coatue stack. Shipped real hardware.</li>
                             </ul>
                         </div>
 
@@ -673,10 +673,10 @@
                             <span class="sem-tier-num">Tier 2 &middot; Capital-heavy moonshots</span>
                             <h4>Underwrite like deep tech</h4>
                             <ul>
-                                <li><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
-                                <li><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
-                                <li><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
-                                <li><strong><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semi</a></strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
+                                <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> &mdash; X-ray litho. High beta. Diligence the team beyond Proud.</li>
+                                <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> &mdash; FEL-EUV source. Lower beta. Long hold (10 years).</li>
+                                <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> &mdash; Zeloof + Keller. Wait for first paying fab customer.</li>
+                                <li><strong title="MIT spinout (Palacios). Vertical GaN FinFETs on 200mm wafers. $11M seed Oct 2025, Playground Global led."><a href="https://verticalsemi.com" target="_blank" rel="noopener">Vertical Semi</a></strong> &mdash; MIT GaN-on-Si. Shin-Etsu validation at seed.</li>
                             </ul>
                         </div>
 
@@ -684,12 +684,12 @@
                             <span class="sem-tier-num">Tier 3 &middot; Watch list</span>
                             <h4>Earlier, narrower, or both</h4>
                             <ul>
-                                <li><strong><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> &mdash; analog layout RL.</li>
-                                <li><strong><a href="https://www.diode.computer" target="_blank" rel="noopener">Diode Computers</a></strong> &mdash; PCB-as-code.</li>
-                                <li><strong><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> &mdash; late-stage metrology.</li>
-                                <li><strong><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting compute.</li>
-                                <li><strong><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
-                                <li><strong><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
+                                <li><strong title="Toronto. AlphaZero-style RL for analog SerDes layout. $8M seed from Khosla."><a href="https://www.astrus.ai" target="_blank" rel="noopener">Astrus</a></strong> &mdash; analog layout RL.</li>
+                                <li><strong title="PCB-as-code."><a href="https://www.diode.computer" target="_blank" rel="noopener">Diode Computers</a></strong> &mdash; PCB-as-code.</li>
+                                <li><strong title="Dutch non-destructive 3D AFM metrology. €135M Series C from Walden Catalyst and Temasek."><a href="https://www.nearfieldinstruments.com" target="_blank" rel="noopener">Nearfield Instruments</a></strong> &mdash; late-stage metrology.</li>
+                                <li><strong title="Superconducting digital compute on NbTiN at 4.5K. Pat Gelsinger board chair. $23M seed."><a href="https://www.snowcapcompute.com" target="_blank" rel="noopener">Snowcap Compute</a></strong> &mdash; superconducting compute.</li>
+                                <li><strong title="Jim Keller. RISC-V CPU IP with full RTL source-code access. Reported $3.2B pre-money."><a href="https://tenstorrent.com" target="_blank" rel="noopener">Tenstorrent</a></strong> &mdash; Arm-IP disruption pure-play.</li>
+                                <li><strong title="Photonic quantum chips manufactured at GlobalFoundries Fab 8. $1B Series E at $7B."><a href="https://psiquantum.com" target="_blank" rel="noopener">PsiQuantum</a></strong> &mdash; secondary access if available.</li>
                             </ul>
                         </div>
                     </div>
@@ -697,11 +697,11 @@
                     <div class="sem-benchmarks">
                         <h4>Benchmarks that would change the thesis</h4>
                         <ul>
-                            <li>Synopsys or Siemens acquires <strong><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong>, <strong><a href="https://www.silimate.com" target="_blank" rel="noopener">Silimate</a></strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
-                            <li>First full-stack chip tape-out designed end-to-end by <strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive</a></strong> or <strong><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> → re-rates the entire AI-EDA category upward.</li>
-                            <li><strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
-                            <li><strong><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
-                            <li><strong><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
+                            <li>Synopsys or Siemens acquires <strong title="UCSB prof. William Wang. $74M total. 140x YoY ARR. Deployed at 80 chip companies."><a href="https://chipagents.ai" target="_blank" rel="noopener">ChipAgents</a></strong>, <strong title="AI for EDA signoff (DRC/LVS)."><a href="https://www.silimate.com" target="_blank" rel="noopener">Silimate</a></strong>, or another verification copilot in 2026 → category enters consolidation phase; only platform-scale plays survive.</li>
+                            <li>First full-stack chip tape-out designed end-to-end by <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive</a></strong> or <strong title="Physics-informed foundation model for chip design (ACI). $93M total. Lip-Bu Tan on board."><a href="https://cognichip.ai" target="_blank" rel="noopener">Cognichip</a></strong> → re-rates the entire AI-EDA category upward.</li>
+                            <li><strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> demonstrates a third-party-verified sub-10nm working die from X-ray lithography → moves from speculative to Tier 1.</li>
+                            <li><strong title="Free-electron-laser EUV source. Pat Gelsinger chairman. $40M Series B plus $150M CHIPS LOI."><a href="https://xlight.com" target="_blank" rel="noopener">xLight</a></strong> CHIPS LOI converts to binding award, OR a scanner OEM agrees to integrate the FEL source → de-risks materially.</li>
+                            <li><strong title="Sam Zeloof + Jim Keller. Building small fast fabs and the tools inside them. ~$15M seed from OpenAI Startup Fund."><a href="https://atomicsemi.com" target="_blank" rel="noopener">Atomic Semi</a></strong> announces a named paying fab customer beyond itself → unblocks the commercial thesis.</li>
                         </ul>
                     </div>
 
@@ -731,7 +731,7 @@
                         <div class="sem-method-col">
                             <h3>Known caveats</h3>
                             <ul class="sem-method-list">
-                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong>, not "Recursive." The lithography company is <strong><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
+                                <li><span class="sem-method-k">Spelling</span><span class="sem-method-v">The AI-EDA company is <strong title="AlphaChip authors Goldie + Mirhoseini. $300M Series A at $4B post-money, Lightspeed led."><a href="https://www.ricursive.com" target="_blank" rel="noopener">Ricursive Intelligence</a></strong>, not "Recursive." The lithography company is <strong title="James Proud&#x27;s SF startup. X-ray lithography from custom particle accelerators. $100M at $1B, Founders Fund led."><a href="https://www.substrate.com" target="_blank" rel="noopener">Substrate</a></strong> (James Proud's SF company), distinct from any other entity by that name.</span></li>
                                 <li><span class="sem-method-k">Substrate</span><span class="sem-method-v">Technical claims (12nm contact arrays, $10K-per-wafer) come from the company itself. Independent analysts (Fox Chapel Research, summarized in Tom's Hardware) have publicly questioned founder pedigree and the credibility of the demonstrations. Treat accordingly.</span></li>
                                 <li><span class="sem-method-k">Atomic Semi</span><span class="sem-method-v">Valuation ($100M) and seed size (~$15M) come from a January 2023 TechCrunch report citing unnamed sources. The 60-engineer team count is current as of Nov 2025 (Berkeley BWRC). A follow-on round has likely closed but is not public.</span></li>
                                 <li><span class="sem-method-k">Tenstorrent</span><span class="sem-method-v">The reported $3.2B pre-money Fidelity round comes from The Information citing two people with knowledge of the talks. Confirm terms directly before underwriting.</span></li>

--- a/labs/semiconductor-silicon-stack/lab.css
+++ b/labs/semiconductor-silicon-stack/lab.css
@@ -392,18 +392,58 @@
     letter-spacing: 0.02em;
     transition: background 0.15s, border-color 0.15s;
 }
-.sem-pill[title] { cursor: help; }
-.sem-pill[title]:hover { background: rgba(15, 23, 42, 0.06); border-color: var(--sem-ink-faint); }
-.sem-layer-col.challenger .sem-pill[title]:hover {
+.sem-pill[data-tip] { cursor: pointer; }
+.sem-pill[data-tip]:hover { background: rgba(15, 23, 42, 0.06); border-color: var(--sem-ink-faint); }
+.sem-layer-col.challenger .sem-pill[data-tip]:hover {
     background: rgba(249, 115, 22, 0.12);
     border-color: var(--sem-accent);
 }
-strong[title] {
-    cursor: help;
+strong[data-tip] {
+    cursor: pointer;
     text-decoration: underline dotted rgba(30, 58, 138, 0.4);
     text-underline-offset: 3px;
 }
-strong[title]:hover { text-decoration-color: var(--sem-accent); }
+strong[data-tip]:hover { text-decoration-color: var(--sem-accent); }
+
+/* ============ SVG DIAGRAM LINKS ============ */
+.sem-svg-link { cursor: pointer; transition: filter 0.15s ease, transform 0.15s ease; transform-box: fill-box; transform-origin: center; }
+.sem-svg-link:hover { filter: drop-shadow(0 0 8px rgba(249, 115, 22, 0.6)); }
+.sem-svg-link:hover rect { stroke: var(--sem-accent); stroke-width: 2.5px; }
+.sem-svg-link:focus { outline: none; }
+.sem-svg-link:focus-visible rect { stroke: var(--sem-accent); stroke-width: 3px; }
+
+/* ============ CUSTOM TOOLTIP OVERLAY ============ */
+.sem-tooltip {
+    position: fixed;
+    pointer-events: none;
+    background: rgba(10, 14, 26, 0.97);
+    color: #ffffff;
+    border: 1px solid rgba(249, 115, 22, 0.45);
+    border-radius: 0.45rem;
+    padding: 0.65rem 0.85rem;
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    max-width: 320px;
+    z-index: 200;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.12s ease;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+    letter-spacing: 0.005em;
+}
+.sem-tooltip.show { opacity: 1; visibility: visible; }
+.sem-tooltip-hint {
+    display: block;
+    margin-top: 0.4rem;
+    padding-top: 0.4rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    font-family: var(--sem-mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--sem-accent-soft);
+}
 .sem-layer-col.challenger .sem-pill {
     border-color: rgba(249, 115, 22, 0.4);
     background: rgba(249, 115, 22, 0.06);

--- a/labs/semiconductor-silicon-stack/lab.css
+++ b/labs/semiconductor-silicon-stack/lab.css
@@ -390,7 +390,20 @@
     color: var(--sem-ink-soft);
     background: rgba(15, 23, 42, 0.02);
     letter-spacing: 0.02em;
+    transition: background 0.15s, border-color 0.15s;
 }
+.sem-pill[title] { cursor: help; }
+.sem-pill[title]:hover { background: rgba(15, 23, 42, 0.06); border-color: var(--sem-ink-faint); }
+.sem-layer-col.challenger .sem-pill[title]:hover {
+    background: rgba(249, 115, 22, 0.12);
+    border-color: var(--sem-accent);
+}
+strong[title] {
+    cursor: help;
+    text-decoration: underline dotted rgba(30, 58, 138, 0.4);
+    text-underline-offset: 3px;
+}
+strong[title]:hover { text-decoration-color: var(--sem-accent); }
 .sem-layer-col.challenger .sem-pill {
     border-color: rgba(249, 115, 22, 0.4);
     background: rgba(249, 115, 22, 0.06);


### PR DESCRIPTION
Follow-up to #20. Three commits that complete the semiconductor stack page after the initial merge.

## Summary

- **Complete the company backlink coverage** ([22ac920](https://github.com/anandiyer/anandiyer.github.io/commit/22ac920)) — wraps every pill and every linked `<strong>` mention in an outbound link to the company's official site. Adds links for the incumbents that were previously plain text (Wacker, Hemlock, Shin-Etsu, SUMCO, Wolfspeed, AMAT, Lam, TEL, KLA, Samsung Foundry, Intel Foundry, Synopsys, Cadence, Siemens EDA, Arm, Canon NIL, and the specific verification/IP product pages) and all startup challengers (Highland Materials, Vertical Semi, Orbray, Innoscience, Substrate, Inversion Semi, AlixLabs, Nearfield, SixSense, EuQlid, Silimate, Ricursive, Astrus, Diode, Snowcap). Total external links: 20 → 101.
- **Hover tooltips on every linked company** ([86a09c6](https://github.com/anandiyer/anandiyer.github.io/commit/86a09c6)) — 51 pill tooltips + 51 strong-tag tooltips + 27 SVG box tooltips. Native HTML/SVG `title` element, zero JS. CSS affordances: `cursor:help`, hover background shift on pills, dotted underline on linked strongs.
- **Clickable SVG boxes + styled overlay tooltip + referrer tag** ([6ffe370](https://github.com/anandiyer/anandiyer.github.io/commit/6ffe370)) — wraps each of the 27 SVG company boxes in an `<a target="_blank" rel="noopener">` so clicking opens the company's site in a new tab. Adds `?ref=canonicalcc` to every external company URL (108 hrefs across pills, strongs, SVG anchors, and CTAs; internal canonical.cc / mailto / x.com / Substack URLs are excluded). Replaces the plain native browser tooltip with a styled JS overlay that follows the cursor, shows a "click → opens site" hint for clickable elements, and clips to the viewport. Native `title` attributes retained as a JS-disabled fallback and as the SVG screen-reader label.

## Files

- `labs/semiconductor-silicon-stack/index.html` — pill links, strong-tag links, SVG anchor wrappers, `?ref=canonicalcc` everywhere, `data-tip` attributes, inline tooltip script
- `labs/semiconductor-silicon-stack/lab.css` — `.sem-svg-link` hover (orange glow + stroke), `.sem-tooltip` overlay styling, `cursor:pointer` on tooltipped elements

## Test plan

- [ ] Visit `/labs/semiconductor-silicon-stack/` and confirm the stack diagram renders with all 27 company boxes
- [ ] Hover a company in the diagram — styled tooltip should appear instantly near the cursor with a "click → opens site" hint
- [ ] Click any SVG company box — should open the company's site in a new tab with `?ref=canonicalcc` in the URL
- [ ] Hover a pill (e.g., "Ricursive Intelligence") in any layer panel — same styled tooltip should appear
- [ ] Hover a linked `<strong>` mention in prose (e.g., **Atomic Semi** in the benchmarks) — styled tooltip appears, dotted underline visible
- [ ] Spot-check a few external links resolve (Substrate → www.substrate.com, xLight → xlight.com, Cognichip → cognichip.ai)
- [ ] Confirm canonical.cc internal links (Physical AI Map cross-references, Portfolio, Substack, X) are NOT tagged with `?ref=canonicalcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)