### PR TITLE
Render canonical site footer on fundmodeler

### DIFF
--- a/labs/fundmodeler/src/App.tsx
+++ b/labs/fundmodeler/src/App.tsx
@@ -1,4 +1,5 @@
 import { Header } from "./components/Header";
+import { Footer } from "./components/Footer";
 import { Hero } from "./components/Hero";
 import { KpiRow } from "./components/KpiRow";
 import { JCurveChart } from "./components/JCurveChart";
@@ -83,7 +84,7 @@ function App() {
           />
         </div>
 
-        <footer className="mt-16 pt-8 border-t border-white/15 text-xs text-white/65 flex flex-col sm:flex-row sm:justify-between gap-2">
+        <div className="mt-16 pt-8 border-t border-white/15 text-xs text-white/65 flex flex-col sm:flex-row sm:justify-between gap-2">
           <div>
             Built by{" "}
             <a
@@ -100,8 +101,9 @@ function App() {
             Scenarios live in your browser. Share via link — nothing leaves your
             device.
           </div>
-        </footer>
+        </div>
       </main>
+      <Footer />
     </div>
   );
 }

--- a/labs/fundmodeler/src/components/Footer.tsx
+++ b/labs/fundmodeler/src/components/Footer.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useRef, useState } from "react";
+
+export function Footer() {
+  const [html, setHtml] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch("/partials/footer.html", { cache: "no-store" })
+      .then((r) => r.text())
+      .then(setHtml)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!html || !ref.current) return;
+    ref.current.querySelectorAll("script").forEach((oldScript) => {
+      const next = document.createElement("script");
+      Array.from(oldScript.attributes).forEach((a) =>
+        next.setAttribute(a.name, a.value),
+      );
+      next.text = oldScript.textContent || "";
+      oldScript.parentNode?.replaceChild(next, oldScript);
+    });
+  }, [html]);
+
+  return <div ref={ref} dangerouslySetInnerHTML={{ __html: html }} />;
+}

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,4 @@
+---
+permalink: /partials/footer.html
+---
+{% include footer.html %}


### PR DESCRIPTION
## Summary

The shared canonical footer (© line + X/Substack links) was missing from `canonical.cc/labs/fundmodeler/`. Other labs include it via Jekyll's `{% include footer.html %}`, but the SPA had no equivalent — `Header.tsx` already runtime-fetches the canonical nav partial, but there was no Footer counterpart.

- **`partials/footer.html`**: new Jekyll page mirroring the existing `partials/header.html` so the SPA can fetch `/partials/footer.html` same-origin.
- **`Footer.tsx`**: new component, same pattern as `Header.tsx` (fetch + `dangerouslySetInnerHTML` + script-tag re-bind).
- **`App.tsx`**: render `<Footer />` below the existing inline lab-specific footer notes (kept those — they're fundmodeler-specific copy about scenarios living in your browser, not brand boilerplate).

## Test plan

- [ ] Canonical site footer appears at the bottom of `canonical.cc/labs/fundmodeler/`: "© 2025 Canonical. All rights reserved." + "Canonical on X" + "Canonical on Substack".
- [ ] Lab-specific inline footer ("Built by Canonical. Free for any fund manager." + "Scenarios live in your browser...") still appears above it.
- [ ] Footer styling matches the other labs visually (full-width navy band, centered content).
- [ ] Mobile layout still wraps cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)