### PR TITLE
Footer: drop "Crypto" from copyright line

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
     <div class="container mx-auto px-8">
         <div class="flex flex-col md:flex-row justify-between items-center">
             <p class="footer-text">
-                &copy; 2025 Canonical Crypto. All rights reserved.
+                &copy; 2025 Canonical. All rights reserved.
             </p>
             <div class="flex items-center space-x-6 mt-4 md:mt-0">
                 <a href="https://x.com/canonicalcc" target="_blank" rel="noopener noreferrer" class="footer-link">


### PR DESCRIPTION
## Summary

- The shared `_includes/footer.html` had `© 2025 Canonical Crypto. All rights reserved.` — stale brand. Everywhere else the firm operates as "Canonical".
- This was the only remaining `Canonical Crypto` reference in tracked source.

## Test plan

- [ ] After deploy, footer on any canonical.cc page reads "© 2025 Canonical. All rights reserved."
- [ ] No other affected copy (the X handle and Substack URL are unchanged: `canonicalcc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)