### PR TITLE
Add Europe coverage + feedback button to Physical AI & Robotics

### DIFF
--- a/physical-ai-robotics/data.json
+++ b/physical-ai-robotics/data.json
@@ -343,10 +343,33 @@
         {
           "name": "Quantum Systems",
           "first_unicorn_year": 2024,
-          "latest_val_m": 1000,
-          "latest_round": "Series C 2024"
+          "latest_val_m": 3000,
+          "latest_round": "Series C ext Nov 2025 (€3B)"
         }
       ]
+    },
+
+    "europe": {
+      "headline": "Europe doesn't out-raise. It out-specializes.",
+      "lede": "Europe is roughly 5% of global robotics venture dollars, so on a pure capital chart it looks like a rounding error next to the US and China. That framing misses the point. Europe doesn't compete for the humanoid OEM crown; it owns specific, defensible categories outright. It leads the world in surgical robotics and clinical exoskeletons, has the deepest warehouse-automation bench, and supplies the actuators and joints that the humanoid race runs on.",
+      "pov": "The most under-covered story on this entire map is Ukraine. It has become the world's largest live robotics testbed: from ~7 drone makers in 2021 to ~500 by 2025, producing ~2.2M aerial drones in 2024 and targeting 25,000-40,000 ground robots in 2026. None of it shows up on a cap-table map because it's funded by state procurement and Brave1 grants, not priced equity. If you only watch valuations, you miss where the fastest real-world robotics iteration on earth is happening.",
+      "leadership": [
+        {"category": "Surgical robotics", "eu_share": 40, "note": "Intuitive's 25-yr monopoly cracked", "champions": ["CMR Surgical", "Distalmotion", "MMI"]},
+        {"category": "Exoskeletons", "eu_share": 55, "note": "global clinical leader, but fragile", "champions": ["Wandercraft", "German Bionic"]},
+        {"category": "Warehouse / intralogistics", "eu_share": 15, "note": "deepest European bench", "champions": ["AutoStore", "Exotec", "Dexory", "Verity"]},
+        {"category": "Components / actuation", "eu_share": 30, "note": "Europe supplies the joints", "champions": ["Schaeffler", "maxon"]},
+        {"category": "Defense drones", "eu_share": 25, "note": "fastest-growing European pole", "champions": ["Helsing", "Quantum Systems", "Tekever"]}
+      ],
+      "ukraine": {
+        "headline": "Ukraine: the live testbed",
+        "stats": [
+          {"value": "7 → ~500", "label": "drone makers, 2021 → 2025"},
+          {"value": "~2.2M", "label": "aerial drones produced in 2024 (>1.5M FPV)"},
+          {"value": "25-40K", "label": "ground robots (UGVs) targeted for 2026"},
+          {"value": "~$105M", "label": "defense-tech VC in 2025 — grants & procurement dwarf it"}
+        ],
+        "companies": ["Skyeton", "Fire Point", "TAF Drones", "Tencore", "DevDroid", "Wild Hornets"]
+      }
     }
   },
   "subsectors": [
@@ -427,6 +450,12 @@
           "geo": "China",
           "valuation_m": 1400,
           "last_round_label": "Apr 2026"
+        },
+        {
+          "name": "PAL Robotics",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "TALOS/Kangaroo humanoids + TIAGo; founded 2004, bootstrapped (Spain)"
         }
       ],
       "top_investors": [
@@ -494,6 +523,12 @@
           "valuation_m": 750,
           "last_round_label": "$750M LIG Nex1 tender 2024",
           "flag": "estimated"
+        },
+        {
+          "name": "RIVR",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "ex-Swiss-Mile wheeled-legged delivery; acquired by Amazon ~2026 (Switzerland)"
         }
       ],
       "top_investors": [],
