### PR TITLE
Widen fundmodeler container to match other labs

### DIFF
--- a/labs/fundmodeler/src/App.tsx
+++ b/labs/fundmodeler/src/App.tsx
@@ -14,7 +14,7 @@ function App() {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1 w-full max-w-4xl mx-auto px-6 sm:px-10 pt-28 sm:pt-32 pb-24">
+      <main className="flex-1 w-full max-w-7xl mx-auto px-6 sm:px-8 pt-28 sm:pt-32 pb-24">
         <div className="flex items-baseline justify-between gap-4 mb-8">
           <div
             className="text-xs uppercase tracking-[0.18em] text-white/55"


### PR DESCRIPTION
## Summary

Fundmodeler's main was constrained to `max-w-4xl` (896px). The other labs (dilutionlab, power-law) use the canonical `.container` width of 1280px. On a wide screen the fundmodeler's outcomes table was visibly cramped (6 columns squeezed into ~800px usable width) and the page had a lot of unused navy on each side, making it look inconsistent with the rest of the site.

- `max-w-4xl` → `max-w-7xl` (1280px), matching `.container` in canonical's stylesheet.
- Tightened horizontal padding from `px-6 sm:px-10` to `px-6 sm:px-8` to match canonical's `px-8` convention.

## Test plan

- [ ] `canonical.cc/labs/fundmodeler/` content area is visually the same width as `/labs/dilutionlab/` and `/labs/power-law/`.
- [ ] Outcomes table (Bucket / Share / Multiple / Exit / Capital / Returns) columns have comfortable spacing — no overlap, inputs not cramped.
- [ ] Hero text + KPI row + J-curve chart still look right at the wider width.
- [ ] On mobile (≤640px) the layout still wraps cleanly — Tailwind's `max-w-7xl` only constrains at large viewports, so narrow screens behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)