### PR TITLE
Fund Modeler: align header fallback with canonical nav

### DIFF
--- a/labs/fundmodeler/src/components/Header.tsx
+++ b/labs/fundmodeler/src/components/Header.tsx
@@ -37,14 +37,19 @@ export function Header() {
                 </a>
                 <nav style="display:flex;align-items:center;gap:2.5rem;">
                   <a href="https://canonical.cc/#about" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">ABOUT</a>
+                  <a href="https://blog.canonical.cc" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">BLOG</a>
                   <a href="https://canonical.cc/#thesis" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">THESIS</a>
                   <a href="https://canonical.cc/portfolio" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">PORTFOLIO</a>
                   <div class="nav-dropdown">
-                    <button class="nav-dropdown-toggle" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;background:none;border:none;cursor:pointer;" type="button">LABS</button>
+                    <a href="https://canonical.cc/labs/" class="nav-dropdown-toggle" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">LABS</a>
                     <div class="nav-dropdown-menu">
                       <a href="https://canonical.cc/labs/dilutionlab/" class="nav-dropdown-item">Dilution Lab</a>
                       <a href="https://canonical.cc/labs/fundmodeler/" class="nav-dropdown-item">Fund Modeler</a>
                       <a href="https://canonical.cc/labs/power-law/" class="nav-dropdown-item">Power Law Lab</a>
+                      <a href="https://canonical.cc/physical-ai-robotics/" class="nav-dropdown-item">Physical AI &amp; Robotics</a>
+                      <a href="https://canonical.cc/labs/semiconductor-silicon-stack/" class="nav-dropdown-item">Semiconductor Stack</a>
+                      <a href="https://canonical.cc/labs/lookalike/" class="nav-dropdown-item">Lookalike Finder</a>
+                      <a href="https://canonical.cc/labs/capital-call-planner/" class="nav-dropdown-item">Capital Call Planner</a>
                     </div>
                   </div>
                   <a href="https://canonical.cc/#team" style="color:rgba(255,255,255,0.8);font-size:0.875rem;font-weight:500;letter-spacing:0.1em;text-decoration:none;">TEAM</a>


### PR DESCRIPTION
The live Fund Modeler header already inherits the shared `/partials/header.html` (which re-emits `_includes/header.html`), so it shows the correct nav. This only updates the **offline dev-fallback** in `Header.tsx` to match — adds BLOG, points LABS at `/labs/`, and lists the full set of labs (incl. Capital Call Planner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)