@@ -553,8 +588,20 @@
         {
           "name": "Exotec",
           "geo": "EU",
+          "valuation_m": 1300,
+          "last_round_label": "Series D 2022 ($335M, France unicorn)"
+        },
+        {
+          "name": "Dexory",
+          "geo": "EU",
           "valuation_m": null,
-          "last_round_label": "Series D 2022"
+          "last_round_label": "Series C £124M Oct 2025, Atomico-led (UK)"
+        },
+        {
+          "name": "Verity",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Series B $43M, warehouse inventory drones (Switzerland)"
         }
       ],
       "top_investors": [
@@ -579,9 +626,9 @@
       "yoy_growth_pct": 60,
       "deals_count": 38,
       "geo_split": {
-        "US": 60,
+        "US": 50,
         "China": 10,
-        "EU": 25,
+        "EU": 35,
         "RoW": 5
       },
       "top_companies": [
@@ -612,15 +659,23 @@
         {
           "name": "Quantum Systems",
           "geo": "EU",
-          "valuation_m": 1000,
-          "last_round_label": "Series C 2024"
+          "valuation_m": 3000,
+          "last_round_label": "Series C ext Nov 2025 (€3B, triple unicorn)"
+        },
+        {
+          "name": "Tekever",
+          "geo": "EU",
+          "valuation_m": 1300,
+          "last_round_label": "€70M May 2025 (€1.2B, Portugal)"
         }
       ],
       "top_investors": [
         "Nvidia NVentures",
         "a16z",
         "Founders Fund",
-        "Linse Capital"
+        "Linse Capital",
+        "NATO Innovation Fund",
+        "Balderton"
       ],
       "canonical_pov": "Skydio's Blue UAS Cleared List plus the Trump Drone Dominance EO creates a regulatory moat against DJI. But Skydio's hardware-only revenue grew 80% while software is ~30% of mix. The moat may be regulatory, not technical.",
       "caveats": [
@@ -756,16 +811,17 @@
       },
       "top_companies": [
         {
-          "name": "German Bionic",
-          "geo": "EU",
-          "valuation_m": null,
-          "last_round_label": "Archimedes acq 2026"
-        },
-        {
           "name": "Wandercraft",
           "geo": "EU",
           "valuation_m": null,
-          "last_round_label": "FDA Atalante 2024"
+          "last_round_label": "Series D $75M Jun 2025 (Renault, Bpifrance); ~$142M total"
+        },
+        {
+          "name": "German Bionic",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "filed for insolvency Nov 2025",
+          "flag": "distressed"
         },
         {
           "name": "Ekso Bionics",
@@ -787,8 +843,8 @@
         "Hyundai",
         "Honda"
       ],
-      "canonical_pov": "Exoskeletons remain the most under-capitalized physical AI category relative to the size of the labor-strain TAM. 1/3 of workplace injuries are overexertion. Despite that, the entire global venture pool is smaller than a single Figure round.",
-      "caveats": []
+      "canonical_pov": "Exoskeletons remain the most under-capitalized physical AI category relative to the size of the labor-strain TAM. 1/3 of workplace injuries are overexertion. Despite that, the entire global venture pool is smaller than a single Figure round. Europe leads the category (~55% of capital), but its leadership is fragile: France's Wandercraft is the global clinical leader and raised a $75M Series D in 2025, while Germany's German Bionic — long the European front-runner — filed for insolvency in November 2025 with full order books. Strong demand, brutal unit economics.",
+      "caveats": ["German Bionic filed for insolvency Nov 2025 despite reported full order books — a warning on exoskeleton hardware margins"]
     },
     {
       "id": "industrial-automation",
@@ -848,6 +904,24 @@
           "geo": "US",
           "valuation_m": null,
           "last_round_label": "Aug 2024"
+        },
+        {
+          "name": "Agile Robots",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "unicorn since 2021 Series C €186M; DLR spinout (Germany)"
+        },
+        {
+          "name": "Sereact",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Series B $110M Apr 2026, Headline-led; VLA pick-and-place (Germany)"
+        },
+        {
+          "name": "Wandelbots",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Series C $84M 2024, Insight-led; no-code robot OS (Germany)"
         }
       ],
       "top_investors": [
@@ -856,7 +930,9 @@
         "Accel",
         "a16z",
         "Khosla Ventures",
-        "CapitalG"
+        "CapitalG",
+        "Insight Partners",
+        "Headline"
       ],
       "canonical_pov": "Mind Robotics is the auto-OEM spin-out template. The 'factory floor as proprietary training environment' thesis is now competitive with the Figure/Apptronik humanoid playbook, and arguably better for capital efficiency since the data acquisition cost is embedded in the host's operating business. Watch which other OEMs spin out robotics units. BMW, Mercedes, Ford, Stellantis are all candidates.",
       "caveats": [
@@ -906,7 +982,13 @@
           "name": "Ecorobotix",
           "geo": "EU",
           "valuation_m": null,
-          "last_round_label": null
+          "last_round_label": "AI plant-by-plant spraying, ~CHF 50M+ (Switzerland)"
+        },
+        {
+          "name": "Lely",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "dairy-farm robots (Astronaut milking); family-owned market leader (Netherlands)"
         }
       ],
       "top_investors": [
@@ -964,6 +1046,12 @@
           "geo": "US",
           "valuation_m": null,
           "last_round_label": "wound down workforce 2024"
+        },
+        {
+          "name": "Monumental",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "$25M seed Feb 2024, Plural-led; autonomous bricklaying (Netherlands)"
         }
       ],
       "top_investors": [
@@ -986,9 +1074,9 @@
       "yoy_growth_pct": 94,
       "deals_count": 120,
       "geo_split": {
-        "US": 75,
+        "US": 72,
         "China": 0,
-        "EU": 22,
+        "EU": 25,
         "RoW": 3
       },
       "top_companies": [
@@ -1040,6 +1128,42 @@
           "geo": "US",
           "valuation_m": 1200,
           "last_round_label": "Series C Nov 2025"
+        },
+        {
+          "name": "Quantum Systems",
+          "geo": "EU",
+          "valuation_m": 3000,
+          "last_round_label": "€3B Nov 2025; VTOL recon drones (Germany)"
+        },
+        {
+          "name": "Tekever",
+          "geo": "EU",
+          "valuation_m": 1300,
+          "last_round_label": "€1.2B May 2025; maritime/ISR drones (Portugal)"
+        },
+        {
+          "name": "Milrem Robotics",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "THeMIS/Type-X UGVs; EDGE Group (UAE) majority since 2023 (Estonia)"
+        },
+        {
+          "name": "Skyeton",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Raybird ISR drone; co-producing in Slovakia + UK (Ukraine)"
+        },
+        {
+          "name": "Fire Point",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "FP-1/FP-2 deep-strike drones, hundreds of km range (Ukraine)"
+        },
+        {
+          "name": "TAF Drones",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "80,000+ FPV drones/month via Brave1 (Ukraine)"
         }
       ],
       "top_investors": [
@@ -1050,12 +1174,16 @@
         "8VC",
         "NightDragon",
         "Lightspeed",
-        "Blackstone (preferred)"
+        "Blackstone (preferred)",
+        "Prima Materia",
+        "NATO Innovation Fund",
+        "Brave1 (UA state cluster)"
       ],
