### PR TITLE
Add Lookalike Finder lab

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,6 +16,7 @@
                         <a href="https://canonical.cc/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
                         <a href="https://canonical.cc/physical-ai-robotics/" class="nav-dropdown-item" role="menuitem">Physical AI &amp; Robotics</a>
                         <a href="https://canonical.cc/labs/semiconductor-silicon-stack/" class="nav-dropdown-item" role="menuitem">Semiconductor Stack</a>
+                        <a href="https://canonical.cc/labs/lookalike/" class="nav-dropdown-item" role="menuitem">Lookalike Finder</a>
                     </div>
                 </div>
                 <a href="https://canonical.cc/#team" class="nav-link" data-canonical-anchor="team">TEAM</a>

--- a/index.html
+++ b/index.html
@@ -244,6 +244,13 @@
                                 </p>
                                 <span class="lab-card-cta">Try it &rarr;</span>
                             </a>
+                            <a href="/labs/lookalike/" class="lab-card flex-shrink-0">
+                                <h3 class="lab-card-title">Lookalike Finder</h3>
+                                <p class="lab-card-description">
+                                    Paste a LinkedIn URL or X handle and find people with the same career DNA — trajectory and archetype, not just job title.
+                                </p>
+                                <span class="lab-card-cta">Try it &rarr;</span>
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/labs/lookalike/app.js
+++ b/labs/lookalike/app.js
@@ -1,0 +1,319 @@
+/* Lookalike Finder — frontend.
+   Streams the Worker's pipeline over a fetch/ReadableStream SSE channel and
+   renders the stepper, source profile, and match cards as events arrive. */
+
+// Point this at your deployed Cloudflare Worker. Resolution order:
+//   1. ?api=… query param (explicit override)
+//   2. localhost → the local `wrangler dev` Worker (so no param needed in dev)
+//   3. the deployed production Worker
+const LOCAL_HOSTS = ["localhost", "127.0.0.1"];
+const ENDPOINT =
+  new URLSearchParams(location.search).get("api") ||
+  (LOCAL_HOSTS.includes(location.hostname)
+    ? "http://localhost:8787"
+    : "https://lookalike.ai-29d.workers.dev");
+
+const STEPS = [
+  ["ingest", "Reconstructing profile"],
+  ["traits", "Extracting traits"],
+  ["queries", "Generating queries"],
+  ["retrieve", "Searching the web"],
+  ["score", "Scoring candidates"],
+];
+
+const ICONS = {
+  linkedin:
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.1c0-1.7-.03-3.9-2.38-3.9-2.38 0-2.75 1.86-2.75 3.78V24h-4V8z"/></svg>',
+  x:
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M18.9 1.5h3.3l-7.2 8.24L23.7 22.5h-6.6l-5.18-6.77L5.99 22.5H2.68l7.7-8.8L2.3 1.5h6.77l4.68 6.19L18.9 1.5zm-1.16 19h1.83L7.34 3.38H5.38L17.74 20.5z"/></svg>',
+  link:
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+};
+
+const $ = (id) => document.getElementById(id);
+const el = (tag, cls, html) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (html != null) n.innerHTML = html;
+  return n;
+};
+const esc = (s) =>
+  String(s ?? "").replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+const pct = (x) => Math.round((x || 0) * 100);
+
+let running = false;
+let lastInput = "";
+
+function buildStepper() {
+  const wrap = $("stepper");
+  wrap.innerHTML = "";
+  STEPS.forEach(([id, label], i) => {
+    const s = el("div", "step", `<span class="dot">${i + 1}</span><span>${label}</span>`);
+    s.id = "step-" + id;
+    wrap.appendChild(s);
+  });
+}
+
+// Active step → yellow (with number); earlier steps → grey with a ✓; later → faint.
+function setStep(id, state) {
+  if (!$("step-" + id)) return;
+  let passed = false;
+  STEPS.forEach(([sid], i) => {
+    const n = $("step-" + sid);
+    const dot = n.querySelector(".dot");
+    if (sid === id) {
+      passed = true;
+      const done = state === "done";
+      n.className = "step " + (done ? "done" : "active");
+      dot.textContent = done ? "✓" : String(i + 1);
+    } else if (!passed) {
+      n.className = "step done";
+      dot.textContent = "✓";
+    } else {
+      n.className = "step";
+      dot.textContent = String(i + 1);
+    }
+  });
+}
+
+// LinkedIn / X / source link buttons for any profile object.
+function linkBtn(href, kind, label) {
+  return `<a class="link-btn" href="${esc(href)}" target="_blank" rel="noopener">${ICONS[kind]}<span>${label}</span></a>`;
+}
+function renderLinks(container, obj) {
+  const parts = [];
+  if (obj.linkedin) parts.push(linkBtn(obj.linkedin, "linkedin", "LinkedIn"));
+  if (obj.x) parts.push(linkBtn(obj.x, "x", "X"));
+  if (!obj.linkedin && !obj.x && obj.url) parts.push(linkBtn(obj.url, "link", "Source"));
+  container.innerHTML = parts.join("");
+  container.style.display = parts.length ? "" : "none";
+}
+
+// Animated circular score gauge.
+function scoreRing(score) {
+  const p = pct(score);
+  const r = 24;
+  const c = 2 * Math.PI * r;
+  const off = c * (1 - p / 100);
+  const wrap = el(
+    "div",
+    "score",
+    `<svg viewBox="0 0 58 58">
+       <circle class="ring-bg" cx="29" cy="29" r="${r}" stroke-width="5"></circle>
+       <circle class="ring-fg" cx="29" cy="29" r="${r}" stroke-width="5"
+         stroke-dasharray="${c.toFixed(1)}" stroke-dashoffset="${c.toFixed(1)}"></circle>
+     </svg>
+     <div class="pct">${p}%</div>`
+  );
+  const fg = wrap.querySelector(".ring-fg");
+  requestAnimationFrame(() => (fg.style.strokeDashoffset = off.toFixed(1)));
+  return wrap;
+}
+
+// Feedback affordance: a toggle that reveals a textarea → POSTs to /feedback.
+function renderFeedback(container, target) {
+  container.innerHTML =
+    `<button class="fb-toggle" type="button">✎ Feedback on this result</button>
+     <div class="fb-form is-hidden">
+       <textarea placeholder="What was off — or right — about this? (e.g. wrong company, missed a key role, great match)"></textarea>
+       <div class="fb-actions">
+         <button class="fb-send" type="button">Send feedback</button>
+         <button class="fb-cancel" type="button">Cancel</button>
+       </div>
+     </div>`;
+  const toggle = container.querySelector(".fb-toggle");
+  const form = container.querySelector(".fb-form");
+  const ta = container.querySelector("textarea");
+  const send = container.querySelector(".fb-send");
+  const cancel = container.querySelector(".fb-cancel");
+
+  toggle.addEventListener("click", () => {
+    form.classList.toggle("is-hidden");
+    if (!form.classList.contains("is-hidden")) ta.focus();
+  });
+  cancel.addEventListener("click", () => { form.classList.add("is-hidden"); ta.value = ""; });
+  send.addEventListener("click", async () => {
+    const comment = ta.value.trim();
+    if (!comment) return ta.focus();
+    send.disabled = true;
+    send.textContent = "Sending…";
+    try {
+      await fetch(ENDPOINT + "/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ input: lastInput, target, comment }),
+      });
+      container.innerHTML = `<span class="fb-thanks">✓ Thanks — your feedback was recorded.</span>`;
+    } catch {
+      send.disabled = false;
+      send.textContent = "Send feedback";
+      ta.insertAdjacentHTML("afterend", `<span class="fb-thanks" style="color:#dc2626">Couldn't send — try again.</span>`);
+    }
+  });
+}
+
+function renderProfile(p) {
+  $("src-name").textContent = p.name || "Profile";
+  $("src-sub").textContent = [p.current_role, p.current_company, p.location].filter(Boolean).join(" · ");
+  $("src-arc").textContent = p.arc || p.company_description || "";
+  const chips = $("src-traits");
+  chips.innerHTML = "";
+  (p.traits || []).forEach((t) => {
+    const w = t.weight != null ? `<span class="w">${pct(t.weight)}</span>` : "";
+    chips.appendChild(el("span", "chip", `${esc(t.value || t)}${w}`));
+  });
+  renderLinks($("src-links"), p);
+  renderFeedback($("src-fb"), `source: ${p.name || lastInput}`);
+  $("source").classList.remove("is-hidden");
+}
+
+function renderMatches(matches) {
+  const grid = $("results");
+  grid.innerHTML = "";
+  matches.forEach((m, i) => {
+    const card = el("div", "card match" + (i === 0 ? " top" : ""));
+    card.style.animationDelay = i * 0.08 + "s";
+
+    if (i === 0) card.appendChild(el("div", "match-badge", "★ Top match"));
+
+    const head = el("div", "match-head");
+    head.appendChild(
+      el("div", null,
+        `<h3 class="match-name">${esc(m.name)}</h3>
+         <p class="match-role">${esc([m.role, m.company].filter(Boolean).join(" · "))}</p>`)
+    );
+    head.appendChild(scoreRing(m.score));
+    card.appendChild(head);
+
+    if (m.arc) card.appendChild(el("p", "match-arc", esc(m.arc)));
+
+    if (m.axes && m.axes.length) {
+      const axes = el("div", "axes");
+      m.axes.forEach((a) => {
+        const row = el("div", "axis");
+        row.appendChild(el("div", "axis-top", `<span>${esc(a.axis)}</span><span>${pct(a.score)}</span>`));
+        const bar = el("div", "axis-bar");
+        const fill = el("div", "axis-fill");
+        bar.appendChild(fill);
+        row.appendChild(bar);
+        axes.appendChild(row);
+        requestAnimationFrame(() => (fill.style.width = pct(a.score) + "%"));
+      });
+      card.appendChild(axes);
+    }
+
+    if (m.note) card.appendChild(el("p", "match-note", `<b>Why:</b> ${esc(m.note)}`));
+
+    const links = el("div", "links");
+    renderLinks(links, m);
+    card.appendChild(links);
+
+    const fb = el("div", "fb");
+    renderFeedback(fb, m.name);
+    card.appendChild(fb);
+
+    grid.appendChild(card);
+  });
+  $("results-wrap").classList.remove("is-hidden");
+}
+
+function showNotice(html, isError) {
+  const n = $("notice");
+  n.innerHTML = html;
+  n.className = "notice" + (isError ? " error" : "");
+}
+
+function handleEvent(ev) {
+  switch (ev.type) {
+    case "stage": setStep(ev.step, ev.state || "active"); break;
+    case "status": $("status").textContent = ev.text || ""; break;
+    case "profile": renderProfile(ev.profile); break;
+    case "results": renderMatches(ev.matches || []); break;
+    case "quota":
+      if (ev.remaining != null)
+        $("quota").textContent = `${ev.remaining} lookup${ev.remaining === 1 ? "" : "s"} left today`;
+      break;
+    case "error":
+      $("spinner").style.display = "none";
+      $("status").textContent = "";
+      showNotice(`<b>Couldn't finish:</b> ${esc(ev.message)}`, true);
+      break;
+  }
+}
+
+async function run(input) {
+  if (running || !input.trim()) return;
+  running = true;
+  lastInput = input.trim();
+  const go = $("go");
+  go.disabled = true;
+  go.classList.add("loading");
+  $("go-label").textContent = "Finding…";
+  $("notice").className = "notice is-hidden";
+  $("source").classList.add("is-hidden");
+  $("results-wrap").classList.add("is-hidden");
+  $("stage").classList.remove("is-hidden");
+  $("spinner").style.display = "";
+  buildStepper();
+  $("status").textContent = "Starting — reconstructing the profile from the open web…";
+  // make it obvious something is happening on Enter
+  $("stage").scrollIntoView({ behavior: "smooth", block: "start" });
+
+  try {
+    const res = await fetch(ENDPOINT + "/lookalike", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ input: lastInput }),
+    });
+
+    if (res.status === 429) {
+      const body = await res.json().catch(() => ({}));
+      $("stage").classList.add("is-hidden");
+      showNotice(
+        `<b>Daily limit reached.</b> You've used your lookups for today${
+          body.resetHint ? " — " + esc(body.resetHint) : ""
+        }. This keeps the lab free for everyone. Come back tomorrow.`
+      );
+      return;
+    }
+    if (!res.ok || !res.body) throw new Error(`Server returned ${res.status}`);
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      const parts = buf.split("\n\n");
+      buf = parts.pop();
+      for (const part of parts) {
+        const line = part.replace(/^data:\s?/, "").trim();
+        if (!line) continue;
+        try { handleEvent(JSON.parse(line)); } catch (_) {}
+      }
+    }
+    $("spinner").style.display = "none";
+    if (!$("results-wrap").classList.contains("is-hidden")) {
+      $("status").textContent = "Done — your closest matches are below.";
+      $("results-wrap").scrollIntoView({ behavior: "smooth", block: "start" });
+    } else {
+      $("status").textContent = "";
+    }
+  } catch (err) {
+    showNotice(
+      `<b>Something went wrong:</b> ${esc(err.message)}. The Worker may be down or not yet configured.`,
+      true
+    );
+  } finally {
+    running = false;
+    const go = $("go");
+    go.disabled = false;
+    go.classList.remove("loading");
+    $("go-label").textContent = "Find Lookalikes →";
+    $("spinner").style.display = "none";
+  }
+}
+
+$("go").addEventListener("click", () => run($("input").value));
+$("input").addEventListener("keydown", (e) => { if (e.key === "Enter") run($("input").value); });