-      "canonical_pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is the first signal defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble. Anduril is the only defense unicorn with revenue ($2.2B 2025) proportional to its valuation. Most others are pricing in multi-year DoD procurement that hasn't materialized.",
+      "canonical_pov": "The most under-examined story is the capital structure. Shield AI's March 2026 round is the first signal defense unicorns are institutionalizing balance sheets with structured credit. The category is maturing into a real procurement layer, not a bubble. Anduril is the only defense unicorn with revenue ($2.2B 2025) proportional to its valuation. Most others are pricing in multi-year DoD procurement that hasn't materialized. Europe is now the fastest-growing pole here: Helsing (~$18B, in talks) is the software champion, Quantum Systems (€3B) and Tekever (€1.2B) the drone unicorns — and Ukraine has become the world's largest live robotics testbed, scaling from ~7 drone makers in 2021 to ~500 by 2025. The Ukrainian ecosystem is grant- and procurement-funded, not VC-priced, which is exactly why it's invisible on a cap-table map.",
       "caveats": [
         "$22B+ figure depends on PitchBook vs Crunchbase methodology",
-        "PitchBook $49.1B 2025 deal-value figure includes debt and structured financing, not pure equity"
+        "PitchBook $49.1B 2025 deal-value figure includes debt and structured financing, not pure equity",
+        "Ukrainian companies (Skyeton, Fire Point, TAF Drones) are production-scale operations funded by state procurement + Brave1 grants, not priced equity rounds — valuations are N/A, not zero"
       ]
     },
     {
@@ -1220,6 +1348,12 @@
           "geo": "US",
           "valuation_m": 750,
           "last_round_label": "Series C Khosla-led"
+        },
+        {
+          "name": "Oxa",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "£253M total (£77M 2025); ex-Oxbotica autonomy software (UK)"
         }
       ],
       "top_investors": [
@@ -1267,11 +1401,17 @@
           "name": "Schaeffler",
           "geo": "EU",
           "valuation_m": null,
-          "last_round_label": "Germany public, Neura partner"
+          "last_round_label": "Germany public; launched humanoid planetary-gear actuator Dec 2025, Hexagon partner"
+        },
+        {
+          "name": "maxon",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "Switzerland private; robotics drive portfolio + High-Efficiency Joints (2025)"
         }
       ],
       "top_investors": [],
-      "canonical_pov": "The pick-and-shovel play for humanoids is harmonic drive / strain wave gear and high-torque-density actuators. This layer is dominated by Japanese and German incumbents. Not a single US/EU venture-backed actuator company has reached $100M revenue. Unitree's prospectus discloses they manufacture their own motors, reducers, encoders, and dexterous hands in-house, with purchased parts accounting for only 14-18% of total cost, a vertical-integration playbook the US ecosystem has not replicated.",
+      "canonical_pov": "The pick-and-shovel play for humanoids is harmonic drive / strain wave gear and high-torque-density actuators. This layer is dominated by Japanese and German incumbents. Not a single US/EU venture-backed actuator company has reached $100M revenue. Unitree's prospectus discloses they manufacture their own motors, reducers, encoders, and dexterous hands in-house, with purchased parts accounting for only 14-18% of total cost, a vertical-integration playbook the US ecosystem has not replicated. This is a quiet European strength: Schaeffler (DE) shipped a humanoid actuator in Dec 2025 and maxon (CH) launched a robotics drive line in 2025. Europe may not win the humanoid OEM race, but it supplies the joints.",
       "caveats": [
         "Most companies in this layer are public incumbents, not VC-backed"
       ]
@@ -1634,6 +1774,12 @@
           "geo": "China",
           "valuation_m": null,
           "last_round_label": "2000sqm, 133 humanoids across 13 models"
+        },
+        {
+          "name": "mimic",
+          "geo": "EU",
+          "valuation_m": null,
+          "last_round_label": "€13.8M seed Nov 2025; dexterous manipulation from human demos, ETH spinout (Switzerland)"
         }
       ],
       "top_investors": [

--- a/physical-ai-robotics/index.html
+++ b/physical-ai-robotics/index.html
@@ -37,7 +37,7 @@
     <link href="https://db.onlinewebfonts.com/c/8f2a9d487bbbc60974cd132fc3a63862?family=Aeonik+Regular" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://canonical.cc/css/style.css?v=20260514f">
-    <link rel="stylesheet" href="lab.css?v=1">
+    <link rel="stylesheet" href="lab.css?v=2">
 </head>
 <body>
     <div class="min-h-screen">
@@ -55,7 +55,7 @@
                         </p>
                         <div class="pai-meta">
                             <div class="pai-meta-item"><span class="pai-meta-key">Window</span><span class="pai-meta-val">Q1 2023 &rarr; Q1 2026</span></div>
-                            <div class="pai-meta-item"><span class="pai-meta-key">Geography</span><span class="pai-meta-val">Global, China flagged</span></div>
+                            <div class="pai-meta-item"><span class="pai-meta-key">Geography</span><span class="pai-meta-val">Global &middot; US, China, Europe tagged</span></div>
                             <div class="pai-meta-item"><span class="pai-meta-key">Sources</span><span class="pai-meta-val">Harmonic &middot; Pitchbook &middot; Crunchbase &middot; primary filings</span></div>
                             <div class="pai-meta-item"><span class="pai-meta-key">Updated</span><span class="pai-meta-val" id="pai-updated">May 15, 2026</span></div>
                         </div>
@@ -96,6 +96,7 @@
                         <li><a href="#scene-1" data-spy="scene-1">Chasm</a></li>
                         <li><a href="#scene-2" data-spy="scene-2">Velocity</a></li>
                         <li><a href="#scene-3" data-spy="scene-3">US &amp; China</a></li>
+                        <li><a href="#scene-europe" data-spy="scene-europe">Europe</a></li>
                         <li><a href="#scene-4" data-spy="scene-4">Defense</a></li>
                         <li><a href="#explorer" data-spy="explorer">Explorer</a></li>
                         <li><a href="#methodology" data-spy="methodology">Methodology</a></li>
@@ -200,6 +201,35 @@
                 </div>
             </section>
 
+            <!-- SCENE 3.5: EUROPE -->
+            <section class="pai-scene" id="scene-europe">
+                <div class="container mx-auto px-8">
+                    <div class="pai-scene-grid">
+                        <div class="pai-scene-text">
+                            <div class="pai-section-label"><span class="pai-section-num">[04]</span> Europe</div>
+                            <h2 class="pai-scene-h2">Europe doesn't out-raise. It <em>out-specializes</em>.</h2>
+                            <p class="pai-lede">
+                                Europe is roughly 5% of global robotics venture dollars, so on a pure capital chart it looks like a rounding error next to the US and China. That framing misses the point. Europe doesn't compete for the humanoid OEM crown, it owns specific, defensible categories outright: surgical robotics, clinical exoskeletons, warehouse automation, and the actuators and joints the humanoid race runs on.
+                            </p>
+                            <div class="pai-pov">
+                                <div class="pai-pov-label">Canonical POV</div>
+                                <p>The most under-covered story on this entire map is Ukraine. It has become the world's largest live robotics testbed, from ~7 drone makers in 2021 to ~500 by 2025. None of it shows up on a cap-table map because it's funded by state procurement and Brave1 grants, not priced equity. If you only watch valuations, you miss where the fastest real-world robotics iteration on earth is happening.</p>
+                            </div>
+                        </div>
+                        <div class="pai-europe-viz">
+                            <div class="pai-viz" id="viz-europe-leadership">
+                                <div class="pai-viz-title">
+                                    <span>Where Europe leads &middot; EU share of capital by category</span>
+                                    <span class="pai-viz-source">click a champion to open it</span>
+                                </div>
+                                <div class="pai-europe-leadership" id="europe-leadership"></div>
+                            </div>
+                            <div class="pai-ukraine-callout" id="europe-ukraine"></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <!-- SCENE 4: DEFENSE UNICORNS -->
             <section class="pai-scene" id="scene-4">
                 <div class="container mx-auto px-8">
@@ -212,7 +242,7 @@
                             <div class="pai-defense-chart" id="defense-chart"></div>
                         </div>
                         <div class="pai-scene-text">
-                            <div class="pai-section-label"><span class="pai-section-num">[04]</span> Defense Autonomy</div>
+                            <div class="pai-section-label"><span class="pai-section-num">[05]</span> Defense Autonomy</div>
                             <h2 class="pai-scene-h2">From 2 unicorns to <em>22 in 3 years</em>.</h2>
                             <p class="pai-lede">
                                 In 2022, exactly 2 pure-play defense tech companies were valued above $1B: Anduril and Shield AI. By mid-2026, the count has crossed 22, and Anduril alone has tripled to $61B post Series H in 12 months, anchored by a $20B DoD enterprise agreement signed March 2026. Andreessen Horowitz has been the most active defense investor with 18 deals across the period.
@@ -229,7 +259,7 @@
             <!-- EXPLORER -->
             <section class="pai-explorer-section" id="explorer">
                 <div class="container mx-auto px-8">
-                    <div class="pai-section-label"><span class="pai-section-num">[05]</span> Sub-sector Explorer</div>
+                    <div class="pai-section-label"><span class="pai-section-num">[06]</span> Sub-sector Explorer</div>
                     <h2 class="pai-scene-h2 pai-h2-explorer">Click into any of the <em>22 sub-sectors</em> for top companies, totals, and active investors.</h2>
                     <p class="pai-explorer-intro">Filter by stack layer, geography, or sort by capital deployed. Every sub-sector has a Canonical POV blurb and a data-caveat flag.</p>
 
@@ -271,7 +301,7 @@
             <!-- METHODOLOGY -->
             <section class="pai-method-section" id="methodology">
                 <div class="container mx-auto px-8">
-                    <div class="pai-section-label"><span class="pai-section-num">[06]</span> Methodology</div>
+                    <div class="pai-section-label"><span class="pai-section-num">[07]</span> Methodology</div>
                     <h2 class="pai-scene-h2 pai-h2-method">How this <em>was built</em>, and where the data is weakest.</h2>
                     <div class="pai-method-grid">
                         <div class="pai-method-col">
@@ -301,7 +331,7 @@
                 <div class="container mx-auto px-8">
                     <div class="pai-cta-grid">
                         <div>
-                            <div class="pai-section-label pai-section-label-light"><span class="pai-section-num">[07]</span> Talk to Canonical</div>
+                            <div class="pai-section-label pai-section-label-light"><span class="pai-section-num">[08]</span> Talk to Canonical</div>
                             <h2 class="pai-cta-h2">If you're building or investing in the <em>picks-and-shovels</em> of physical AI, we want to hear from you.</h2>
                             <p class="pai-cta-p">Canonical leads early-stage investments in technical teams building at the frontier. SF-based, founder-obsessed, pre-product friendly.</p>
                         </div>
@@ -334,6 +364,26 @@
     <!-- Tooltip element used by hero scenes -->
     <div class="pai-tip" id="pai-tip" role="tooltip" aria-hidden="true"></div>
 
-    <script src="lab.js?v=1"></script>
+    <!-- Feedback widget (floating). Posts to labs-api.canonical.cc/feedback → Slack #hack-central -->
+    <div class="pai-fb" id="pai-fb">
+        <button class="pai-fb-toggle" id="pai-fb-toggle" type="button" aria-expanded="false" aria-controls="pai-fb-panel">
+            <span class="pai-fb-toggle-icon">✎</span> Feedback
+        </button>
+        <div class="pai-fb-panel" id="pai-fb-panel" role="dialog" aria-label="Send feedback" hidden>
+            <div class="pai-fb-head">
+                <span class="pai-fb-title">Tell us what we got wrong</span>
+                <button class="pai-fb-close" id="pai-fb-close" type="button" aria-label="Close feedback">&times;</button>
+            </div>
+            <p class="pai-fb-sub">Missing a company or a whole region? Wrong number? Goes straight to our team.</p>
+            <textarea class="pai-fb-text" id="pai-fb-text" rows="4" placeholder="e.g. You're missing the Ukraine drone ecosystem, or Helsing's valuation is stale…"></textarea>
+            <input class="pai-fb-email" id="pai-fb-email" type="email" placeholder="Email (optional, if you want a reply)" />
+            <div class="pai-fb-actions">
+                <button class="pai-fb-send" id="pai-fb-send" type="button">Send feedback</button>
+            </div>
+            <div class="pai-fb-status" id="pai-fb-status" aria-live="polite"></div>
+        </div>
+    </div>
+
+    <script src="lab.js?v=2"></script>
 </body>
 </html>

--- a/physical-ai-robotics/lab.css
+++ b/physical-ai-robotics/lab.css
@@ -232,7 +232,7 @@
     scroll-margin-top: 130px;
 }
 