--- a/labs/lookalike/index.html
+++ b/labs/lookalike/index.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canonical Lookalike Finder · Find people with similar career DNA</title>
+    <meta
+      name="description"
+      content="Paste a LinkedIn URL or X handle and find 3–4 people with similar career DNA — same trajectory, same archetype, not just the same job title. A Canonical Labs tool."
+    />
+    <meta property="og:title" content="Canonical Lookalike Finder" />
+    <meta property="og:description" content="Find people with similar career DNA. By Canonical." />
+    <meta property="og:type" content="website" />
+    <link rel="preconnect" href="https://db.onlinewebfonts.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular"
+    />
+    <!-- Shared canonical.cc stylesheet: carries the global header, footer,
+         nav-dropdown and layout utilities so this lab matches the site exactly. -->
+    <link rel="stylesheet" href="https://canonical.cc/css/style.css?v=20260515" />
+    <!-- Lab-specific styles load after, so they win on any overlap. -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <!-- Shared canonical.cc header (verbatim markup + global stylesheet classes). -->
+    <header id="header" class="fixed top-0 w-full bg-transparent z-50 transition-all duration-200">
+      <div class="container mx-auto px-8 py-8">
+        <div class="flex items-center justify-between">
+          <a href="https://canonical.cc/" class="logo-link">
+            <img src="https://canonical.cc/images/logo-rectangle-trans-short.svg" alt="Canonical" class="h-8 w-auto" />
+          </a>
+          <nav class="hidden md:flex items-center space-x-10">
+            <a href="https://canonical.cc/#about" class="nav-link">ABOUT</a>
+            <a href="https://canonical.cc/#thesis" class="nav-link">THESIS</a>
+            <a href="https://canonical.cc/portfolio" class="nav-link">PORTFOLIO</a>
+            <div class="nav-dropdown">
+              <a href="https://canonical.cc/#labs" class="nav-link nav-dropdown-toggle" aria-haspopup="true" aria-expanded="false">LABS</a>
+              <div class="nav-dropdown-menu" role="menu">
+                <a href="https://canonical.cc/labs/dilutionlab/" class="nav-dropdown-item" role="menuitem">Dilution Lab</a>
+                <a href="https://canonical.cc/labs/fundmodeler/" class="nav-dropdown-item" role="menuitem">Fund Modeler</a>
+                <a href="https://canonical.cc/labs/power-law/" class="nav-dropdown-item" role="menuitem">Power Law Lab</a>
+                <a href="https://canonical.cc/labs/lookalike/" class="nav-dropdown-item" role="menuitem">Lookalike Finder</a>
+                <a href="https://canonical.cc/physical-ai-robotics/" class="nav-dropdown-item" role="menuitem">Physical AI &amp; Robotics</a>
+                <a href="https://canonical.cc/labs/semiconductor-silicon-stack/" class="nav-dropdown-item" role="menuitem">Semiconductor Stack</a>
+              </div>
+            </div>
+            <a href="https://canonical.cc/#team" class="nav-link">TEAM</a>
+          </nav>
+          <button class="nav-menu-toggle md:hidden" type="button" id="navToggle" aria-label="Toggle navigation menu" aria-expanded="false" aria-controls="nav-mobile">
+            <span></span><span></span><span></span>
+          </button>
+        </div>
+        <nav class="nav-mobile" id="nav-mobile" hidden>
+          <a href="https://canonical.cc/#about" class="nav-link">ABOUT</a>
+          <a href="https://canonical.cc/#thesis" class="nav-link">THESIS</a>
+          <a href="https://canonical.cc/portfolio" class="nav-link">PORTFOLIO</a>
+          <a href="https://canonical.cc/#labs" class="nav-link">LABS</a>
+          <a href="https://canonical.cc/#team" class="nav-link">TEAM</a>
+        </nav>
+      </div>
+    </header>
+
+    <header class="hero">
+      <span class="lab-eyebrow">CANONICAL LABS · LOOKALIKE FINDER</span>
+      <h1>Lookalike Finder</h1>
+      <p>
+        Paste a LinkedIn URL or X handle. Get back 3–4 people with the same career
+        DNA — trajectory, archetype, rare skill combinations — not just the same job title.
+      </p>
+    </header>
+
+    <section class="search">
+      <div class="search-row">
+        <input
+          id="input"
+          type="text"
+          placeholder="https://www.linkedin.com/in/…  or  @handle"
+          autocomplete="off"
+          spellcheck="false"
+        />
+        <button class="btn" id="go"><span class="btn-spinner"></span><span id="go-label">Find Lookalikes →</span></button>
+      </div>
+      <div class="search-hint">
+        <span>Career-arc matching across the open web — powered by Claude + Exa.</span>
+        <span class="quota" id="quota"></span>
+      </div>
+    </section>
+
+    <!-- run stage -->
+    <section class="stage is-hidden" id="stage">
+      <div class="stepper" id="stepper"></div>
+      <div class="run-status" id="run-status">
+        <span class="spinner" id="spinner"></span>
+        <span class="status-text" id="status"></span>
+      </div>
+
+      <div class="card source-card is-hidden" id="source">
+        <div class="source-head">
+          <div>
+            <h2 class="source-name" id="src-name"></h2>
+            <p class="source-sub" id="src-sub"></p>
+          </div>
+          <div class="links" id="src-links"></div>
+        </div>
+        <p class="label">Career arc</p>
+        <p class="arc" id="src-arc"></p>
+        <p class="label">Defining traits</p>
+        <div class="chips" id="src-traits"></div>
+        <div class="fb" id="src-fb"></div>
+      </div>
+
+      <div class="is-hidden" id="results-wrap">
+        <h2 class="results-title">Closest career-DNA matches</h2>
+        <div class="results" id="results"></div>
+      </div>
+    </section>
+
+    <!-- notices (errors / rate limit) -->
+    <div class="notice is-hidden" id="notice"></div>
+
+    <!-- methodology -->
+    <section class="method">
+      <h2>How it works</h2>
+      <p class="method-sub">The same pipeline a human researcher runs — turned into an algorithm.</p>
+      <div class="method-steps">
+        <div class="method-step"><span class="method-num">01</span><div>
+          <h3>Profile ingestion</h3>
+          <p>Reconstruct the full profile from the open web — education, every role, the company's actual product.</p></div></div>
+        <div class="method-step"><span class="method-num">02</span><div>
+          <h3>Trait extraction</h3>
+          <p>Distil 5–8 <em>defining</em> dimensions — career arc, domain pivots, rare skill combos — each weighted by how distinctive it is.</p></div></div>
+        <div class="method-step"><span class="method-num">03</span><div>
+          <h3>Query generation</h3>
+          <p>Turn the trait vector into multiple neural search queries. You can't find a lookalike with one search — you search across trait combinations.</p></div></div>
+        <div class="method-step"><span class="method-num">04</span><div>
+          <h3>Candidate retrieval</h3>
+          <p>Exa neural search surfaces people by career <em>meaning</em>, not keywords, then results are merged and de-duplicated.</p></div></div>
+        <div class="method-step"><span class="method-num">05</span><div>
+          <h3>Scoring &amp; ranking</h3>
+          <p>Each candidate is scored on every trait axis (0–1), weighted, and ranked. The top 3–4 come back with a note on what matches — and what doesn't.</p></div></div>
+      </div>
+    </section>
+
+    <!-- Shared canonical.cc footer (verbatim markup + global stylesheet classes). -->
+    <footer class="footer">
+      <div class="container mx-auto px-8">
+        <div class="flex flex-col md:flex-row justify-between items-center">
+          <p class="footer-text">&copy; 2025 Canonical. All rights reserved.</p>
+          <div class="flex items-center space-x-6 mt-4 md:mt-0">
+            <a href="https://x.com/canonicalcc" target="_blank" rel="noopener noreferrer" class="footer-link">Canonical on X</a>
+            <a href="https://blog.canonical.cc" target="_blank" rel="noopener noreferrer" class="footer-link">Canonical on Substack</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Minimal mobile-nav toggle (the shared site script is home-page-specific).
+      (function () {
+        var t = document.getElementById("navToggle"),
+          m = document.getElementById("nav-mobile");
+        if (!t || !m) return;
+        t.addEventListener("click", function () {
+          var open = m.hasAttribute("hidden");
+          if (open) m.removeAttribute("hidden");
+          else m.setAttribute("hidden", "");
+          t.setAttribute("aria-expanded", String(open));
+        });
+      })();
+    </script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/labs/lookalike/style.css
+++ b/labs/lookalike/style.css
@@ -1,0 +1,423 @@
+/* Canonical Labs — Lookalike Finder
+   Palette + type lifted verbatim from canonical.cc so this lab is visually
+   indistinguishable from the others (Dilution Lab, Fund Modeler, …). */
+
+:root {
+  /* electric-blue gradient + palette — exact canonical.cc values */
+  --bg-from: #1e3a8a;   /* blue-900 */
+  --bg-mid:  #1e40af;   /* blue-800 */
+  --bg-to:   #1d4ed8;   /* blue-700 */
+
+  --ink:     #ffffff;
+  --muted:   rgba(255, 255, 255, 0.7);
+  --subtle:  rgba(255, 255, 255, 0.85);
+  --faint:   rgba(255, 255, 255, 0.45);
+
+  --accent:       #2563eb;   /* blue-600 */
+  --accent-hover: #1d4ed8;   /* blue-700 */
+  --accent-soft:  #bfdbfe;   /* blue-200 — the signature pale-blue accent + glow */
+
+  /* warm "in-progress" accent — the yellow/orange used in the Power Law
+     (#facc15) and Semiconductor (#f97316) labs. Active step = yellow, done = grey. */
+  --active:        #facc15;  /* yellow-400 */
+  --active-strong: #f97316;  /* orange-500 */
+  --active-glow:   rgba(250, 204, 21, 0.5);
+  --done-grey:     rgba(255, 255, 255, 0.42);
+  --pending-grey:  rgba(255, 255, 255, 0.28);
+
+  /* white-card interior palette */
+  --card-bg:     #ffffff;
+  --card-soft:   rgba(255, 255, 255, 0.95);
+  --card-ink:    #0f172a;    /* slate-900 */
+  --card-soft-ink: #475569;  /* slate-600 */
+  --card-muted:  #64748b;    /* slate-500 */
+  --card-faint:  #94a3b8;    /* slate-400 */
+  --card-line:   #e2e8f0;    /* slate-200 */
+  --card-tint:   #f8fafc;    /* slate-50 */
+
+  --positive: #059669;
+  --warning:  #b45309;
+
+  /* amber accents for use INSIDE white cards (yellow #facc15 is unreadable there,
+     so we use the readable end of the same warm family) */
+  --card-accent:        #d97706;  /* amber-600 — accent text/links on white */
+  --card-accent-bright: #f59e0b;  /* amber-500 — score rings + axis bars */
+  --card-accent-deep:   #b45309;  /* amber-700 — hover */
+  --card-accent-tint:   #fffbeb;  /* amber-50  — top-match wash */
+
+  --font: 'Aeonik Regular', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { min-height: 100%; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, var(--bg-from) 0%, var(--bg-mid) 50%, var(--bg-to) 100%);
+  background-attachment: fixed;
+  color: var(--subtle);
+  font-family: var(--font);
+  font-size: 15px;
+  line-height: 1.6;
+  letter-spacing: 0.01em;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+a { color: var(--accent-soft); text-decoration: none; transition: color 0.15s ease; }
+a:hover { color: #ffffff; }
+
+.tabular, .mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+/* Header + footer are inherited from the global canonical.cc stylesheet.
+   Just the mobile menu (the shared site script is home-page-specific). */
+.nav-mobile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+.nav-mobile[hidden] { display: none; }
+
+/* ── hero ────────────────────────────────────────────────────────────── */
+.hero {
+  max-width: 820px;
+  margin: 0 auto;
+  padding: 9rem 2rem 2.5rem;   /* top clears the fixed shared header */
+  text-align: center;
+}
+/* identical element + rule to canonical.cc/labs/power-law (span.lab-eyebrow):
+   font-size 0.75rem → 12px at the default 16px root. */
+.lab-eyebrow {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 1.5rem;
+}
+.hero h1 {
+  font-size: clamp(2.6rem, 6vw, 4.25rem);
+  font-weight: 300;
+  line-height: 1.05;
+  color: #fff;
+  margin: 0 0 1.25rem;
+  letter-spacing: -0.01em;
+}
+.hero p {
+  font-size: clamp(1.05rem, 2vw, 1.3rem);
+  color: var(--muted);
+  max-width: 600px;
+  margin: 0 auto;
+  font-weight: 300;
+}
+
+/* ── search box ──────────────────────────────────────────────────────── */
+.search {
+  max-width: 720px;
+  margin: 2.75rem auto 0;
+  padding: 0 2rem;
+}
+.search-row {
+  display: flex;
+  gap: 0.75rem;
+}
+.search input {
+  flex: 1;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0.65rem;
+  padding: 1rem 1.15rem;
+  color: #fff;
+  font-family: var(--font);
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+.search input::placeholder { color: var(--faint); }
+.search input:focus {
+  border-color: var(--active);
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.14);
+}
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 1rem;
+  font-weight: 500;
+  border-radius: 0.65rem;
+  padding: 1rem 1.6rem;
+  background: #fff;
+  color: var(--bg-from);
+  white-space: nowrap;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+.btn:hover { transform: translateY(-2px); box-shadow: 0 12px 24px -8px rgba(0, 0, 0, 0.4); }
+.btn:disabled { cursor: progress; transform: none; box-shadow: none; }
+.btn-spinner {
+  display: none;
+  width: 15px; height: 15px; flex-shrink: 0;
+  border: 2px solid rgba(30, 58, 138, 0.25);
+  border-top-color: var(--bg-from);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+.btn.loading .btn-spinner { display: inline-block; }
+.search-hint {
+  margin: 0.85rem 0.2rem 0;
+  font-size: 0.8rem;
+  color: var(--faint);
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.search-hint .quota { color: var(--active); }
+
+/* ── stage / stepper ─────────────────────────────────────────────────── */
+.stage { max-width: 980px; margin: 3rem auto 0; padding: 0 2rem; scroll-margin-top: 6.5rem; }
+
+.stepper {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 1.4rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+.step {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: var(--pending-grey);
+  transition: color 0.3s ease;
+}
+.step .dot {
+  width: 26px; height: 26px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 0.74rem; font-variant-numeric: tabular-nums; line-height: 1;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  color: var(--pending-grey);
+  background: transparent;
+  flex-shrink: 0;
+  transition: all 0.3s ease;
+}
+/* active = warm yellow + glow + pulse */
+.step.active { color: var(--active); font-weight: 500; }
+.step.active .dot {
+  background: var(--active);
+  color: #1e293b;
+  border-color: var(--active);
+  animation: glow 1.4s ease-in-out infinite;
+}
+/* completed = grey, with a check */
+.step.done { color: var(--done-grey); }
+.step.done .dot {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: transparent;
+  color: var(--done-grey);
+}
+@keyframes glow {
+  0%, 100% { box-shadow: 0 0 9px var(--active-glow); }
+  50%      { box-shadow: 0 0 20px var(--active-glow); }
+}
+
+/* live status row: spinner + yellow message */
+.run-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  min-height: 1.5rem;
+  margin-bottom: 2rem;
+}
+.run-status .status-text { color: var(--active); font-size: 1rem; }
+.spinner {
+  width: 16px; height: 16px; flex-shrink: 0;
+  border: 2px solid rgba(250, 204, 21, 0.25);
+  border-top-color: var(--active);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── cards ───────────────────────────────────────────────────────────── */
+.card {
+  background-color: var(--card-soft);
+  border-radius: 0.75rem;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.2);
+  color: var(--card-soft-ink);
+  padding: 1.75rem;
+}
+
+/* source profile summary */
+.source-card { margin-bottom: 1.75rem; }
+.source-head { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+.source-name { font-size: 1.4rem; font-weight: 600; color: var(--card-ink); margin: 0; }
+.source-sub { color: var(--card-muted); font-size: 0.9rem; margin: 0.15rem 0 0; }
+.label {
+  font-size: 0.68rem; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--card-faint); margin: 1.25rem 0 0.6rem;
+}
+.chips { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.chip {
+  background: var(--card-tint);
+  border: 1px solid var(--card-line);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  color: var(--card-soft-ink);
+}
+.chip .w { color: var(--card-accent); font-variant-numeric: tabular-nums; margin-left: 0.35rem; font-size: 0.72rem; font-weight: 600; }
+.arc { margin: 0.4rem 0 0; color: var(--card-soft-ink); font-size: 0.92rem; }
+
+/* profile / match link buttons (LinkedIn · X · source) */
+.links { display: flex; flex-wrap: wrap; gap: 0.45rem; }
+.link-btn {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  font-size: 0.78rem; font-weight: 500;
+  padding: 0.34rem 0.7rem; border-radius: 999px;
+  border: 1px solid var(--card-line); background: var(--card-tint);
+  color: var(--card-soft-ink); cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.link-btn:hover { border-color: var(--card-accent-bright); color: var(--card-accent); background: #fff; }
+.link-btn svg { width: 13px; height: 13px; }
+
+/* lightweight feedback affordance on every profile */
+.fb { margin-top: 0.25rem; }
+.fb-toggle {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font: inherit; font-size: 0.78rem; color: var(--card-muted);
+  display: inline-flex; align-items: center; gap: 0.35rem;
+}
+.fb-toggle:hover { color: var(--card-accent); }
+.fb-form { margin-top: 0.65rem; }
+.fb-form textarea {
+  width: 100%; resize: vertical; min-height: 58px;
+  font-family: var(--font); font-size: 0.85rem; color: var(--card-ink);
+  border: 1px solid var(--card-line); border-radius: 0.5rem;
+  padding: 0.55rem 0.7rem; outline: none;
+}
+.fb-form textarea:focus { border-color: var(--card-accent-bright); box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.12); }
+.fb-actions { display: flex; align-items: center; gap: 0.6rem; margin-top: 0.5rem; }
+.fb-send {
+  background: var(--card-accent); color: #fff; border: none; cursor: pointer;
+  border-radius: 0.5rem; padding: 0.4rem 0.95rem; font: inherit; font-size: 0.8rem; font-weight: 600;
+  transition: background 0.15s ease;
+}
+.fb-send:hover { background: var(--card-accent-deep); }
+.fb-cancel { background: none; border: none; cursor: pointer; color: var(--card-muted); font: inherit; font-size: 0.8rem; }
+.fb-thanks { color: var(--positive); font-size: 0.82rem; font-weight: 500; }
+
+/* results grid */
+.results-title {
+  text-align: center; color: #fff; font-weight: 300;
+  font-size: 1.75rem; margin: 0.5rem 0 1.75rem;
+}
+.results { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }
+.match {
+  display: flex; flex-direction: column; gap: 0.85rem;
+  border: 1px solid var(--card-line);
+  animation: rise 0.5s ease both;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.match:hover { transform: translateY(-4px); box-shadow: 0 26px 32px -12px rgba(0, 0, 0, 0.32); }
+.match.top {
+  border-color: var(--card-accent-bright);
+  background: linear-gradient(150deg, #fff 0%, var(--card-accent-tint) 100%);
+}
+@keyframes rise { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+
+.match-badge {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  font-size: 0.62rem; letter-spacing: 0.14em; text-transform: uppercase; font-weight: 600;
+  color: var(--card-accent-deep); background: var(--card-accent-tint);
+  border: 1px solid var(--card-accent-bright); border-radius: 999px;
+  padding: 0.2rem 0.6rem; margin-bottom: -0.2rem;
+}
+.match-head { display: flex; align-items: center; justify-content: space-between; gap: 0.85rem; }
+.match-name { font-size: 1.2rem; font-weight: 600; color: var(--card-ink); margin: 0; }
+.match-role { color: var(--card-muted); font-size: 0.85rem; margin: 0.1rem 0 0; }
+
+/* circular score gauge */
+.score { position: relative; width: 58px; height: 58px; flex-shrink: 0; }
+.score svg { width: 58px; height: 58px; transform: rotate(-90deg); }
+.score .ring-bg { fill: none; stroke: var(--card-line); }
+.score .ring-fg { fill: none; stroke: var(--card-accent-bright); stroke-linecap: round;
+  transition: stroke-dashoffset 0.9s cubic-bezier(0.22, 1, 0.36, 1); }
+.score .pct {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  font-family: var(--mono); font-size: 0.92rem; font-weight: 600; color: var(--card-ink);
+  letter-spacing: -0.02em;
+}
+
+.match-arc { font-size: 0.9rem; color: var(--card-soft-ink); margin: 0; }
+
+.axes { display: flex; flex-direction: column; gap: 0.4rem; }
+.axis { font-size: 0.78rem; }
+.axis-top { display: flex; justify-content: space-between; color: var(--card-muted); margin-bottom: 0.2rem; }
+.axis-bar { height: 5px; background: var(--card-line); border-radius: 3px; overflow: hidden; }
+.axis-fill { height: 100%; background: var(--card-accent-bright); border-radius: 3px; transition: width 0.7s ease; }
+
+.match-note {
+  font-size: 0.85rem; color: var(--card-soft-ink);
+  border-top: 1px solid var(--card-line); padding-top: 0.85rem; margin: 0;
+}
+.match-note b { color: var(--card-ink); font-weight: 600; }
+
+/* notices */
+.notice {
+  max-width: 640px; margin: 2rem auto 0; padding: 1.1rem 1.35rem;
+  border-radius: 0.65rem; font-size: 0.92rem;
+  /* warm yellow/orange — matches the in-progress accent used across the labs */
+  background: rgba(249, 115, 22, 0.1);
+  border: 1px solid rgba(250, 204, 21, 0.5);
+  color: var(--subtle);
+}
+.notice b { color: var(--active); }
+/* genuine failures stay red so they read as errors, not warnings */
+.notice.error { background: rgba(252, 165, 165, 0.08); border-color: rgba(252, 165, 165, 0.5); }
+.notice.error b { color: #fecaca; }
+
+/* methodology */
+.method { max-width: 760px; margin: 5rem auto 0; padding: 0 2rem; }
+.method h2 { color: #fff; font-weight: 300; font-size: 1.6rem; text-align: center; margin-bottom: 0.5rem; }
+.method-sub { text-align: center; color: var(--muted); margin: 0 0 2.25rem; font-weight: 300; }
+.method-steps { display: grid; gap: 1rem; }
+.method-step {
+  display: flex; gap: 1rem; align-items: flex-start;
+  background: rgba(255, 255, 255, 0.06); border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.65rem; padding: 1.1rem 1.3rem;
+}
+.method-num {
+  font-family: var(--mono); color: var(--active); font-size: 0.85rem;
+  flex-shrink: 0; padding-top: 0.1rem; min-width: 1.5rem;
+}
+.method-step h3 { color: #fff; font-size: 0.98rem; font-weight: 500; margin: 0 0 0.2rem; }
+.method-step p { color: var(--muted); font-size: 0.88rem; margin: 0; }
+
+/* Give the inherited global footer breathing room from the methodology section. */
+.method { margin-bottom: 5rem; }
+
+/* namespaced so it never collides with the global Tailwind `.hidden` the
+   inherited canonical header relies on (class="hidden md:flex"). */
+.is-hidden { display: none !important; }
+
+@media (max-width: 560px) {
+  .search-row { flex-direction: column; }
+  .nav { padding-top: 1.25rem; }
+  .hero { padding-top: 3.5rem; }
+}


### PR DESCRIPTION
Adds the **Lookalike Finder** lab (built in the [canonical-lookalike](https://github.com/anandiyer/canonical-lookalike) repo).

**What's included**
- `labs/lookalike/` — the static page (`index.html`, `style.css`, `app.js`). It calls the deployed Cloudflare Worker at `https://lookalike.ai-29d.workers.dev`.
- Home **Labs carousel** card (after Semiconductor Stack).
- **Header nav dropdown** entry in `_includes/header.html`.

**Before/after merge notes**
- The Worker's CORS is locked to `https://canonical.cc`, so the page works once served from the canonical.cc domain.
- No secrets in this change — the page ships zero keys; all key-bearing calls happen server-side in the Worker.
- Card placement is last in the carousel; easy to reorder if you'd like it more prominent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)