-#explorer, #methodology, #map {
+#explorer, #methodology, #map, #scene-europe {
     scroll-margin-top: 130px;
 }
 
@@ -569,6 +569,89 @@
 }
 .pai-flow-us .pai-flow-exit strong { color: var(--pai-navy); }
 .pai-flow-china .pai-flow-exit strong { color: var(--pai-accent); }
+
+/* ============ EUROPE SCENE ============ */
+.pai-europe-viz { display: flex; flex-direction: column; gap: 1.25rem; }
+
+.pai-europe-leadership { display: flex; flex-direction: column; gap: 1.1rem; }
+.pai-eu-row { display: flex; flex-direction: column; gap: 0.4rem; }
+.pai-eu-row-head { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem; }
+.pai-eu-cat { font-weight: 600; color: var(--pai-ink); font-size: 0.92rem; }
+.pai-eu-share {
+    font-family: var(--pai-mono);
+    font-size: 0.78rem;
+    color: var(--pai-navy);
+    font-weight: 600;
+    white-space: nowrap;
+}
+.pai-eu-bar {
+    height: 7px;
+    background: rgba(15, 23, 42, 0.07);
+    border-radius: 4px;
+    overflow: hidden;
+}
+.pai-eu-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--pai-navy) 0%, #3b5bdb 100%);
+    border-radius: 4px;
+    transition: width 0.9s cubic-bezier(.2,.8,.2,1);
+}
+.pai-eu-champs {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: var(--pai-ink-muted);
+}
+
+/* Ukraine callout — orange-accented box, the standout story */
+.pai-ukraine-callout {
+    background: linear-gradient(135deg, rgba(249, 115, 22, 0.06), rgba(30, 58, 138, 0.05));
+    border: 1px solid rgba(249, 115, 22, 0.25);
+    border-radius: 0.75rem;
+    padding: 1.5rem 1.6rem;
+    color: var(--pai-ink);
+}
+.pai-uk-head {
+    font-family: var(--pai-mono);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--pai-accent);
+    font-weight: 600;
+    margin-bottom: 1.1rem;
+}
+.pai-uk-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.1rem 1.4rem;
+    margin-bottom: 1.1rem;
+}
+.pai-uk-stat-v {
+    font-size: 1.5rem;
+    font-weight: 300;
+    color: var(--pai-ink);
+    line-height: 1.05;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.2rem;
+}
+.pai-uk-stat-l {
+    font-size: 0.74rem;
+    line-height: 1.4;
+    color: var(--pai-ink-muted);
+}
+.pai-uk-companies {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    color: var(--pai-ink-muted);
+    padding-top: 1rem;
+    border-top: 1px solid var(--pai-rule);
+}
+.pai-uk-companies-label { font-family: var(--pai-mono); font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--pai-ink-faint); }
+
+/* Distressed flag (e.g. German Bionic insolvency) — red warning pill */
+.pai-d-flag-distressed {
+    background: rgba(185, 28, 28, 0.12) !important;
+    color: #b91c1c !important;
+}
 
 /* ============ DEFENSE TIMELINE ============ */
 .pai-defense-chart svg { width: 100%; height: auto; display: block; overflow: visible; }
@@ -1491,3 +1574,88 @@
 
 /* When the canonical.cc header is in "scrolled" state, give the subnav a touch more contrast */
 #header.scrolled ~ main .pai-subnav { background: rgba(30, 58, 138, 0.95); }
+
+/* ============ FEEDBACK WIDGET ============ */
+.pai-fb {
+    position: fixed;
+    right: 1.25rem;
+    bottom: 1.25rem;
+    z-index: 120;
+    font-family: 'Aeonik Regular', system-ui, sans-serif;
+}
+.pai-fb-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    background: var(--pai-accent);
+    color: #ffffff;
+    border: none;
+    border-radius: 100px;
+    padding: 0.7rem 1.15rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    box-shadow: 0 8px 24px -6px rgba(249, 115, 22, 0.55), 0 2px 6px rgba(0, 0, 0, 0.2);
+    transition: transform 0.15s, box-shadow 0.15s, background 0.15s;
+}
+.pai-fb-toggle:hover { transform: translateY(-2px); background: #ea6a0c; }
+.pai-fb-toggle-icon { font-size: 0.95rem; }
+
+.pai-fb-panel {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.6rem);
+    width: min(360px, calc(100vw - 2.5rem));
+    background: #ffffff;
+    color: var(--pai-ink);
+    border-radius: 0.85rem;
+    padding: 1.25rem 1.3rem 1.1rem;
+    box-shadow: 0 20px 50px -12px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.12);
+    border: 1px solid var(--pai-rule);
+}
+.pai-fb-panel[hidden] { display: none; }
+.pai-fb-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.35rem; }
+.pai-fb-title { font-weight: 600; font-size: 1rem; color: var(--pai-ink); }
+.pai-fb-close {
+    background: none; border: none; font-size: 1.5rem; line-height: 1;
+    color: var(--pai-ink-faint); cursor: pointer; padding: 0 0.2rem;
+}
+.pai-fb-close:hover { color: var(--pai-ink); }
+.pai-fb-sub { font-size: 0.82rem; color: var(--pai-ink-muted); line-height: 1.45; margin: 0 0 0.85rem; }
+.pai-fb-text, .pai-fb-email {
+    width: 100%;
+    border: 1px solid var(--pai-rule-strong);
+    border-radius: 0.5rem;
+    padding: 0.6rem 0.7rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    color: var(--pai-ink);
+    background: var(--pai-card-bg-2);
+    resize: vertical;
+    transition: border-color 0.15s;
+}
+.pai-fb-text:focus, .pai-fb-email:focus { outline: none; border-color: var(--pai-accent); }
+.pai-fb-email { margin-top: 0.6rem; }
+.pai-fb-actions { display: flex; justify-content: flex-end; margin-top: 0.8rem; }
+.pai-fb-send {
+    background: var(--pai-navy);
+    color: #ffffff;
+    border: none;
+    border-radius: 0.5rem;
+    padding: 0.6rem 1.1rem;
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, opacity 0.15s;
+}
+.pai-fb-send:hover { background: var(--pai-navy-deep); }
+.pai-fb-send:disabled { opacity: 0.6; cursor: default; }
+.pai-fb-status { font-size: 0.8rem; margin-top: 0.6rem; min-height: 1rem; }
+.pai-fb-status.ok { color: #15803d; }
+.pai-fb-status.err { color: #b91c1c; }
+
+@media (max-width: 640px) {
+    .pai-fb { right: 0.9rem; bottom: 0.9rem; }
+    .pai-fb-toggle { padding: 0.6rem 1rem; font-size: 0.8rem; }
+}

--- a/physical-ai-robotics/lab.js
+++ b/physical-ai-robotics/lab.js
@@ -43,6 +43,24 @@
         'Nirvana AI': 'https://nrvana.ai',
         'Eastworlds (Virtuals)': 'https://eastworlds.io',
         'Eastworlds': 'https://eastworlds.io',
+
+        // Europe (added in Europe-coverage pass)
+        'Dexory': 'https://www.dexory.com',
+        'Verity': 'https://verity.net',
+        'Tekever': 'https://www.tekever.com',
+        'Agile Robots': 'https://www.agile-robots.com',
+        'Sereact': 'https://www.sereact.ai',
+        'Wandelbots': 'https://www.wandelbots.com',
+        'Monumental': 'https://www.monumental.co',
+        'Oxa': 'https://www.oxa.tech',
+        'maxon': 'https://www.maxongroup.com',
+        'RIVR': 'https://www.rivr.ai',
+        'mimic': 'https://www.mimicrobotics.com',
+        'Lely': 'https://www.lely.com',
+        'PAL Robotics': 'https://pal-robotics.com',
+        'Milrem Robotics': 'https://milremrobotics.com',
+        'Skyeton': 'https://www.skyeton.com',
+        'Wild Hornets': 'https://wildhornets.com.ua',
         // Humanoid robotics
         'Figure AI': 'https://www.figure.ai',
         'Figure': 'https://www.figure.ai',
@@ -670,6 +688,67 @@
         return row;
     }
 
+    /* ---------- SCENE 3.5: Europe ---------- */
+    function renderEurope() {
+        const eu = DATA.scenes.europe;
+        if (!eu) return;
+
+        // Category leadership rows: each shows EU share bar + champion company links
+        const lead = document.getElementById('europe-leadership');
+        if (lead) {
+            lead.innerHTML = '';
+            const maxShare = Math.max(...eu.leadership.map(c => c.eu_share));
+            eu.leadership.forEach(cat => {
+                const row = el('div', { class: 'pai-eu-row' });
+                // header: category name + share
+                const head = el('div', { class: 'pai-eu-row-head' },
+                    el('span', { class: 'pai-eu-cat' }, cat.category),
+                    el('span', { class: 'pai-eu-share' }, cat.eu_share + '% EU')
+                );
+                const barWrap = el('div', { class: 'pai-eu-bar' });
+                const fill = el('div', { class: 'pai-eu-fill' });
+                fill.style.width = '0%';
+                barWrap.appendChild(fill);
+                setTimeout(() => { fill.style.width = (cat.eu_share / maxShare * 100) + '%'; }, 80);
+                // champions
+                const champs = el('div', { class: 'pai-eu-champs' });
+                champs.appendChild(document.createTextNode(cat.note + ' — '));
+                cat.champions.forEach((name, i) => {
+                    if (i > 0) champs.appendChild(document.createTextNode(' · '));
+                    champs.appendChild(companyLink(name));
+                });
+                row.appendChild(head);
+                row.appendChild(barWrap);
+                row.appendChild(champs);
+                lead.appendChild(row);
+            });
+        }
+
+        // Ukraine callout
+        const uk = document.getElementById('europe-ukraine');
+        if (uk && eu.ukraine) {
+            uk.innerHTML = '';
+            uk.appendChild(el('div', { class: 'pai-uk-head' }, eu.ukraine.headline));
+            const grid = el('div', { class: 'pai-uk-grid' });
+            eu.ukraine.stats.forEach(s => {
+                grid.appendChild(el('div', { class: 'pai-uk-stat' },
+                    el('div', { class: 'pai-uk-stat-v' }, s.value),
+                    el('div', { class: 'pai-uk-stat-l' }, s.label)
+                ));
+            });
+            uk.appendChild(grid);
+            if (eu.ukraine.companies && eu.ukraine.companies.length) {
+                const co = el('div', { class: 'pai-uk-companies' });
+                co.appendChild(el('span', { class: 'pai-uk-companies-label' }, 'Production leaders: '));
+                eu.ukraine.companies.forEach((name, i) => {
+                    if (i > 0) co.appendChild(document.createTextNode(' · '));
+                    co.appendChild(companyLink(name));
+                });
+                uk.appendChild(co);
+            }
+        }
+    }
+
     /* ---------- SCENE 4: Defense Unicorn Timeline ---------- */
     function renderDefense() {
         const host = document.getElementById('defense-chart');
@@ -1108,7 +1187,7 @@
             if (c.canonical_portfolio) nameCell.classList.add('pai-d-portfolio-row');
             nameCell.appendChild(companyLink(c.name));
             if (c.flag) {
-                const flagEl = el('span', { class: 'pai-d-flag' + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
+                const flagEl = el('span', { class: 'pai-d-flag pai-d-flag-' + c.flag + (c.flag === 'public-market-cap' ? ' public' : '') }, c.flag.replace(/-/g, ' '));
                 nameCell.appendChild(flagEl);
             }
             // Canonical portfolio pill — links to the internal /companies/<slug>.html page
@@ -1399,6 +1478,7 @@
         renderChasm();
         renderVelocity();
         renderFlows();
+        renderEurope();
         renderDefense();
         bindFilters();
         syncChips();
@@ -1447,6 +1527,81 @@
         drawerOverlay.addEventListener('click', closeDrawer);
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && drawer.classList.contains('open')) closeDrawer();
+        });
+
+        bindFeedback();
+    }
+
+    /* ---------- FEEDBACK WIDGET ---------- */
+    // POSTs to the shared Cloudflare Worker (same endpoint Lookalike Finder uses).
+    // source + channel let the Worker route this to Slack #hack-central.
+    const FEEDBACK_ENDPOINT =
+        (['localhost', '127.0.0.1'].includes(window.location.hostname))
+            ? 'http://localhost:8787/feedback'
+            : 'https://labs-api.canonical.cc/feedback';
+
+    function bindFeedback() {
+        const toggle = document.getElementById('pai-fb-toggle');
+        const panel = document.getElementById('pai-fb-panel');
+        const closeBtn = document.getElementById('pai-fb-close');
+        const text = document.getElementById('pai-fb-text');
+        const email = document.getElementById('pai-fb-email');
+        const send = document.getElementById('pai-fb-send');
+        const status = document.getElementById('pai-fb-status');
+        if (!toggle || !panel) return;
+
+        function open() {
+            panel.hidden = false;
+            toggle.setAttribute('aria-expanded', 'true');
+            text.focus();
+        }
+        function close() {
+            panel.hidden = true;
+            toggle.setAttribute('aria-expanded', 'false');
+        }
+        toggle.addEventListener('click', () => (panel.hidden ? open() : close()));
+        closeBtn.addEventListener('click', close);
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && !panel.hidden) close();
+        });
+
+        send.addEventListener('click', async () => {
+            const comment = text.value.trim();
+            if (!comment) { text.focus(); return; }
+            send.disabled = true;
+            status.className = 'pai-fb-status';
+            status.textContent = 'Sending…';
+            const payload = {
+                source: 'physical-ai-robotics',
+                channel: 'hack-central',
+                comment: comment,
+                email: email.value.trim() || null,
+                page: window.location.href,
+                // a little context on what they were looking at
+                view: (function () {
+                    const f = readFilters();
+                    return { sector: f.sector || null, investor: f.investor || null, layer: f.layer, geo: f.geo, sort: f.sort };
+                })(),
+                ts: new Date().toISOString()
+            };
+            try {
+                const res = await fetch(FEEDBACK_ENDPOINT, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                });
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                status.className = 'pai-fb-status ok';
+                status.textContent = '✓ Thanks — sent to the Canonical team.';
+                text.value = '';
+                email.value = '';
+                setTimeout(close, 1800);
+            } catch (err) {
+                console.error('Feedback send failed', err);
+                status.className = 'pai-fb-status err';
+                status.textContent = 'Couldn’t send. Email hello@canonical.cc instead?';
+                send.disabled = false;
+            }
         });
     }
 


### PR DESCRIPTION
## Why

Reader feedback: the map read as a *US vs China* story and treated Europe as incidental — "Kind of crazy to ignore UK, Switzerland, France, Germany, Ukraine…" Fair. This PR makes Europe a first-class part of the map and adds a feedback channel so critiques like this reach us directly.

## Europe coverage

**New "[04] Europe" hero scene** (between US/China and Defense): *"Europe doesn't out-raise. It out-specializes."*
- Category-leadership panel with EU-share bars + champion companies: surgical (CMR, Distalmotion, MMI), exoskeletons (Wandercraft), warehouse (AutoStore, Exotec, Dexory, Verity), components/actuation (Schaeffler, maxon), defense drones (Helsing, Quantum Systems, Tekever).
- **Ukraine "live testbed" callout** — the genuinely under-covered story: 7→~500 drone makers (2021→2025), ~2.2M aerial drones in 2024, 25–40K UGVs targeted for 2026, and only ~$105M of defense-tech VC because it's grant/procurement-funded, not priced equity.

**~20 net-new European companies** across sub-sectors (Dexory, Verity, Tekever, Milrem, Skyeton, Fire Point, TAF Drones, Agile Robots, Sereact, Wandelbots, Monumental, Oxa, maxon, RIVR, mimic, Lely, PAL Robotics).

**Corrections from fresh research** (May 2026):
- German Bionic → flagged **distressed** (filed insolvency Nov 2025), red pill in the drawer
- Quantum Systems → **$1B → €3B** (Nov 2025) in both the aerial sub-sector and the defense unicorn timeline
- Bumped aerial-drones EU share 25→35%, defense EU 22→25%
- Hero geo meta → "Global · US, China, Europe tagged"; sub-nav gains Europe; labels renumbered (Defense→05 … CTA→08)

All new companies are linked (outbound, `?ref=canonicalcc`). 148 company links on the page, all ref-tagged.

## Feedback button

Floating **✎ Feedback** widget (bottom-right), modeled on the Lookalike lab. Opens a panel with a textarea + optional email; POSTs to `labs-api.canonical.cc/feedback` with `source:"physical-ai-robotics"`, `channel:"hack-central"`, the comment, email, page URL, and current view context (sector/investor/filters). Resolves to `localhost:8787` in dev like Lookalike.

> [!IMPORTANT]
> **Worker change needed:** the Cloudflare Worker behind `labs-api.canonical.cc/feedback` must route `source:"physical-ai-robotics"` (or `channel:"hack-central"`) to Slack **#hack-central**. The client already sends both hints — this is a one-rule change on the Worker, which lives outside this repo.

## Verified on preview

- Europe scene renders: 5 leadership bars animate proportionally (55% widest → 15% narrowest), Ukraine callout with 4 stats + gradient styling
- German Bionic shows red "distressed" flag in the exoskeletons drawer
- Sub-nav Europe entry + scroll-spy work; section labels renumbered correctly
- Feedback widget opens, builds correct payload, shows success/error states
- No console errors; 148/148 company links carry `?ref=canonicalcc`

## Test plan

- [ ] Confirm the Worker routes physical-ai-robotics feedback to #hack-central (send a test from the live page)
- [ ] Europe scene renders on desktop (two-column) and mobile (stacked)
- [ ] Spot-check a few new European company links resolve (Dexory, Tekever, maxon)
- [ ] Defense timeline shows Quantum Systems at €3B

🤖 Generated with [Claude Code](https://claude.com/claude-code)